### PR TITLE
Fix reservation timestamp and loan actions

### DIFF
--- a/Backend/login-microsoft365/src/main/java/com/miapp/mapper/BibliotecaMapper.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/mapper/BibliotecaMapper.java
@@ -321,6 +321,7 @@ public class BibliotecaMapper {
         tmp.setUsuarioModificacion(d.getUsuarioModificacion());
         tmp.setFechaModificacion(d.getFechaModificacion());
         tmp.setIdEstado(d.getIdEstado());
+        tmp.setFechaReserva(d.getFechaSolicitud());
 
         return tmp;
     }

--- a/Backend/login-microsoft365/src/main/java/com/miapp/model/dto/DetalleBibliotecaDTO.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/model/dto/DetalleBibliotecaDTO.java
@@ -89,4 +89,10 @@ public class DetalleBibliotecaDTO {
 
     /** 20) ID de estado (Long) */
     private Long idEstado;
+
+    /** Nombre del usuario que reservó */
+    private String nombreUsuario;
+
+    /** Fecha de la reserva */
+    private String fechaReserva;
 }

--- a/Backend/login-microsoft365/src/main/java/com/miapp/service/EmailService.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/service/EmailService.java
@@ -1,6 +1,7 @@
 package com.miapp.service;
 
 import com.miapp.model.DetallePrestamo;
+import com.miapp.model.DetalleBiblioteca;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
@@ -70,6 +71,33 @@ public class EmailService {
                 + "Si necesitas más información, contacta con el administrador.\n\n"
                 + "Saludos,\n"
                 + "Tu App de Préstamos");
+        mailSender.send(msg);
+    }
+
+    public void sendMaterialConfirmation(DetalleBiblioteca detalle) {
+        SimpleMailMessage msg = new SimpleMailMessage();
+        msg.setFrom(from);
+        msg.setTo("moranpedro0398@gmail.com");
+        msg.setSubject("Confirmación de préstamo del material "
+                + detalle.getBiblioteca().getTitulo());
+        msg.setText("Tu préstamo ha sido registrado.\n" +
+                "Fecha devolución: " +
+                (detalle.getFechaFin() != null
+                        ? detalle.getFechaFin().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"))
+                        : "N/A"));
+        mailSender.send(msg);
+    }
+
+    public void sendMaterialRejection(DetalleBiblioteca detalle) {
+        SimpleMailMessage msg = new SimpleMailMessage();
+        msg.setFrom(from);
+        msg.setTo("moranpedro0398@gmail.com");
+        msg.setSubject("Solicitud de préstamo rechazada");
+        msg.setText("Hola " + detalle.getCodigoUsuario() + ",\n\n"
+                + "Tu solicitud del material “" + detalle.getBiblioteca().getTitulo()
+                + "” ha sido rechazada.\n\n"
+                + "Si necesitas más información, contacta con el administrador.\n\n"
+                + "Saludos,\nTu App de Préstamos");
         mailSender.send(msg);
     }
 }

--- a/Backend/login-microsoft365/src/main/java/com/miapp/service/impl/BibliotecaServiceImpl.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/service/impl/BibliotecaServiceImpl.java
@@ -5,12 +5,15 @@ import com.miapp.model.*;
 import com.miapp.model.dto.*;
 import com.miapp.repository.*;
 import com.miapp.service.BibliotecaService;
+import com.miapp.service.EmailService;
+import com.miapp.service.NotificacionService;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -33,6 +36,8 @@ public class BibliotecaServiceImpl implements BibliotecaService {
     private final BibliotecaMapper mapper;
     private final OcurrenciaUsuarioRepository repoU;
     private final OcurrenciaMaterialRepository repoM;
+    private final NotificacionService notificacionService;
+    private final EmailService emailService;
 
     public BibliotecaServiceImpl(BibliotecaRepository bibliotecaRepository,
                                  TipoAdquisicionRepository tipoAdquisicionRepository,
@@ -45,7 +50,9 @@ public class BibliotecaServiceImpl implements BibliotecaService {
                                  DetalleBibliotecaRepository detalleBibliotecaRepository,
                                  BibliotecaMapper mapper,
                                  OcurrenciaUsuarioRepository repoU,
-                                 OcurrenciaMaterialRepository repoM) {
+                                 OcurrenciaMaterialRepository repoM,
+                                 NotificacionService notificacionService,
+                                 EmailService emailService) {
         this.bibliotecaRepository = bibliotecaRepository;
         this.tipoAdquisicionRepository  = tipoAdquisicionRepository;
         this.especialidadRepository = especialidadRepository;
@@ -58,6 +65,8 @@ public class BibliotecaServiceImpl implements BibliotecaService {
         this.mapper = mapper;
         this.repoU = repoU;
         this.repoM = repoM;
+        this.notificacionService = notificacionService;
+        this.emailService = emailService;
     }
 
     @Override
@@ -563,9 +572,34 @@ public class BibliotecaServiceImpl implements BibliotecaService {
                 .orElseThrow(() -> new IllegalArgumentException(
                         "Detalle no encontrado: " + req.getIdDetalleBiblioteca()));
         detalle.setIdEstado(req.getIdEstado());
+        // Registramos el usuario que realiza la reserva en el campo codigoUsuario
+        // ya que el módulo de préstamos lo utiliza para identificar al solicitante
+        detalle.setCodigoUsuario(req.getIdUsuario());
+        if (req.getIdEstado() != null && req.getIdEstado() == 3L) {
+            // Al reservar registramos la fecha de solicitud/reserva
+            detalle.setFechaSolicitud(
+                    LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))
+            );
+        }
         detalle.setUsuarioModificacion(req.getIdUsuario());
         detalle.setFechaModificacion(LocalDateTime.now());
         detalleBibliotecaRepository.save(detalle);
+
+        if (Objects.equals(req.getIdEstado(), 4L)) {
+            notificacionService.crearNotificacion(
+                    detalle.getCodigoUsuario(),
+                    "Tu préstamo del material '" +
+                            detalle.getBiblioteca().getTitulo() + "' fue aprobado."
+            );
+            emailService.sendMaterialConfirmation(detalle);
+        } else if (Objects.equals(req.getIdEstado(), 2L)) {
+            notificacionService.crearNotificacion(
+                    detalle.getCodigoUsuario(),
+                    "Tu solicitud del material '" +
+                            detalle.getBiblioteca().getTitulo() + "' fue rechazada."
+            );
+            emailService.sendMaterialRejection(detalle);
+        }
 
         // 2) Busca si quedan otros detalles pendientes en esta misma biblioteca
         Biblioteca bib = detalle.getBiblioteca();

--- a/Frontend/sakai-ng-master/src/app/biblioteca/interfaces/material-bibliografico/biblioteca.model.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/interfaces/material-bibliografico/biblioteca.model.ts
@@ -94,6 +94,14 @@ export interface DetalleBibliotecaDTO {
   usuarioModificacion?: string;
   fechaModificacion?: string;
   idEstado?: number;
+  /** Usuario que reservó el material */
+  codigoUsuario?: string;
+  /** Nombre del usuario que hizo la reserva */
+  nombreUsuario?: string;
+  /** Tipo de préstamo de la reserva */
+  tipoPrestamo?: string | null;
+  /** Fecha de la reserva */
+  fechaReserva?: string | null;
   /** Detalle puede venir anidado con datos de la biblioteca */
   biblioteca?: BibliotecaDTO;
 }

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/portal/catalogo-enlinea.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/portal/catalogo-enlinea.ts
@@ -209,7 +209,7 @@ import { forkJoin } from 'rxjs';
                             <tr>
                             <td colspan="8">
                             <p-table
-    [value]="detalle"
+    [value]="detallesPorBiblioteca[product.id]"
     showGridlines
     [tableStyle]="{ 'min-width': '50rem' }">
         <ng-template #header>
@@ -278,14 +278,14 @@ import { forkJoin } from 'rxjs';
         <div class="flex flex-col">
           <label>Fecha de inicio</label>
           <p-calendar name="fechaInicioDate" [minDate]="minDate" [(ngModel)]="prestamo.fechaInicioDate" dateFormat="yy-mm-dd"
-            [showTime]="false" appendTo="body" (ngModelChange)="onDateRangeChange()">
+            [showTime]="false" (ngModelChange)="onDateRangeChange()">
           </p-calendar>
         </div>
 
         <div class="flex flex-col">
           <label>Hora de inicio</label>
           <p-calendar name="fechaInicioTime" [(ngModel)]="prestamo.fechaInicioTime" timeOnly="true" hourFormat="24"
-            appendTo="body" [minDate]="minHora" [maxDate]="maxHora" (ngModelChange)="onDateRangeChange()">
+            [minDate]="minHora" [maxDate]="maxHora" (ngModelChange)="onDateRangeChange()">
           </p-calendar>
         </div>
       </div>
@@ -293,14 +293,14 @@ import { forkJoin } from 'rxjs';
         <div class="flex flex-col">
           <label>Fecha de devolución</label>
           <p-calendar name="fechaFinDate" [minDate]="minDate" [(ngModel)]="prestamo.fechaFinDate" dateFormat="yy-mm-dd" [showTime]="false"
-            appendTo="body" (ngModelChange)="onDateRangeChange()">
+            (ngModelChange)="onDateRangeChange()">
           </p-calendar>
         </div>
 
         <div class="flex flex-col">
           <label>Hora de devolución</label>
           <p-calendar name="fechaFinTime" [(ngModel)]="prestamo.fechaFinTime" timeOnly="true" hourFormat="24"
-            appendTo="body" [minDate]="minHora" [maxDate]="maxHora" (ngModelChange)="onDateRangeChange()">
+            [minDate]="minHora" [maxDate]="maxHora" (ngModelChange)="onDateRangeChange()">
           </p-calendar>
         </div>
       </div>
@@ -356,7 +356,8 @@ export class CatalogoEnLineaComponent {
     @ViewChild('filter') filter!: ElementRef;
     data: any[] = [];
     expandedRows = {};
-    detalle: any[] = [];
+    /** Detalles de ejemplares disponibles por id de biblioteca */
+    detallesPorBiblioteca: { [id: number]: any[] } = {};
     reservas: any[] = [];
     members = [
         { name: 'Amy Elsner', image: 'amyelsner.png', email: 'amy@email.com', role: 'Owner' },
@@ -446,9 +447,10 @@ export class CatalogoEnLineaComponent {
     ) { }
 
     async ngOnInit() {
-        this.user = { "idusuario": 0 };
+        // Tomamos el usuario autenticado del token para registrar la reserva
+        this.user = this.authService.getUser();
         this.listar();
-        this.detalle = [];
+        this.detallesPorBiblioteca = {};
     }
     listar() {
         // Recupera solo los registros en estado disponible (idEstado = 2)
@@ -488,19 +490,22 @@ export class CatalogoEnLineaComponent {
             .listarDetallesPorBiblioteca(row.id, false)
             .subscribe({
                 next: (lista: any[]) => {
-                    this.detalle = lista.filter(d =>
-                        (d.idEstado === 2 || d.estado?.descripcion === 'DISPONIBLE')
+                    this.detallesPorBiblioteca[row.id] = lista.filter(
+                        d => (d.idEstado === 2 || d.estado?.descripcion === 'DISPONIBLE')
                     );
                 },
                 error: () => {
-                    this.detalle = [];
+                    this.detallesPorBiblioteca[row.id] = [];
                     this.messageService.add({ severity: 'error', detail: 'Error al cargar detalles' });
                 }
             });
     }
 
     onRowCollapse(event: TableRowCollapseEvent) {
-        this.detalle = [];
+        const row = event.data;
+        if (row && row.id && this.detallesPorBiblioteca[row.id]) {
+            delete this.detallesPorBiblioteca[row.id];
+        }
     }
     cancelar(objeto: any) {
         this.reservas = this.reservas.filter(r => r !== objeto);
@@ -641,7 +646,7 @@ export class CatalogoEnLineaComponent {
             const payload = {
                 idDetalleBiblioteca: it.idDetalleBiblioteca ?? it.id,
                 idEstado: 3,
-                idUsuario: this.user?.idusuario ?? 0
+                idUsuario: this.user?.sub ?? this.user?.idusuario ?? 0
             };
             return this.genericoService.conf_event_put(payload, 'api/biblioteca/detalles/estado');
         });

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/prestamos/material-bibliografico/material-bibliografico.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/prestamos/material-bibliografico/material-bibliografico.ts
@@ -25,6 +25,14 @@ import { BibliotecaDTO } from '../../../interfaces/material-bibliografico/biblio
 import { DetalleBibliotecaDTO } from '../../../interfaces/material-bibliografico/DetalleBibliotecaDTO';
 import { GrupoBiblioteca, BibliotecaResumen } from '../../../interfaces/material-bibliografico/grupo-biblioteca.model';
 
+interface ReservaUsuario {
+  codigoUsuario: string;
+  nombreUsuario: string;
+  tipoPrestamo: string | null;
+  cantidad: number;
+  detalles: DetalleBibliotecaDTO[];
+}
+
 @Component({
     selector: 'app-aceptaciones',
     standalone: true,
@@ -77,12 +85,12 @@ import { GrupoBiblioteca, BibliotecaResumen } from '../../../interfaces/material
         </p-toolbar>
 
                         <p-table #dt1 [value]="reservadosDetalle"
-                                           dataKey="idDetalleBiblioteca" [rows]="10"
+                                           dataKey="codigoUsuario" [rows]="10"
                         [showCurrentPageReport]="true"
                         [expandedRowKeys]="expandedRows" (onRowExpand)="onRowExpand($event)" (onRowCollapse)="onRowCollapse($event)"
                         currentPageReportTemplate="Mostrando {first} a {last} de {totalRecords} registros"
                         [rowsPerPageOptions]="[10, 25, 50]" [loading]="loading" [rowHover]="true" styleClass="p-datatable-gridlines" [paginator]="true"
-                        [globalFilterFields]="['id','sede.descripcion','nombreEquipo','numeroEquipo','ip','estado.descripcion']" responsiveLayout="scroll">
+                        [globalFilterFields]="['nombreUsuario','tipoPrestamo']" responsiveLayout="scroll">
                         <ng-template pTemplate="caption">
 
                        <div class="flex items-center justify-between">
@@ -97,7 +105,7 @@ import { GrupoBiblioteca, BibliotecaResumen } from '../../../interfaces/material
                                 <tr>
                                 <th style="width: 5rem"></th>
                                     <th ></th>
-                                    <th pSortableColumn="nombres" style="min-width:200px">Apellidos y Nombres<p-sortIcon field="nombres"></p-sortIcon></th>
+                                    <th pSortableColumn="nombreUsuario" style="min-width:200px">Apellidos y Nombres<p-sortIcon field="nombreUsuario"></p-sortIcon></th>
                                  <th pSortableColumn="tipo.descripcion" style="width: 8rem">Tipo<p-sortIcon field="tipo.descripcion"></p-sortIcon></th>
                                     <th pSortableColumn="cantidad" style="width: 4rem">Cantidad<p-sortIcon field="cantidad"></p-sortIcon></th>
 
@@ -113,7 +121,7 @@ import { GrupoBiblioteca, BibliotecaResumen } from '../../../interfaces/material
                                 <!--<img [src]="objeto.foto" [alt]="objeto.nombres" width="50" class="shadow-lg" />-->
 
                                     </td>
-                                <td>{{detalle.codigoUsuario}}
+                                <td>{{detalle.nombreUsuario}}
                                     </td>
                                     <td>
                                         {{detalle.tipoPrestamo}}
@@ -131,15 +139,14 @@ import { GrupoBiblioteca, BibliotecaResumen } from '../../../interfaces/material
 
 
                             <p-table
-    [value]="[ detalle.biblioteca ]"
+    [value]="detalle.detalles"
     showGridlines
     [tableStyle]="{ 'min-width': '50rem' }">
         <ng-template pTemplate="header">
             <tr>
-                <th>Coleccion</th>
-                <th>Codigo</th>
+                <th>Título</th>
+                <th>Código</th>
                 <th>N.I</th>
-                <th>Titulo</th>
                 <th>Fecha de reserva</th>
                 <th>Prestar</th>
                 <th>Cancelar</th>
@@ -147,10 +154,9 @@ import { GrupoBiblioteca, BibliotecaResumen } from '../../../interfaces/material
         </ng-template>
         <ng-template pTemplate="body" let-bib>
             <tr>
-                <td>{{ bib.titulo || '-' }}</td>
+                <td>{{ bib.biblioteca?.titulo || '-' }}</td>
                 <td>{{ bib.biblioteca?.id }}</td>
                 <td>{{ bib.numeroIngreso }}</td>
-                <td>{{ bib.titulo }}</td>
                 <td>{{ bib.fechaReserva }}</td>
                 <td>
                    <p-button icon="pi pi-check" rounded outlined (click)="prestar(bib)"pTooltip="Prestar" tooltipPosition="bottom"/>
@@ -210,8 +216,8 @@ export class PrestamoMaterialBibliografico implements OnInit {
     opcionFiltro: ClaseGeneral = new ClaseGeneral();
     palabra: any;
     palabraClave: string = "";
-    expandedRows: { [key: number]: boolean } = {};
-    reservadosDetalle: DetalleBibliotecaDTO[] = [];
+    expandedRows: { [key: string]: boolean } = {};
+    reservadosDetalle: ReservaUsuario[] = [];
     grupos: GrupoBiblioteca[] = [];
     private todosDetallesReservados: DetalleBibliotecaDTO[] = [];
       @ViewChild('modalRegularizar') modalRegularizar!: ModalRegularizarComponent;
@@ -243,8 +249,8 @@ export class PrestamoMaterialBibliografico implements OnInit {
     this.loading = true;
     this.materialBibliograficoService.listarTodosDetallesReservados().subscribe({
       next: (lista: DetalleBibliotecaDTO[]) => {
-        // Guardamos toda la lista en reservadosDetalle
-        this.reservadosDetalle = lista;
+        // Agrupamos por usuario para mostrar un resumen
+        this.reservadosDetalle = this.agruparPorUsuario(lista);
         this.loading = false;
       },
       error: () => {
@@ -259,7 +265,7 @@ export class PrestamoMaterialBibliografico implements OnInit {
   }
 
 
-private agruparPorBiblioteca(
+  private agruparPorBiblioteca(
     detalles: DetalleBibliotecaDTO[]
   ): GrupoBiblioteca[] {
     const mapa = new Map<number, GrupoBiblioteca>();
@@ -344,6 +350,35 @@ private agruparPorBiblioteca(
       }
       // Añade el detalle al grupo correspondiente:
       mapa.get(bibId)!.detalles.push(det);
+    });
+
+    return Array.from(mapa.values());
+  }
+
+  private agruparPorUsuario(detalles: DetalleBibliotecaDTO[]): ReservaUsuario[] {
+    const mapa = new Map<string, ReservaUsuario>();
+
+    detalles.forEach(det => {
+      const codigo = det.codigoUsuario ?? 'DESCONOCIDO';
+      const nombre = det.nombreUsuario ?? det.codigoUsuario ?? 'DESCONOCIDO';
+      if (!mapa.has(codigo)) {
+        mapa.set(codigo, {
+          codigoUsuario: codigo,
+          nombreUsuario: nombre,
+          tipoPrestamo: det.tipoPrestamo ?? null,
+          cantidad: 0,
+          detalles: []
+        });
+      }
+      const entry = mapa.get(codigo)!;
+      entry.detalles.push(det);
+      entry.cantidad = entry.detalles.length;
+      if (!entry.tipoPrestamo) {
+        entry.tipoPrestamo = det.tipoPrestamo ?? null;
+      }
+      if (!entry.nombreUsuario) {
+        entry.nombreUsuario = nombre;
+      }
     });
 
     return Array.from(mapa.values());

--- a/Frontend/sakai-ng-master/src/app/biblioteca/services/material-bibliografico.service.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/services/material-bibliografico.service.ts
@@ -408,38 +408,42 @@ listarUsuariosOcurrencia(id: number): Observable<OcurrenciaUsuario[]> {
         .pipe(map(resp => resp.data));
     }
   /**
-   * Llama al endpoint para marcar un detalle como “prestado”.
-   * Equivale a DELETE /auth/api/prestamos/prestar con body { id }.
+   * Marca un detalle como “prestado”.
    */
   prestarDetalle(idDetalle: number): Observable<any> {
     const headers = new HttpHeaders().set(
       'Authorization',
       `Bearer ${this.authService.getToken()}`
     );
-    return this.http.delete<any>(
-      `${this.apiUrl}/api/prestamos/prestar`,
-      {
-        body: { id: idDetalle },
-        headers
-      }
+    const payload = {
+      idDetalleBiblioteca: idDetalle,
+      idEstado: 4,
+      idUsuario: this.authService.getUser()?.sub ?? 0
+    };
+    return this.http.put<any>(
+      `${this.apiUrl}/api/biblioteca/detalles/estado`,
+      payload,
+      { headers }
     );
   }
 
   /**
-   * Llama al endpoint para cancelar la reserva de un detalle.
-   * Equivale a DELETE /auth/api/prestamos/cancelar con body { id }.
+   * Cancela la reserva de un detalle, regresándolo a DISPONIBLE.
    */
   cancelarDetalle(idDetalle: number): Observable<any> {
     const headers = new HttpHeaders().set(
       'Authorization',
       `Bearer ${this.authService.getToken()}`
     );
-    return this.http.delete<any>(
-      `${this.apiUrl}/api/prestamos/cancelar`,
-      {
-        body: { id: idDetalle },
-        headers
-      }
+    const payload = {
+      idDetalleBiblioteca: idDetalle,
+      idEstado: 2,
+      idUsuario: this.authService.getUser()?.sub ?? 0
+    };
+    return this.http.put<any>(
+      `${this.apiUrl}/api/biblioteca/detalles/estado`,
+      payload,
+      { headers }
     );
   }
 


### PR DESCRIPTION
## Summary
- store reservation date when changing detail state
- expose the reservation date in DetalleBibliotecaDTO
- update Angular service to use the state endpoint for lending actions
- send email confirmation or rejection when processing material loans

## Testing
- `mvn -q -f Backend/login-microsoft365/pom.xml -DskipTests package` *(failed: Could not transfer artifact)*
- `npm --prefix Frontend/sakai-ng-master run build`
- `npm --prefix Frontend/sakai-ng-master test` *(failed: No inputs were found in tsconfig.spec.json)*

------
https://chatgpt.com/codex/tasks/task_e_684c71608914832990a8db845020a7bd