### PR TITLE
Modify ocurrencia view

### DIFF
--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/biblioteca/ocurrencias-biblioteca.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/biblioteca/ocurrencias-biblioteca.ts
@@ -13,10 +13,15 @@ import { ModalNuevoOcurencia } from '../laboratorio-computo/modal-nuevo-ocurrenc
 import { ModalDetalleOcurencia } from '../laboratorio-computo/modal-detalle-ocurrencia';
 import { MaterialBibliograficoService } from '../../services/material-bibliografico.service';
 import { OcurrenciaDTO } from '../../interfaces/ocurrenciaDTO';
+import { OcurrenciaEventService } from '../../services/ocurrencia-event.service';
 
 @Component({
     selector: 'app-ocurrencias-biblioteca',
     standalone: true,
+    styles: [
+      `.highlight-row { animation: fadeHighlight 2s ease-in-out forwards; }
+       @keyframes fadeHighlight { from { background-color: #ffe08a; } to { background-color: transparent; } }`
+    ],
     template: ` <div class="card">
         <h5>{{titulo}}</h5>
         <p-toolbar styleClass="mb-6">
@@ -88,7 +93,7 @@ import { OcurrenciaDTO } from '../../interfaces/ocurrenciaDTO';
                                 </tr>
                             </ng-template>
                             <ng-template pTemplate="body" let-objeto>
-                                <tr>
+                                <tr [ngClass]="{ 'highlight-row': objeto.highlight }">
                                     <td>
                                     <div class="flex flex-wrap justify-center gap-2">
                                 <p-button outlined icon="pi pi-pencil" pTooltip="Actualizar" tooltipPosition="bottom" (click)="editar(objeto)"/>
@@ -149,11 +154,16 @@ export class OcurrenciasBiblioteca implements OnInit {
     @ViewChild('filter') filter!: ElementRef;
     @ViewChild('modalNuevoOcurrencia') modalNuevoOcurrencia!: ModalNuevoOcurencia;
     @ViewChild('modalDetalleOcurrencia') modalDetalleOcurrencia!: ModalDetalleOcurencia;
+    @ViewChild('dt1') table!: Table;
+    /** ID del material cuya ocurrencia debe resaltarse */
+    destinoId: number | null = null;
 
     constructor(private ocurrenciasService: OcurrenciasService, private genericoService: GenericoService, private fb: FormBuilder,
     private router: Router, private authService: AuthService, private confirmationService: ConfirmationService, private messageService: MessageService,
-    private materialBsvc: MaterialBibliograficoService) { }
+    private materialBsvc: MaterialBibliograficoService,
+    private ocurrenciaEvents: OcurrenciaEventService) { }
     async ngOnInit() {
+        this.destinoId = this.ocurrenciaEvents.consumeDestino();
         this.buscar();
     }
   buscar() {
@@ -166,9 +176,11 @@ export class OcurrenciasBiblioteca implements OnInit {
         // aseguramos un campo usuarioNombre para filtros o visualización
         this.data = ordered.map((o:any)=> ({
           ...o,
-          usuarioNombre: o.usuario?.nombres
+          usuarioNombre: o.usuario?.nombres,
+          highlight: false
         }));
         this.loading = false;
+        this.aplicarResaltado();
       },
       error: (err: HttpErrorResponse) => {
         this.loading = false;
@@ -203,4 +215,21 @@ export class OcurrenciasBiblioteca implements OnInit {
         // abrimos el modal en modo “costear”
         this.modalDetalleOcurrencia.openModal(obj.id!, true);
       }
+
+  /** Resalta temporalmente la fila relacionada con `destinoId` y navega a su página */
+  private aplicarResaltado(): void {
+    if (!this.destinoId || !this.table) {
+      return;
+    }
+    const index = this.data.findIndex(d => d.idDetalleBiblioteca === this.destinoId);
+    if (index >= 0) {
+      const pageSize = this.table.rows || 10;
+      const page = Math.floor(index / pageSize);
+      this.table.first = page * pageSize;
+      const fila = this.data[index];
+      fila.highlight = true;
+      setTimeout(() => (fila.highlight = false), 2000);
+    }
+    this.destinoId = null;
+  }
 }

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/laboratorio-computo/ocurrencias.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/laboratorio-computo/ocurrencias.ts
@@ -94,7 +94,7 @@ import { OcurrenciaEventService } from '../../services/ocurrencia-event.service'
                                 </tr>
                             </ng-template>
                             <ng-template pTemplate="body" let-objeto>
-                                <tr>
+                                <tr [ngClass]="{ 'highlight-row': objeto.highlight }">
                                     <td>
                                     <div class="flex flex-wrap justify-center gap-2">
                                 <p-button outlined icon="pi pi-pencil" pTooltip="Actualizar" tooltipPosition="bottom" (click)="editar(objeto)"/>
@@ -170,6 +170,7 @@ export class OcurrenciasLaboratorio {
     @ViewChild('modalNuevoOcurrencia') modalNuevoOcurrencia!: ModalNuevoOcurencia;
     @ViewChild('modalDetalleOcurrencia') modalDetalleOcurrencia!: ModalDetalleOcurencia;
     /** ID de equipo cuyo registro debe resaltarse */
+    @ViewChild('dt1') table!: Table;
     destinoId: number | null = null;
 
     constructor(private ocurrenciasService: OcurrenciasService, private genericoService: GenericoService, private fb: FormBuilder,
@@ -223,13 +224,17 @@ export class OcurrenciasLaboratorio {
     this.modalDetalleOcurrencia.openModal(obj.id!, true);
   }
 
-  /** Resalta temporalmente la fila relacionada con `destinoId` */
+  /** Resalta temporalmente la fila relacionada con `destinoId` y navega a su página */
   private aplicarResaltado(): void {
-    if (!this.destinoId) {
+    if (!this.destinoId || !this.table) {
       return;
     }
-    const fila = this.data.find(d => (d.idEquipo || d.equipoNumero) === this.destinoId);
-    if (fila) {
+    const index = this.data.findIndex(d => (d.idEquipo || d.equipoNumero) === this.destinoId);
+    if (index >= 0) {
+      const pageSize = this.table.rows || 10;
+      const page = Math.floor(index / pageSize);
+      this.table.first = page * pageSize;
+      const fila = this.data[index];
       fila.highlight = true;
       setTimeout(() => fila.highlight = false, 2000);
     }

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/mantenimientos/aceptaciones/aceptaciones-equipos.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/mantenimientos/aceptaciones/aceptaciones-equipos.ts
@@ -115,15 +115,13 @@ import { OcurrenciaEventService } from '../../../services/ocurrencia-event.servi
                 [pTooltip]="objeto.tieneOcurrencia ? 'Material con observación' : 'Confirmar'"
                 tooltipPosition="bottom">
             </button>
-            <button
+            <span
                 *ngIf="objeto.tieneOcurrencia"
-                pButton
-                type="button"
-                class="p-button-rounded p-button-info pulse ml-2"
-                icon="pi pi-exclamation-circle"
                 (click)="irAutorizacion(objeto)"
+                class="text-xs text-blue-500 underline cursor-pointer block mt-1"
                 pTooltip="Autorizar ocurrencia" tooltipPosition="bottom">
-            </button>
+                Ver ocurrencia
+            </span>
 
                                     </td>
                                     <td>

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/mantenimientos/aceptaciones/aceptaciones.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/mantenimientos/aceptaciones/aceptaciones.ts
@@ -1,5 +1,5 @@
 import { HttpErrorResponse } from '@angular/common/http';
-import { Component, ElementRef, ViewChild, OnInit } from '@angular/core';
+import { Component, ElementRef, ViewChild, OnInit, AfterViewInit } from '@angular/core';
 import { FormGroup, FormBuilder, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
 import { MessageService, ConfirmationService, MenuItem } from 'primeng/api';
@@ -21,11 +21,16 @@ import { BibliotecaVirtualService } from '../../../services/biblioteca-virtual.s
 import { TipoMaterial } from '../../../interfaces/material-bibliografico/tipo-material';
 import { TipoAdquisicion } from '../../../interfaces/material-bibliografico/tipo-adquisicion';
 import { ModalNuevoOcurencia } from '../../laboratorio-computo/modal-nuevo-ocurrencia';
+import { OcurrenciaEventService } from '../../../services/ocurrencia-event.service';
 
 
 @Component({
   selector: 'app-aceptaciones',
   standalone: true,
+  styles: [
+    `.highlight-row { animation: fadeHighlight 2s ease-in-out forwards; }
+     @keyframes fadeHighlight { from { background-color: #ffe08a; } to { background-color: transparent; } }`
+  ],
   template: ` <div class="">
                 <div class="">
                     <div class="card flex flex-col gap-4 w-full">
@@ -154,7 +159,7 @@ import { ModalNuevoOcurencia } from '../../laboratorio-computo/modal-nuevo-ocurr
             </tr>
         </ng-template>
         <ng-template pTemplate="body" let-objetoDetalle>
-            <tr>
+            <tr [ngClass]="{ 'highlight-row': objetoDetalle.highlight }">
                 <td>{{ objetoDetalle.numeroIngreso  }}</td>
                 <td>{{ objetoDetalle.sede?.descripcion }}</td>
                 <td>{{ objetoDetalle.tipoAdquisicion?.descripcion }}</td>
@@ -169,12 +174,21 @@ import { ModalNuevoOcurencia } from '../../laboratorio-computo/modal-nuevo-ocurr
                  <button
                    pButton
                    type="button"
-                   class="p-button-rounded p-button-success"
+                   class="p-button-rounded"
+                   [ngClass]="objetoDetalle.tieneOcurrencia ? 'p-button-warning' : 'p-button-success'"
                    icon="pi pi-check"
                    (click)="aceptarDetalle(objetoDetalle)"
-                   pTooltip="Marcar Disponible"
+                   [disabled]="objetoDetalle.tieneOcurrencia"
+                   [pTooltip]="objetoDetalle.tieneOcurrencia ? 'Material con observación' : 'Confirmar'"
                    tooltipPosition="bottom">
                  </button>
+                 <span
+                   *ngIf="objetoDetalle.tieneOcurrencia"
+                   (click)="irAutorizacion(objetoDetalle)"
+                   class="text-xs text-blue-500 underline cursor-pointer block mt-1"
+                   pTooltip="Autorizar ocurrencia" tooltipPosition="bottom">
+                   Ver ocurrencia
+                 </span>
                 </td>
                 <td>
                  <p-button
@@ -215,7 +229,7 @@ import { ModalNuevoOcurencia } from '../../laboratorio-computo/modal-nuevo-ocurr
   imports: [TemplateModule,TooltipModule, ModalNuevoOcurencia],
   providers: [MessageService, ConfirmationService]
 })
-export class Aceptaciones implements OnInit {
+export class Aceptaciones implements OnInit, AfterViewInit {
   titulo: string = "Aceptaciones de MB";
   data: any[] = [];
   detalle:any[]=[];
@@ -241,9 +255,32 @@ export class Aceptaciones implements OnInit {
   tipoMaterialLista: TipoMaterial[]     = [];
   estadoLista: EstadoRecurso[]         = [];
   detallePorId: { [bibliotecaId: number]: any[] } = {};
+  /** Detalle seleccionado para registrar ocurrencia */
+  selectedDetalleOcurrencia: any | null = null;
 
   constructor(private materialBibliograficoService: MaterialBibliograficoService, private genericoService: GenericoService, private fb: FormBuilder,
-    private router: Router, private authService: AuthService, private confirmationService: ConfirmationService, private messageService: MessageService) { }
+    private router: Router, private authService: AuthService, private confirmationService: ConfirmationService, private messageService: MessageService,
+    private ocurrenciaEvents: OcurrenciaEventService) { }
+
+  ngAfterViewInit(): void {
+    this.modal.saved.subscribe(() => {
+      if (this.selectedDetalleOcurrencia) {
+        this.selectedDetalleOcurrencia.tieneOcurrencia = true;
+        this.selectedDetalleOcurrencia.highlight = true;
+        const id = this.selectedDetalleOcurrencia.idDetalleBiblioteca || this.selectedDetalleOcurrencia.id;
+        if (id) {
+          this.ocurrenciaEvents.addEquipo(id);
+        }
+        const ref = this.selectedDetalleOcurrencia;
+        setTimeout(() => ref.highlight = false, 2000);
+        this.selectedDetalleOcurrencia = null;
+      }
+    });
+
+    this.ocurrenciaEvents.ocurrenciaAutorizada.subscribe(() => {
+      this.listar();
+    });
+  }
   async ngOnInit() {
     // this.user = this.authService.getUser();
     this.user = {
@@ -402,11 +439,20 @@ aceptarDetalle(detalle: any) {
   }
 
   onAbrirOcurrencia(item: any) {
+    this.selectedDetalleOcurrencia = item;
     this.modal.openModal(item);
   }
 
   verDetalle(objeto:any){
 
+  }
+
+  irAutorizacion(detalle: any): void {
+    const id = detalle.idDetalleBiblioteca || detalle.id;
+    if (id) {
+      this.ocurrenciaEvents.setDestino(id);
+    }
+    this.router.navigate(['/main/biblioteca/ocurrencias']);
   }
   private async listaTipoMaterial() {
     try {
@@ -501,7 +547,9 @@ onRowExpand(event: TableRowExpandEvent) {
           sede: this.dataSede.find(s => s.id == d.codigoSede),
           tipoAdquisicion: this.tipoAdquisicionLista.find(t => t.id == d.tipoAdquisicionId),
           tipoMaterial:    this.tipoMaterialLista.find(m => m.id == d.tipoMaterialId),
-          estado: this.estadoLista.find(e => e.id === Number(d.idEstado))
+          estado: this.estadoLista.find(e => e.id === Number(d.idEstado)),
+          tieneOcurrencia: this.ocurrenciaEvents.tieneOcurrencia(d.idDetalleBiblioteca),
+          highlight: false
         }));
         console.log('→ mapeados:', this.detallePorId[lib.id]);
       });


### PR DESCRIPTION
## Summary
- replace the ocurrencia button with text link in `aceptaciones-equipos` component
- add a similar text link for `aceptaciones` to view pending ocurrencias
- ensure saved ocurrencias mark the detail as pending and display link
- highlight the selected ocurrencia when navigating to the library module
- highlight and scroll to the selected ocurrencia in the equipment module
- **fix**: apply highlight styling in the laboratorio occurrences table

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685377fe9cfc8329a7bce4c78008136a