### PR TITLE
Implement inactivity-based logout

### DIFF
--- a/Backend/login-microsoft365/src/main/java/com/miapp/util/JwtUtil.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/util/JwtUtil.java
@@ -33,7 +33,7 @@ public class JwtUtil {
 //                .sign(Algorithm.HMAC256(secret));
 //    }
     public String generateToken(String login, String role) {
-        long expirationTime = 3600000; // 20 segundos en milisegundos
+        long expirationTime = 86400000; // 24 horas en milisegundos
         return Jwts.builder()
                 .setSubject(login)
                 .claim("role", role)

--- a/Frontend/sakai-ng-master/src/app/biblioteca/services/auth.service.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/services/auth.service.ts
@@ -36,6 +36,10 @@ export class AuthService {
   public currentUser: Observable<Usuario>;
   public currentUsuario: Usuario | undefined;
 
+  private inactivityTimer: any;
+  private activityEvents = ['mousemove', 'keydown', 'click', 'scroll'];
+  private boundResetTimer = this.resetInactivityTimer.bind(this);
+
   private apiUrl = environment.apiUrl;
 
   constructor(private http: HttpClient, private router: Router, private msalService: MsalService) {
@@ -46,7 +50,9 @@ export class AuthService {
       );
 
     this.currentUser = this.currentUserSubject.asObservable();
-
+    if (this.idAuthenticated()) {
+      this.scheduleAutoLogout();
+    }
 
   }
   public get currentUserValue(): Usuario {
@@ -114,6 +120,7 @@ export class AuthService {
         localStorage.setItem("role", JSON.stringify(roles));
         // Emite el usuario incluyendo los roles
         this.currentUserSubject.next({ ...user, roles });
+        this.scheduleAutoLogout();
       }
   }
   getToken(): string {
@@ -223,36 +230,32 @@ register(userData: any): Observable<any> {
     return this.http.post<any>(`${this.apiUrl}/register`, userData);
 }
 
-// Llama a esta función después de un login exitoso para programar el cierre de sesión automático.
+// Inicia el temporizador de inactividad para cerrar sesión tras 1 hora sin movimiento
 scheduleAutoLogout(): void {
-  const token = localStorage.getItem(this.TOKEN_NAME);
-  if (token) {
-    try {
-        const helper = new JwtHelperService();
-        const decoded = helper.decodeToken(token);
-      const expirationTime = decoded.exp * 1000; // Convertir de segundos a milisegundos
-      const currentTime = Date.now();
-      const timeout = expirationTime - currentTime;
+  this.activityEvents.forEach(event =>
+    document.addEventListener(event, this.boundResetTimer)
+  );
+  this.resetInactivityTimer();
+}
 
-      console.log('⏳ Tiempo restante para logout automático (ms):', timeout);
-
-      if (timeout > 0) {
-        setTimeout(() => {
-          console.log('🔒 Token expirado. Cerrando sesión automáticamente...');
-          this.logout();
-        }, timeout);
-      } else {
-        this.logout();
-      }
-    } catch (error) {
-      console.error('❌ Error al decodificar el token:', error);
-      this.logout();
-    }
+private resetInactivityTimer(): void {
+  if (this.inactivityTimer) {
+    clearTimeout(this.inactivityTimer);
   }
+  this.inactivityTimer = setTimeout(() => {
+    console.log('🔒 Sesión cerrada por inactividad.');
+    this.logout();
+  }, 3600000); // 1 hora
 }
 
 
   logout(): void {
+    this.activityEvents.forEach(event =>
+      document.removeEventListener(event, this.boundResetTimer)
+    );
+    if (this.inactivityTimer) {
+      clearTimeout(this.inactivityTimer);
+    }
     localStorage.removeItem('currentUser');
     localStorage.removeItem(this.TOKEN_NAME);
     // Redirige a la página de inicio luego de cerrar sesión


### PR DESCRIPTION
## Summary
- extend backend JWT token expiration to 24 hours
- implement inactivity timer on the frontend
- trigger timer on login and logout

## Testing
- `npm test --silent` *(fails: ng not found)*
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68524d727f0c8329a32d47ac6d7408b9