### PR TITLE
Add most borrowed report exports

### DIFF
--- a/Backend/login-microsoft365/src/main/java/com/miapp/controller/BibliotecaController.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/controller/BibliotecaController.java
@@ -206,6 +206,12 @@ public class BibliotecaController {
         resp.put("data", lista);
         return ResponseEntity.ok(resp);
     }
+    /** Reporte: ejemplares mas prestados */
+    @GetMapping("/reporte/ejemplar-mas-prestado")
+    public ResponseEntity<?> reporteEjemplarMasPrestado() {
+        return ResponseEntity.ok(Map.of("status", 0, "data", bibliotecaService.reporteEjemplarMasPrestado()));
+    }
+
 
 
 }

--- a/Backend/login-microsoft365/src/main/java/com/miapp/model/dto/EjemplarPrestadoDTO.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/model/dto/EjemplarPrestadoDTO.java
@@ -1,0 +1,40 @@
+package com.miapp.model.dto;
+
+public class EjemplarPrestadoDTO {
+    private Long idDetalle;
+    private String titulo;
+    private Long totalPrestamos;
+
+    public EjemplarPrestadoDTO() {
+    }
+
+    public EjemplarPrestadoDTO(Long idDetalle, String titulo, Long totalPrestamos) {
+        this.idDetalle = idDetalle;
+        this.titulo = titulo;
+        this.totalPrestamos = totalPrestamos;
+    }
+
+    public Long getIdDetalle() {
+        return idDetalle;
+    }
+
+    public void setIdDetalle(Long idDetalle) {
+        this.idDetalle = idDetalle;
+    }
+
+    public String getTitulo() {
+        return titulo;
+    }
+
+    public void setTitulo(String titulo) {
+        this.titulo = titulo;
+    }
+
+    public Long getTotalPrestamos() {
+        return totalPrestamos;
+    }
+
+    public void setTotalPrestamos(Long totalPrestamos) {
+        this.totalPrestamos = totalPrestamos;
+    }
+}

--- a/Backend/login-microsoft365/src/main/java/com/miapp/repository/OcurrenciaBibliotecaRepository.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/repository/OcurrenciaBibliotecaRepository.java
@@ -2,6 +2,8 @@ package com.miapp.repository;
 
 import com.miapp.model.OcurrenciaBiblioteca;
 import org.springframework.data.jpa.repository.JpaRepository;
+import com.miapp.model.dto.EjemplarPrestadoDTO;
+import org.springframework.data.jpa.repository.Query;
 import java.util.List;
 
 public interface OcurrenciaBibliotecaRepository
@@ -15,4 +17,21 @@ public interface OcurrenciaBibliotecaRepository
 
     /** Lista todas las ocurrencias ordenadas de forma descendente */
     List<OcurrenciaBiblioteca> findAllByOrderByIdDesc();
+
+    /**
+     * Devuelve los ejemplares de material bibliográfico más prestados
+     * junto con la cantidad de préstamos realizados.
+     */
+    @Query(
+            "SELECT new com.miapp.model.dto.EjemplarPrestadoDTO(" +
+            " d.idDetalle," +
+            " cast(function('DBMS_LOB.SUBSTR', b.titulo, 4000, 1) as string)," +
+            " COUNT(o.id)" +
+            ") " +
+            "FROM OcurrenciaBiblioteca o " +
+            "JOIN o.detalleBiblioteca d " +
+            "JOIN d.biblioteca b " +
+            "GROUP BY d.idDetalle, cast(function('DBMS_LOB.SUBSTR', b.titulo, 4000, 1) as string) " +
+            "ORDER BY COUNT(o.id) DESC")
+    List<EjemplarPrestadoDTO> reporteEjemplarMasPrestado();
 }

--- a/Backend/login-microsoft365/src/main/java/com/miapp/service/BibliotecaService.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/service/BibliotecaService.java
@@ -6,6 +6,7 @@ import com.miapp.model.Biblioteca;
 import com.miapp.model.dto.CambioEstadoBibliotecaRequest;
 import com.miapp.model.dto.DetalleBibliotecaDTO;
 import com.miapp.model.dto.ResponseDTO;
+import com.miapp.model.dto.EjemplarPrestadoDTO;
 import jakarta.transaction.Transactional;
 
 import java.util.List;
@@ -25,4 +26,7 @@ public interface BibliotecaService {
     List<BibliotecaDTO> findDisponibles();
 
     List<DetalleBibliotecaDTO> listarTodosDetallesReservados();
+
+    /** Reporte de ejemplares más prestados */
+    List<EjemplarPrestadoDTO> reporteEjemplarMasPrestado();
 }

--- a/Backend/login-microsoft365/src/main/java/com/miapp/service/impl/BibliotecaServiceImpl.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/service/impl/BibliotecaServiceImpl.java
@@ -36,6 +36,7 @@ public class BibliotecaServiceImpl implements BibliotecaService {
     private final BibliotecaMapper mapper;
     private final OcurrenciaUsuarioRepository repoU;
     private final OcurrenciaMaterialRepository repoM;
+    private final OcurrenciaBibliotecaRepository ocurrenciaBibliotecaRepository;
     private final NotificacionService notificacionService;
     private final EmailService emailService;
 
@@ -51,6 +52,7 @@ public class BibliotecaServiceImpl implements BibliotecaService {
                                  BibliotecaMapper mapper,
                                  OcurrenciaUsuarioRepository repoU,
                                  OcurrenciaMaterialRepository repoM,
+                                 OcurrenciaBibliotecaRepository ocurrenciaBibliotecaRepository,
                                  NotificacionService notificacionService,
                                  EmailService emailService) {
         this.bibliotecaRepository = bibliotecaRepository;
@@ -65,6 +67,7 @@ public class BibliotecaServiceImpl implements BibliotecaService {
         this.mapper = mapper;
         this.repoU = repoU;
         this.repoM = repoM;
+        this.ocurrenciaBibliotecaRepository = ocurrenciaBibliotecaRepository;
         this.notificacionService = notificacionService;
         this.emailService = emailService;
     }
@@ -688,6 +691,11 @@ public class BibliotecaServiceImpl implements BibliotecaService {
         return listaEntidades.stream()
                 .map(mapper::toDetalleDto)   // Aquí dentro toDetalleDto ya verá d.getBiblioteca() != null
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<EjemplarPrestadoDTO> reporteEjemplarMasPrestado() {
+        return ocurrenciaBibliotecaRepository.reporteEjemplarMasPrestado();
     }
 
 

--- a/Frontend/sakai-ng-master/src/app/biblioteca/interfaces/reportes/ejemplar-prestado.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/interfaces/reportes/ejemplar-prestado.ts
@@ -1,0 +1,5 @@
+export interface EjemplarPrestadoDTO {
+  idDetalle: number;
+  titulo: string;
+  totalPrestamos: number;
+}

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/ejemplar-mas-prestado.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/ejemplar-mas-prestado.ts
@@ -4,6 +4,13 @@ import { TooltipModule } from 'primeng/tooltip';
 import { TemplateModule } from '../../template.module';
 import { Sedes } from '../../interfaces/sedes';
 import { ClaseGeneral } from '../../interfaces/clase-general';
+import { MaterialBibliograficoService } from '../../services/material-bibliografico.service';
+import { EjemplarPrestadoDTO } from '../../interfaces/reportes/ejemplar-prestado';
+import { HttpClient } from '@angular/common/http';
+import { jsPDF } from 'jspdf';
+import autoTable from 'jspdf-autotable';
+import * as ExcelJS from 'exceljs';
+import { saveAs } from 'file-saver';
 
 @Component({
     selector: 'app-reporte-ejemplar-mas-prestado',
@@ -46,9 +53,9 @@ import { ClaseGeneral } from '../../interfaces/clase-general';
                    
                     <div class="flex flex-col gap-2 col-span-3 md:col-span-2 lg:col-span-2">
                     <label for="tipoPrestamo" class="block text-sm font-medium">Fecha inicio</label>
-                        <p-datepicker 
+                        <p-datepicker
                             appendTo="body"
-                            formControlName="fechaInicio"
+                            [(ngModel)]="fechaInicio"
                             [ngClass]="'w-full'"
                             [style]="{ width: '100%' }"
                             [readonlyInput]="true"
@@ -57,9 +64,9 @@ import { ClaseGeneral } from '../../interfaces/clase-general';
                     </div>
                     <div class="flex flex-col gap-2 col-span-3 md:col-span-2 lg:col-span-2">
                     <label for="tipoPrestamo" class="block text-sm font-medium">Fecha fin</label>
-                    <p-datepicker 
+                    <p-datepicker
                             appendTo="body"
-                            formControlName="fechaFin"
+                            [(ngModel)]="fechaFin"
                             [ngClass]="'w-full'"
                             [style]="{ width: '100%' }"
                             [readonlyInput]="true"
@@ -75,13 +82,30 @@ import { ClaseGeneral } from '../../interfaces/clase-general';
             </button>
         </div>
                     <div class="flex col-span-1 md:col-span-2 lg:col-span-2">
-                    
+                        <button pButton icon="pi pi-file-excel" class="mr-2 p-button-danger" (click)="exportExcel()" tooltip="Exportar a Excel"></button>
+                        <button pButton icon="pi pi-file-pdf" class="mr-2 p-button-danger" (click)="exportPdf()" tooltip="Exportar a PDF"></button>
                     </div>
                 </div>
-               
+
             </div>
-       
+
     </p-toolbar>
+    <p-table [value]="resultados" [paginator]="true" [rows]="10" [loading]="loading" scrollable="true" scrollHeight="400px" [style]="{ 'overflow-x': 'auto', 'padding-bottom': '1rem'}">
+        <ng-template pTemplate="header">
+            <tr>
+                <th>ID</th>
+                <th>Título</th>
+                <th>Préstamos</th>
+            </tr>
+        </ng-template>
+        <ng-template pTemplate="body" let-row>
+            <tr>
+                <td>{{ row.idDetalle }}</td>
+                <td>{{ row.titulo }}</td>
+                <td>{{ row.totalPrestamos }}</td>
+            </tr>
+        </ng-template>
+    </p-table>
 </div>
 `,
             imports: [TemplateModule, TooltipModule],
@@ -112,11 +136,79 @@ export class ReporteEjemplarMasPrestado {
     dataEspecialidad: ClaseGeneral[] = [];
     especialidadFiltro: ClaseGeneral = new ClaseGeneral();
     nroIngreso:string='';
+    fechaInicio: Date = new Date();
+    fechaFin: Date = new Date();
     tipo:number=1;
     loading: boolean = true;
+    resultados: EjemplarPrestadoDTO[] = [];
+
+    constructor(private svc: MaterialBibliograficoService,
+                private messageService: MessageService,
+                private http: HttpClient) {}
 
     async ngOnInit() {
         await this.reporte();
     }
-    reporte(){}
+    async reporte() {
+        this.loading = true;
+        try {
+            this.resultados =
+                (await this.svc
+                    .reporteEjemplarMasPrestado()
+                    .toPromise()) ?? [];
+        } finally {
+            this.loading = false;
+        }
+    }
+
+    async exportExcel() {
+        if (!this.resultados.length) {
+            this.messageService.add({ severity: 'warn', detail: 'No hay datos para exportar.' });
+            return;
+        }
+        const wb = new ExcelJS.Workbook();
+        const ws = wb.addWorksheet('Reporte');
+        const buffer = await this.http.get('/assets/logo.png', { responseType: 'arraybuffer' }).toPromise();
+        const logoId = wb.addImage({ buffer, extension: 'png' });
+        ws.addImage(logoId, { tl: { col: 0.2, row: 0.2 }, ext: { width: 220, height: 80 } });
+        ws.mergeCells('C1', 'E2');
+        const title = ws.getCell('C1');
+        title.value = 'Ejemplares más prestados';
+        title.alignment = { vertical: 'middle', horizontal: 'center' };
+        title.font = { size: 16, bold: true };
+        ws.addRow([]);
+        const headerRow = ws.addRow(['ID', 'Título', 'Préstamos']);
+        headerRow.font = { bold: true };
+        headerRow.alignment = { horizontal: 'center' };
+        this.resultados.forEach(r => ws.addRow([r.idDetalle, r.titulo, r.totalPrestamos]));
+        ws.columns.forEach(col => (col.width = 25));
+        const buf = await wb.xlsx.writeBuffer();
+        saveAs(new Blob([buf]), 'ejemplares_mas_prestados.xlsx');
+    }
+
+    exportPdf() {
+        if (!this.resultados.length) {
+            this.messageService.add({ severity: 'warn', detail: 'No hay datos para exportar.' });
+            return;
+        }
+        const doc = new jsPDF({ orientation: 'landscape' });
+        const img = new Image();
+        img.src = '/assets/logo.png';
+        img.onload = () => {
+            doc.addImage(img, 'PNG', 10, 10, 60, 25);
+            doc.setFontSize(16);
+            doc.text('Ejemplares más prestados', 80, 20);
+            doc.setFontSize(10);
+            const hoy = new Date();
+            doc.text(`Fecha de emisión: ${hoy.toLocaleDateString()}`, 80, 25);
+            autoTable(doc, {
+                head: [['ID', 'Título', 'Préstamos']],
+                body: this.resultados.map(r => [r.idDetalle, r.titulo, r.totalPrestamos]),
+                startY: 35,
+                styles: { fontSize: 8 },
+                headStyles: { fillColor: [41, 128, 185] }
+            });
+            doc.save('ejemplares_mas_prestados.pdf');
+        };
+    }
 }

--- a/Frontend/sakai-ng-master/src/app/biblioteca/services/material-bibliografico.service.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/services/material-bibliografico.service.ts
@@ -1,4 +1,5 @@
 import { HttpClient, HttpHeaders, HttpParams  } from '@angular/common/http';
+import { EjemplarPrestadoDTO } from '../interfaces/reportes/ejemplar-prestado';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { AuthService } from './auth.service';
@@ -448,4 +449,9 @@ listarUsuariosOcurrencia(id: number): Observable<OcurrenciaUsuario[]> {
   }
 
 
+  /** Obtiene el reporte de ejemplares mas prestados */
+  reporteEjemplarMasPrestado(): Observable<EjemplarPrestadoDTO[]> {
+    const headers = new HttpHeaders().set('Authorization', `Bearer ${this.authService.getToken()}`);
+    return this.http.get<{ status: number; data: EjemplarPrestadoDTO[] }>(`${this.apiUrl}/api/biblioteca/reporte/ejemplar-mas-prestado`, { headers }).pipe(map(resp => resp.data));
+  }
 }


### PR DESCRIPTION
## Summary
- add EjemplarPrestadoDTO interface for report
- type MaterialBibliograficoService most-borrowed method
- show results table with export buttons
- support Excel and PDF download in most-borrowed report

## Testing
- `npm install`
- `npm run build`
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dbfca28988329b608fa6097e0d41a