### PR TITLE
Fix empty materiales table by sending auth headers

### DIFF
--- a/Backend/login-microsoft365/src/main/java/com/miapp/controller/BibliotecaController.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/controller/BibliotecaController.java
@@ -188,6 +188,15 @@ public class BibliotecaController {
         return ResponseEntity.ok(Map.of("status", 0, "data", dtos));
     }
 
+    /** Devuelve un detalle de biblioteca por su ID */
+    @GetMapping("/detalles/{id}")
+    public ResponseEntity<DetalleBibliotecaDTO> getDetalleById(@PathVariable Long id) {
+        DetalleBibliotecaDTO dto = detalleService.findById(id);
+        return dto != null
+                ? ResponseEntity.ok(dto)
+                : ResponseEntity.notFound().build();
+    }
+
     /** Endpoint para obtener todos los detalles reservados (con su “biblioteca” anidada) */
     @GetMapping("/detalles-reservados")
     public ResponseEntity<Map<String, Object>> getDetallesReservados() {

--- a/Backend/login-microsoft365/src/main/java/com/miapp/controller/OcurrenciaBibliotecaController.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/controller/OcurrenciaBibliotecaController.java
@@ -35,6 +35,16 @@ public class OcurrenciaBibliotecaController {
         return ResponseEntity.ok(svc.listarTodas());
     }
 
+    @GetMapping("/materiales")
+    public ResponseEntity<List<OcurrenciaBibliotecaDTO>> listarMateriales() {
+        return ResponseEntity.ok(svc.listarMateriales());
+    }
+
+    @GetMapping("/equipos")
+    public ResponseEntity<List<OcurrenciaBibliotecaDTO>> listarEquipos() {
+        return ResponseEntity.ok(svc.listarEquipos());
+    }
+
     @GetMapping("/{id}")
     public ResponseEntity<OcurrenciaBibliotecaDTO> obtener(@PathVariable Long id) {
         OcurrenciaBibliotecaDTO dto = svc.buscarPorId(id);

--- a/Backend/login-microsoft365/src/main/java/com/miapp/model/dto/OcurrenciaBibliotecaDTO.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/model/dto/OcurrenciaBibliotecaDTO.java
@@ -39,4 +39,12 @@ public class OcurrenciaBibliotecaDTO {
     private String  usuarioSedEm;
     private BigDecimal abono;
     private Integer anulado;
+
+    // Campos adicionales para mostrar información del material involucrado
+    private String idEjemplar;
+    private String ejemplar;
+    /** Sede a la cual pertenece el ejemplar */
+    private String sede;
+    /** Tipo de material bibliográfico */
+    private String tipoMaterial;
 }

--- a/Backend/login-microsoft365/src/main/java/com/miapp/repository/OcurrenciaBibliotecaRepository.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/repository/OcurrenciaBibliotecaRepository.java
@@ -2,7 +2,17 @@ package com.miapp.repository;
 
 import com.miapp.model.OcurrenciaBiblioteca;
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
 
 public interface OcurrenciaBibliotecaRepository
         extends JpaRepository<OcurrenciaBiblioteca, Long> {
+
+    /** Obtiene ocurrencias asociadas a materiales bibliográficos */
+    List<OcurrenciaBiblioteca> findByDetalleBibliotecaIsNotNullOrderByIdDesc();
+
+    /** Obtiene ocurrencias asociadas a equipos de cómputo */
+    List<OcurrenciaBiblioteca> findByDetallePrestamoIsNotNullOrderByIdDesc();
+
+    /** Lista todas las ocurrencias ordenadas de forma descendente */
+    List<OcurrenciaBiblioteca> findAllByOrderByIdDesc();
 }

--- a/Backend/login-microsoft365/src/main/java/com/miapp/service/DetalleBibliotecaService.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/service/DetalleBibliotecaService.java
@@ -39,4 +39,11 @@ public class DetalleBibliotecaService {
                 .map(detalle -> mapper.toDetalleDto(detalle))
                 .collect(Collectors.toList());
     }
+
+    /** Obtiene un detalle por ID y lo mapea a DTO */
+    public DetalleBibliotecaDTO findById(Long id) {
+        return detalleBibliotecaRepository.findById(id)
+                .map(mapper::toDetalleDto)
+                .orElse(null);
+    }
 }

--- a/Backend/login-microsoft365/src/main/java/com/miapp/service/OcurrenciaBibliotecaService.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/service/OcurrenciaBibliotecaService.java
@@ -12,6 +12,8 @@ import java.util.List;
 public interface OcurrenciaBibliotecaService {
     OcurrenciaBibliotecaDTO crear(OcurrenciaBibliotecaDTO dto);
     List<OcurrenciaBibliotecaDTO> listarTodas();
+    List<OcurrenciaBibliotecaDTO> listarMateriales();
+    List<OcurrenciaBibliotecaDTO> listarEquipos();
     OcurrenciaBibliotecaDTO buscarPorId(Long id);
     OcurrenciaUsuario saveUsuario(Long idOcurrencia, String codigoUsuario, Integer tipoUsuario);
     OcurrenciaMaterial saveMaterial(Long idOcurrencia, Long idEquipo, Integer cantidad);

--- a/Backend/login-microsoft365/src/main/java/com/miapp/service/impl/OcurrenciaBibliotecaServiceImpl.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/service/impl/OcurrenciaBibliotecaServiceImpl.java
@@ -81,7 +81,26 @@ public class OcurrenciaBibliotecaServiceImpl implements OcurrenciaBibliotecaServ
 
     @Override
     public List<OcurrenciaBibliotecaDTO> listarTodas() {
-        return repo.findAll().stream().map(this::toDTO).collect(Collectors.toList());
+        return repo.findAllByOrderByIdDesc()
+                .stream()
+                .map(this::toDTO)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<OcurrenciaBibliotecaDTO> listarMateriales() {
+        return repo.findByDetalleBibliotecaIsNotNullOrderByIdDesc()
+                .stream()
+                .map(this::toDTO)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<OcurrenciaBibliotecaDTO> listarEquipos() {
+        return repo.findByDetallePrestamoIsNotNullOrderByIdDesc()
+                .stream()
+                .map(this::toDTO)
+                .collect(Collectors.toList());
     }
 
     @Override
@@ -101,8 +120,18 @@ public class OcurrenciaBibliotecaServiceImpl implements OcurrenciaBibliotecaServ
                 dto.setEquipoIp(eq.getIp());
             }
         }
-        if (e.getDetalleBiblioteca()!=null)
-            dto.setIdDetalleBiblioteca(e.getDetalleBiblioteca().getIdDetalle());
+        if (e.getDetalleBiblioteca()!=null) {
+            DetalleBiblioteca det = e.getDetalleBiblioteca();
+            dto.setIdDetalleBiblioteca(det.getIdDetalle());
+            dto.setIdEjemplar(
+                    det.getNumeroIngreso()!=null
+                            ? det.getNumeroIngreso().toString()
+                            : String.valueOf(det.getIdDetalle())
+            );
+            dto.setEjemplar(det.getBiblioteca()!=null ? det.getBiblioteca().getTitulo() : null);
+            dto.setSede(det.getSede()!=null ? det.getSede().getDescripcion() : null);
+            dto.setTipoMaterial(det.getTipoMaterial()!=null ? det.getTipoMaterial().getDescripcion() : null);
+        }
         dto.setCodigoLocalizacion(e.getCodigoLocalizacion());
         dto.setCodigoUsuario(e.getCodigoUsuario());
         dto.setCosto(e.getCosto());
@@ -219,6 +248,49 @@ public class OcurrenciaBibliotecaServiceImpl implements OcurrenciaBibliotecaServ
                 if (!m.getId().equals(idOriginal)) {
                     Equipo e = equipoRepo.findById(m.getIdEquipoLaboratorio())
                             .orElse(null);
+                    String nombreEquipo = (e != null) ? e.getNombreEquipo() : "<sin nombre>";
+                    lista.add(new OcurrenciaMaterialDTO(
+                            m.getId(),
+                            m.getIdEquipoLaboratorio().toString(),
+                            nombreEquipo,
+                            m.getCantidad(),
+                            m.getCostoUnitario()
+                    ));
+                }
+            });
+        } else if (oc.getDetalleBiblioteca() != null) {
+            // Ocurrencia asociada a material bibliográfico
+            DetalleBiblioteca db = oc.getDetalleBiblioteca();
+            Long idRef = db.getNumeroIngreso() != null ? db.getNumeroIngreso() : db.getIdDetalle();
+
+            OcurrenciaMaterial originalEnTabla = repoM
+                    .findByIdocurrenciaAndIdEquipoLaboratorio(idOcurrencia, idRef)
+                    .orElse(null);
+
+            if (originalEnTabla == null) {
+                OcurrenciaMaterial nuevo = new OcurrenciaMaterial();
+                nuevo.setIdocurrencia(idOcurrencia);
+                nuevo.setIdEquipoLaboratorio(idRef);
+                nuevo.setCantidad(1);
+                originalEnTabla = repoM.save(nuevo);
+            }
+
+            final Long idOriginal = originalEnTabla.getId();
+            String nombre = (db.getBiblioteca() != null)
+                    ? db.getBiblioteca().getTitulo()
+                    : (db.getTipoMaterial() != null ? db.getTipoMaterial().getDescripcion() : "<sin nombre>");
+
+            lista.add(new OcurrenciaMaterialDTO(
+                    idOriginal,
+                    idRef.toString(),
+                    nombre,
+                    originalEnTabla.getCantidad(),
+                    originalEnTabla.getCostoUnitario()
+            ));
+
+            repoM.findByIdocurrencia(idOcurrencia).forEach(m -> {
+                if (!m.getId().equals(idOriginal)) {
+                    Equipo e = equipoRepo.findById(m.getIdEquipoLaboratorio()).orElse(null);
                     String nombreEquipo = (e != null) ? e.getNombreEquipo() : "<sin nombre>";
                     lista.add(new OcurrenciaMaterialDTO(
                             m.getId(),

--- a/Frontend/sakai-ng-master/src/app/biblioteca/interfaces/ocurrenciaDTO.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/interfaces/ocurrenciaDTO.ts
@@ -16,4 +16,12 @@ export interface OcurrenciaDTO {
   equipoNombre?:    string;
     equipoNumero?:    number;
     equipoIp?:        string;
-}
+  /** Codigo o número de ingreso del material */
+  idEjemplar?: string;
+  /** Título o nombre del material */
+  ejemplar?: string;
+  /** Descripción de la sede a la que pertenece el material */
+  sede?: string;
+  /** Descripción del tipo de material */
+  tipoMaterial?: string;
+  }

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/biblioteca/ocurrencias-biblioteca.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/biblioteca/ocurrencias-biblioteca.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, ViewChild, OnInit } from '@angular/core';
 import { FormBuilder } from '@angular/forms';
 import { Router } from '@angular/router';
 import { ConfirmationService, MessageService } from 'primeng/api';
@@ -9,9 +9,10 @@ import { TemplateModule } from '../../template.module';
 import { Table } from 'primeng/table';
 import { OcurrenciasService } from '../../services/ocurrencias.service';
 import { HttpErrorResponse } from '@angular/common/http';
-import { ModalDetalleUsuario } from './modal-usuario';
-import { ModalDetalleOcurencia } from './modal-detalle-ocurrencia';
-import { ModalRegularizaOcurencia } from './modal-regulariza-ocurrencia';
+import { ModalNuevoOcurencia } from '../laboratorio-computo/modal-nuevo-ocurrencia';
+import { ModalDetalleOcurencia } from '../laboratorio-computo/modal-detalle-ocurrencia';
+import { MaterialBibliograficoService } from '../../services/material-bibliografico.service';
+import { OcurrenciaDTO } from '../../interfaces/ocurrenciaDTO';
 
 @Component({
     selector: 'app-ocurrencias-biblioteca',
@@ -19,43 +20,57 @@ import { ModalRegularizaOcurencia } from './modal-regulariza-ocurrencia';
     template: ` <div class="card">
         <h5>{{titulo}}</h5>
         <p-toolbar styleClass="mb-6">
+        <ng-template #start>
     <div class="flex flex-col w-full gap-4">
-                <!-- Primera fila: Sede (2 col), Programa (2 col) y Escuela (3 col) -->
                 <div class="grid grid-cols-7 gap-4">
                 <div class="flex flex-col gap-2 col-span-7 md:col-span-2 lg:col-span-2">
                         <label for="opcion" class="block text-sm font-medium">Estado</label>
                         <p-select [(ngModel)]="opcionFiltro" [options]="dataFiltro" optionLabel="descripcion" placeholder="Seleccionar" />
                     </div>
-                    <div class="flex flex-col gap-2 col-span-4">
+                    <div class="flex flex-col gap-2 col-span-6 md:col-span-4">
                     <label for="usuario" class="block text-sm font-medium">Usuario</label>
-                                <input [(ngModel)]="usuario"pInputText id="usuario" type="text" placeholder="Usuario"/>
-                       
+                                <input [(ngModel)]="usuario" pInputText id="usuario" type="text" placeholder="Usuario"/>
+
                     </div>
                     <div class="flex items-end">
-            <button 
-                pButton 
-                type="button" 
-                class="p-button-rounded p-button-danger" 
-                icon="pi pi-search"(click)="buscar()" [disabled]="loading"  pTooltip="Ver reporte" tooltipPosition="bottom">
+            <button
+                pButton
+                type="button"
+                class="p-button-rounded p-button-danger"
+                icon="pi pi-search" (click)="buscar()" [disabled]="loading"  pTooltip="Ver reporte" tooltipPosition="bottom">
             </button>
         </div>
                     </div>
-                    
-                   
-               
+
+
+
             </div>
-       
+            </ng-template>
+            <ng-template #end>
+                 <button pButton type="button" label="Nuevo" icon="pi pi-plus" class="p-button-success mr-2" [disabled]="loading" (click)="nuevoRegistro()"
+                                pTooltip="Nuevo registro" tooltipPosition="bottom"></button>
+
+
+            </ng-template>
     </p-toolbar>
-    <p-table #dt1 [value]="data" dataKey="id" [rows]="10"
+    <p-tabs value="0">
+                            <p-tablist>
+                                <p-tab value="0">Ocurrencias</p-tab>
+                                <p-tab value="1">Estudiantes</p-tab>
+                                <p-tab value="2">Materiales</p-tab>
+                            </p-tablist>
+                            <p-tabpanels>
+                                <p-tabpanel value="0">
+                                <p-table #dt1 [value]="data" dataKey="id" [rows]="10"
                         [showCurrentPageReport]="true"
                         currentPageReportTemplate="Mostrando {first} a {last} de {totalRecords} registros"
-                        [rowsPerPageOptions]="[10, 25, 50]" [loading]="loading" [rowHover]="true" styleClass="p-datatable-gridlines" [paginator]="true" 
-                        [globalFilterFields]="['id','usuario.codigo','usuario.nombres','idEjemplar','ejemplar','fechaRegistro','hora']" responsiveLayout="scroll">
+                        [rowsPerPageOptions]="[10, 25, 50]" [loading]="loading" [rowHover]="true" styleClass="p-datatable-gridlines" [paginator]="true"
+                        [globalFilterFields]="['id','idEjemplar','ejemplar','usuarioNombre','sede','tipoMaterial']" responsiveLayout="scroll">
                         <ng-template pTemplate="caption">
-                       
+
                        <div class="flex items-center justify-between">
                <p-button [outlined]="true" icon="pi pi-filter-slash" label="Limpiar" (click)="clear(dt1)" />
-               
+
                <p-iconfield>
                    <input pInputText type="text" placeholder="Filtrar" #filter (input)="onGlobalFilter(dt1, $event)"/>
                </p-iconfield>
@@ -64,43 +79,32 @@ import { ModalRegularizaOcurencia } from './modal-regulariza-ocurrencia';
                             <ng-template pTemplate="header">
                                 <tr>
                                     <th style="width: 8rem"></th>
-                                <th pSortableColumn="usuario.codigo" style="width: 4rem">Codigo<p-sortIcon field="usuario.codigo"></p-sortIcon></th>
-                                <th pSortableColumn="usuario.nombres" style="min-width:200px">Usuario<p-sortIcon field="usuario.nombres"></p-sortIcon></th>
-                                    <th pSortableColumn="idEjemplar" style="min-width:200px">ID Ejemplar<p-sortIcon field="idEjemplar"></p-sortIcon></th>
-                                    <th pSortableColumn="ejemplar"  style="min-width:200px">Ejemplar<p-sortIcon field="ejemplar"></p-sortIcon></th>
-                                    <th pSortableColumn="fechaRegistro"  style="min-width:200px">Fecha registro<p-sortIcon field="fechaRegistro"></p-sortIcon></th>
-                                    <th pSortableColumn="hora" style="width: 8rem">Hora<p-sortIcon field="hora"></p-sortIcon></th>
-                                    
+                                <th pSortableColumn="id" style="width: 4rem">ID<p-sortIcon field="id"></p-sortIcon></th>
+                                <th pSortableColumn="idEjemplar" style="min-width:160px">Código<p-sortIcon field="idEjemplar"></p-sortIcon></th>
+                                <th pSortableColumn="ejemplar" style="min-width:200px">Ejemplar<p-sortIcon field="ejemplar"></p-sortIcon></th>
+                                <th pSortableColumn="sede" style="min-width: 9rem">Sede<p-sortIcon field="sede"></p-sortIcon></th>
+                                <th pSortableColumn="tipoMaterial" style="min-width: 9rem">Tipo<p-sortIcon field="tipoMaterial"></p-sortIcon></th>
+                                    <th style="min-width:200px"></th>
                                 </tr>
                             </ng-template>
                             <ng-template pTemplate="body" let-objeto>
-                                <tr> 
+                                <tr>
                                     <td>
                                     <div class="flex flex-wrap justify-center gap-2">
-                                <p-button outlined icon="pi pi-search" pTooltip="Más información" tooltipPosition="bottom" (click)="verDetalleUsuario()"/>
-                                <p-button icon="pi pi-align-justify" pTooltip="Detalle de ocurrencia" tooltipPosition="bottom" (click)="verDetalleOcurrencia()"/>
-                                <p-button icon="pi pi-dollar" pTooltip="Regulariza ocurrencia" tooltipPosition="bottom" (click)="regularizaOcurrencia()"/>
-                            </div>
-                                    </td> 
-                                <td>{{objeto.usuario.codigo}}
+                                <p-button outlined icon="pi pi-pencil" pTooltip="Actualizar" tooltipPosition="bottom" (click)="editar(objeto)"/>
+                                                           </div>
                                     </td>
+                                <td>{{objeto.id}}</td>
+                                <td>{{objeto.idEjemplar}}</td>
+                                <td>{{objeto.ejemplar}}</td>
+                                <td>{{objeto.sede}}</td>
+                                <td>{{objeto.tipoMaterial}}</td>
                                     <td>
-                                        {{objeto.usuario.nombres}}
-                                       
-                                    </td>	
-                                    <td>
-                                        {{objeto.idEjemplar}}
-                                       
-                                    </td>	
-                                    <td>
-                                        {{objeto.ejemplar}}
-                                    </td>	 
-                                    <td>
-                                        {{objeto.fechaRegistro}}
-                                    </td>	                                     
-                                    <td>
-                                        {{objeto.hora}}
-                                    </td>	
+                                        <div class="flex flex-wrap justify-center gap-2">
+                                            <p-button outlined icon="pi pi-align-justify" pTooltip="Ver detalle" tooltipPosition="bottom" (click)="verDetalle(objeto)"/>
+                                            <p-button outlined icon="pi pi-dollar" pTooltip="Registrar costo" tooltipPosition="bottom" (click)="costear(objeto)"/>
+                                        </div>
+                                    </td>
                                 </tr>
                             </ng-template>
                             <ng-template pTemplate="emptymessage">
@@ -114,19 +118,23 @@ import { ModalRegularizaOcurencia } from './modal-regulariza-ocurrencia';
                                 </tr>
                             </ng-template>
                         </p-table>
+                                </p-tabpanel>
+                            </p-tabpanels>
+</p-tabs>
+
+
     </div>
-    
-    
-<app-modal-detalle-usuario #modalDetalle></app-modal-detalle-usuario>
-<app-modal-detalle-ocurrencia #modalOcurrencia></app-modal-detalle-ocurrencia>
-<app-modal-regulariza-ocurrencia #modalRegularizaOcurrencia></app-modal-regulariza-ocurrencia>
+
+
+<app-modal-nuevo-ocurrencia #modalNuevoOcurrencia></app-modal-nuevo-ocurrencia>
+<app-modal-detalle-ocurrencia #modalDetalleOcurrencia></app-modal-detalle-ocurrencia>
 <p-confirmDialog [style]="{width: '450px'}"></p-confirmDialog>
             <p-toast></p-toast>`,
-        imports: [TemplateModule,ModalDetalleUsuario,ModalDetalleOcurencia,ModalRegularizaOcurencia],
+        imports: [TemplateModule, ModalNuevoOcurencia, ModalDetalleOcurencia],
         providers: [MessageService, ConfirmationService]
 })
-export class OcurrenciasBiblioteca {
-    data: any[] = [];
+export class OcurrenciasBiblioteca implements OnInit {
+    data: OcurrenciaDTO[] = [];
     dataFiltro: any[] = [
         {"descripcion":"TODOS"},
         {"descripcion":"Pendiente costo"},
@@ -135,50 +143,62 @@ export class OcurrenciasBiblioteca {
     ];
     loading: boolean = false;
     opcionFiltro: any = this.dataFiltro[0];
-    usuario:string="";
+    usuario: string = '';
 
-    titulo: string = "Ocurrencias";
+    titulo: string = "Mantenimiento de materiales en deuda - Biblioteca";
     @ViewChild('filter') filter!: ElementRef;
-        @ViewChild('modalDetalle') modalDetalle!: ModalDetalleUsuario;
-        @ViewChild('modalOcurrencia') modalOcurrencia!: ModalDetalleOcurencia;
-        @ViewChild('modalRegularizaOcurrencia') modalRegularizaOcurrencia!: ModalRegularizaOcurencia;
+    @ViewChild('modalNuevoOcurrencia') modalNuevoOcurrencia!: ModalNuevoOcurencia;
+    @ViewChild('modalDetalleOcurrencia') modalDetalleOcurrencia!: ModalDetalleOcurencia;
 
     constructor(private ocurrenciasService: OcurrenciasService, private genericoService: GenericoService, private fb: FormBuilder,
-    private router: Router, private authService: AuthService, private confirmationService: ConfirmationService, private messageService: MessageService) { }
+    private router: Router, private authService: AuthService, private confirmationService: ConfirmationService, private messageService: MessageService,
+    private materialBsvc: MaterialBibliograficoService) { }
     async ngOnInit() {
         this.buscar();
     }
-    buscar(){
-        this.ocurrenciasService.api_ocurrencias_biblioteca('')
-              .subscribe(
-                (result: any) => {
-                  this.loading = false;
-                  if (result.status == "0") {
-                    this.data = result.data;
-                  }
-                }
-                , (error: HttpErrorResponse) => {
-                  this.loading = false;
-                }
-              );
-    }
-    
+  buscar() {
+    this.loading = true;
+    this.materialBsvc.api_ocurrencias_biblioteca().subscribe({
+      next: (lista) => {
+        const ordered = [...lista].sort((a:any,b:any)=> (b.id ?? 0) - (a.id ?? 0));
+        // aseguramos un campo usuarioNombre para filtros o visualización
+        this.data = ordered.map((o:any)=> ({
+          ...o,
+          usuarioNombre: o.usuario?.nombres
+        }));
+        this.loading = false;
+      },
+      error: (err: HttpErrorResponse) => {
+        this.loading = false;
+        this.messageService.add({
+          severity: 'error',
+          detail: 'Error al cargar las ocurrencias.'
+        });
+        console.error('Ocurrió un error al listar ocurrencias', err);
+      }
+    });
+  }
+
       onGlobalFilter(table: Table, event: Event) {
         table.filterGlobal((event.target as HTMLInputElement).value, 'contains');
       }
-    
+
       clear(table: Table) {
         table.clear();
         this.filter.nativeElement.value = '';
       }
-      verDetalleUsuario(){
-        this.modalDetalle.openModal();
+      verDetalle(obj: OcurrenciaDTO) {
+        // abrimos el modal en modo “solo ver detalle”
+        this.modalDetalleOcurrencia.openModal(obj.id!, false);
       }
-      verDetalleOcurrencia(){
-        this.modalOcurrencia.openModal();
-
+        editar(obj: OcurrenciaDTO) {
+          this.modalNuevoOcurrencia.openForEdit(obj);
+        }
+      nuevoRegistro(){
+//         this.modalNuevoOcurrencia.openModal();
       }
-      regularizaOcurrencia(){
-        this.modalRegularizaOcurrencia.openModal();
+      costear(obj: OcurrenciaDTO) {
+        // abrimos el modal en modo “costear”
+        this.modalDetalleOcurrencia.openModal(obj.id!, true);
       }
 }

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/laboratorio-computo/modal-detalle-ocurrencia.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/laboratorio-computo/modal-detalle-ocurrencia.ts
@@ -306,14 +306,33 @@ loadInvolucrados(ocurrenciaId: number) {
     this.materialBibliograficoService
       .listarMaterialesOcurrencia(ocurrenciaId)
       .subscribe((dtos: OcurrenciaMaterialDTO[]) => {
-        this.materiales = dtos.map(dto => ({
-          idMaterial:   dto.idMaterial ?? undefined,               // puede venir null
-          idEquipo:     Number(dto.codigoEquipo),                  // parseamos string → number
-          nombreEquipo: dto.nombreEquipo,
-          cantidad:     dto.cantidad,
-          costo:        dto.costo ?? 0,                            // si dto.costo = null → 0
-          subTotal:     (dto.costo ?? 0) * dto.cantidad
-        }));
+        if (dtos.length > 0) {
+          this.materiales = dtos.map(dto => ({
+            idMaterial:   dto.idMaterial ?? undefined,
+            idEquipo:     Number(dto.codigoEquipo),
+            nombreEquipo: dto.nombreEquipo,
+            cantidad:     dto.cantidad,
+            costo:        dto.costo ?? 0,
+            subTotal:     (dto.costo ?? 0) * dto.cantidad
+          }));
+        } else if (this.detalle?.idDetalleBiblioteca) {
+          this.materialBibliograficoService
+            .getDetalleBiblioteca(this.detalle.idDetalleBiblioteca)
+            .subscribe(det => {
+              this.materiales = [{
+                idMaterial:   undefined,
+                // `numeroIngreso` o `idDetalleBiblioteca` pueden venir indefinidos
+                // Convertimos a número para cumplir con la interfaz
+                idEquipo:     Number(det.numeroIngreso ?? det.idDetalleBiblioteca ?? 0),
+                nombreEquipo: det.biblioteca?.titulo || det.tipoMaterial?.descripcion || 'Material',
+                cantidad:     1,
+                costo:        0,
+                subTotal:     0
+              }];
+            });
+        } else {
+          this.materiales = [];
+        }
         this.recalcularTotal();
       });
   }

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/laboratorio-computo/modal-nuevo-ocurrencia.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/laboratorio-computo/modal-nuevo-ocurrencia.ts
@@ -369,6 +369,17 @@ openForEdit(ocurrencia: OcurrenciaDTO) {
           ip: dp.equipo.ip!
         }];
       });
+  } else if (ocurrencia.idDetalleBiblioteca) {
+    this.materialBibliograficoService
+      .getDetalleBiblioteca(ocurrencia.idDetalleBiblioteca)
+      .subscribe(det => {
+        this.sourceItem = det;
+        this.materiales = [{
+          codigoEquipo: det.numeroIngreso ?? det.idDetalleBiblioteca,
+          nombre: det.biblioteca?.titulo || det.tipoMaterial?.descripcion || 'Material',
+          cantidad: 1
+        }];
+      });
   }
   this.loadInvolucrados();
   this.loadMateriales();

--- a/Frontend/sakai-ng-master/src/app/biblioteca/services/material-bibliografico.service.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/services/material-bibliografico.service.ts
@@ -242,9 +242,18 @@ crearOcurrencia(dto: OcurrenciaDTO): Observable<OcurrenciaDTO> {
   );
 }
 
+  /** Ocurrencias ligadas a equipos de cómputo */
   api_ocurrencias_laboratorio(): Observable<OcurrenciaDTO[]> {
     return this.http.get<OcurrenciaDTO[]>(
-      `${this.apiUrl}/api/ocurrencias-biblio`,
+      `${this.apiUrl}/api/ocurrencias-biblio/equipos`,
+      { headers: this.headers }
+    );
+  }
+
+  /** Ocurrencias ligadas a material bibliográfico */
+  api_ocurrencias_biblioteca(): Observable<OcurrenciaDTO[]> {
+    return this.http.get<OcurrenciaDTO[]>(
+      `${this.apiUrl}/api/ocurrencias-biblio/materiales`,
       { headers: this.headers }
     );
   }
@@ -260,6 +269,14 @@ crearOcurrencia(dto: OcurrenciaDTO): Observable<OcurrenciaDTO> {
     return this.http
       .get<{status:string, data: DetallePrestamo}>(`${this.apiUrl}/api/prestamos/${id}`, { headers: this.headers })
       .pipe(map(resp => resp.data));
+  }
+
+  /** Obtiene un detalle de biblioteca por su ID */
+  getDetalleBiblioteca(id: number): Observable<DetalleBibliotecaDTO> {
+    return this.http.get<DetalleBibliotecaDTO>(
+      `${this.apiUrl}/api/biblioteca/detalles/${id}`,
+      { headers: this.headers }
+    );
   }
 
     /** Lista usuarios; si pasas `search` filtra por código o email */
@@ -316,7 +333,8 @@ listarUsuariosOcurrencia(id: number): Observable<OcurrenciaUsuario[]> {
 
   listarMaterialesOcurrencia(idOcurrencia: number): Observable<OcurrenciaMaterialDTO[]> {
     return this.http.get<OcurrenciaMaterialDTO[]>(
-      `${this.apiUrl}/api/ocurrencias-biblio/${idOcurrencia}/materiales`
+      `${this.apiUrl}/api/ocurrencias-biblio/${idOcurrencia}/materiales`,
+      { headers: this.headers }
     );
   }
 
@@ -326,7 +344,8 @@ listarUsuariosOcurrencia(id: number): Observable<OcurrenciaUsuario[]> {
   ): Observable<void> {
     return this.http.post<void>(
       `${this.apiUrl}/api/ocurrencias-biblio/${idOcurrencia}/costos`,
-      payload
+      payload,
+      { headers: this.headers }
     );
   }
 

--- a/Frontend/sakai-ng-master/src/assets/demo/biblioteca/ocurrencias/ocurrencias-biblioteca.json
+++ b/Frontend/sakai-ng-master/src/assets/demo/biblioteca/ocurrencias/ocurrencias-biblioteca.json
@@ -3,9 +3,9 @@
     "data": [ 
         {"id":1,"usuario":{"id":1,"nombres": "Nombres del usuario","codigo":"02543", "activo": true},
         "idEjemplar":"658.15/G51 - 28910",
-        "ejemplar": "nombre de ejemplar", 
-        "fechaRegistro":"06/03/2025 21:33",
-        "hora":"21:34",
+        "ejemplar": "nombre de ejemplar",
+        "sede": "LOCAL CENTRAL",
+        "tipoMaterial": "LIBRO",
         "activo": true}
     ]
 }


### PR DESCRIPTION
## Summary
- ensure material list and cost endpoints send auth headers
- include bibliographic fields like `idEjemplar` and `ejemplar`
- show sede and type for biblioteca occurrences

## Testing
- `npm test` *(fails: missing package.json)*
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bc5c443608329ada57be36be0e755