### PR TITLE
Implement estudiantes atendidos report

### DIFF
--- a/Backend/login-microsoft365/src/main/java/com/miapp/controller/PrestamoController.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/controller/PrestamoController.java
@@ -162,6 +162,13 @@ public class PrestamoController {
         return ResponseEntity.ok(Map.of("status","0","data", dp));
     }
 
+    /** Reporte de estudiantes atendidos */
+    @GetMapping("/reporte/estudiantes-atendidos")
+    public ResponseEntity<?> reporteEstudiantesAtendidos() {
+        List<com.miapp.model.dto.UsuarioPrestamosDTO> lista = prestamoService.reporteEstudiantesAtendidos();
+        return ResponseEntity.ok(Map.of("status","0","data", lista));
+    }
+
     @GetMapping("/usuarios")
     public ResponseEntity<?> listarUsuarios(
             @RequestParam(required = false) String search) {

--- a/Backend/login-microsoft365/src/main/java/com/miapp/model/dto/UsuarioPrestamosDTO.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/model/dto/UsuarioPrestamosDTO.java
@@ -1,0 +1,17 @@
+package com.miapp.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/** DTO para la estadística de préstamos por usuario */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class UsuarioPrestamosDTO {
+    /** Identificador del último préstamo del usuario */
+    private Long id;
+    private String usuario;
+    private String sede;
+    private Long totalPrestamos;
+}

--- a/Backend/login-microsoft365/src/main/java/com/miapp/repository/DetallePrestamoRepository.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/repository/DetallePrestamoRepository.java
@@ -38,4 +38,22 @@ public interface DetallePrestamoRepository
 
     List<DetallePrestamo> findByFechaFinBetweenAndReminder48SentFalse(
             LocalDateTime start, LocalDateTime end);
+
+    /**
+     * Devuelve la cantidad de préstamos realizados por cada usuario.
+     * Se incluye la descripción de la sede a la que pertenece el usuario si está disponible.
+     */
+    @org.springframework.data.jpa.repository.Query(
+            "SELECT new com.miapp.model.dto.UsuarioPrestamosDTO(" +
+            " MAX(dp.id)," +
+            " dp.codigoUsuario," +
+            " COALESCE(s.descripcion, s2.descripcion)," +
+            " COUNT(dp)) " +
+            "FROM DetallePrestamo dp " +
+            "LEFT JOIN Usuario u ON upper(u.login) = upper(dp.codigoUsuario) " +
+            "LEFT JOIN Sede s ON u.idSede = s.id " +
+            "LEFT JOIN Sede s2 ON dp.codigoSede = str(s2.id) " +
+            "GROUP BY dp.codigoUsuario, COALESCE(s.descripcion, s2.descripcion) " +
+            "ORDER BY MAX(dp.id) DESC" )
+    List<com.miapp.model.dto.UsuarioPrestamosDTO> contarPrestamosPorUsuario();
 }

--- a/Backend/login-microsoft365/src/main/java/com/miapp/service/PrestamoService.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/service/PrestamoService.java
@@ -11,6 +11,7 @@ import com.miapp.spec.DetallePrestamoSpecs;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.jpa.domain.Specification;
+import org.springframework.data.domain.Sort;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.stereotype.Service;
 
@@ -243,13 +244,21 @@ public class PrestamoService {
                         .and(DetallePrestamoSpecs.porEscuela(escuela))
                         .and(DetallePrestamoSpecs.porPrograma(programa))
                         .and(DetallePrestamoSpecs.porCiclo(ciclo))
-                        .and(DetallePrestamoSpecs.entreFechas(fechaInicio, fechaFin))
+                        .and(DetallePrestamoSpecs.entreFechas(fechaInicio, fechaFin)),
+                Sort.by(Sort.Direction.DESC, "id")
         );
     }
 
     public DetallePrestamo buscarPorId(Long id) {
         return detallePrestamoRepository.findById(id)
                 .orElseThrow(() -> new RuntimeException("DetallePrestamo no encontrado: " + id));
+    }
+
+    /**
+     * Reporte de cantidad de préstamos por usuario.
+     */
+    public List<com.miapp.model.dto.UsuarioPrestamosDTO> reporteEstudiantesAtendidos() {
+        return detallePrestamoRepository.contarPrestamosPorUsuario();
     }
 
 }

--- a/Frontend/sakai-ng-master/src/app/biblioteca/interfaces/detalle-prestamo.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/interfaces/detalle-prestamo.ts
@@ -1,5 +1,7 @@
 import { Equipo } from './biblioteca-virtual/equipo';
 export interface DetallePrestamo {
+  /** Identificador del detalle de préstamo */
+  id: number;
   alcance: string;
   usuario: string;
   especialidad: string;

--- a/Frontend/sakai-ng-master/src/app/biblioteca/interfaces/reportes/usuario-prestamos.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/interfaces/reportes/usuario-prestamos.ts
@@ -1,0 +1,7 @@
+export interface UsuarioPrestamosDTO {
+    /** Identificador del último préstamo */
+    id: number;
+    usuario: string;
+    sede: string | null;
+    totalPrestamos: number;
+}

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/estudiantes-atendidos.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/estudiantes-atendidos.ts
@@ -1,9 +1,12 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { MessageService, ConfirmationService } from 'primeng/api';
 import { TooltipModule } from 'primeng/tooltip';
 import { TemplateModule } from '../../template.module';
 import { Sedes } from '../../interfaces/sedes';
 import { ClaseGeneral } from '../../interfaces/clase-general';
+import { PrestamosService } from '../../services/prestamos.service';
+import { UsuarioPrestamosDTO } from '../../interfaces/reportes/usuario-prestamos';
+import { firstValueFrom } from 'rxjs';
 
 @Component({
     selector: 'app-reporte-estudiantes-atendidos',
@@ -78,12 +81,37 @@ import { ClaseGeneral } from '../../interfaces/clase-general';
             </div>
        
     </p-toolbar>
+    <p-table
+        [value]="resultados"
+        [loading]="loading"
+        [paginator]="true"
+        [rows]="10"
+        [rowsPerPageOptions]="[10, 25, 50]"
+        [showCurrentPageReport]="true"
+        currentPageReportTemplate="Mostrando {first} a {last} de {totalRecords} registros"
+        sortField="id"
+        [sortOrder]="-1">
+        <ng-template pTemplate="header">
+            <tr>
+                <th>Usuario</th>
+                <th>Sede</th>
+                <th>Préstamos</th>
+            </tr>
+        </ng-template>
+        <ng-template pTemplate="body" let-row>
+            <tr>
+                <td>{{ row.usuario }}</td>
+                <td>{{ row.sede || '-' }}</td>
+                <td>{{ row.totalPrestamos }}</td>
+            </tr>
+        </ng-template>
+    </p-table>
 </div>
 `,
             imports: [TemplateModule, TooltipModule],
             providers: [MessageService, ConfirmationService]
 })
-export class ReporteEstudiantesAtendidos {
+export class ReporteEstudiantesAtendidos implements OnInit {
     titulo: string = "Estudiantes atendidos material bibliográfico";
     dataSede: Sedes[] = [];
     sedeFiltro: Sedes = new Sedes();
@@ -110,9 +138,22 @@ export class ReporteEstudiantesAtendidos {
     nroIngreso:string='';
     tipo:number=1;
     loading: boolean = true;
+    resultados: UsuarioPrestamosDTO[] = [];
+
+    constructor(private prestamosService: PrestamosService) {}
 
     async ngOnInit() {
         await this.reporte();
     }
-    reporte(){}
+
+    async reporte() {
+        this.loading = true;
+        try {
+            this.resultados = await firstValueFrom(
+                this.prestamosService.reporteEstudiantesAtendidos()
+            );
+        } finally {
+            this.loading = false;
+        }
+    }
 }

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/reporte-prestamo-equipo-computo.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/reporte-prestamo-equipo-computo.ts
@@ -118,7 +118,8 @@ import { HttpClient } from '@angular/common/http';
   <!-- TABLA -->
   <div class="table-wrapper">
     <p-table [value]="resultados" [paginator]="true" [rows]="10" [loading]="loading" scrollable="true"
-      scrollHeight="800px" [style]="{ 'overflow-x': 'auto', 'padding-bottom': '1rem'}">
+      scrollHeight="800px" [style]="{ 'overflow-x': 'auto', 'padding-bottom': '1rem'}"
+      sortField="id" [sortOrder]="-1">
       <ng-template pTemplate="header">
         <tr>
           <th>Equipo</th>

--- a/Frontend/sakai-ng-master/src/app/biblioteca/services/prestamos.service.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/services/prestamos.service.ts
@@ -6,6 +6,7 @@ import { environment } from '../../../environments/environment';
 import { Notificacion } from '../interfaces/notificacion';
 import { DetallePrestamo } from '../interfaces/detalle-prestamo';
 import { map } from 'rxjs/operators';
+import { UsuarioPrestamosDTO } from '../interfaces/reportes/usuario-prestamos';
 
 @Injectable({
   providedIn: 'root'
@@ -113,5 +114,14 @@ procesarPrestamo(id: number, aprobar: boolean): Observable<any> {
   listarEstados(): Observable<any> {
       return this.http.get<any>(`${this.apiUrl}/api/equipos/estados`);
       }
+
+  /** Obtiene el total de préstamos por usuario */
+  reporteEstudiantesAtendidos(): Observable<UsuarioPrestamosDTO[]> {
+      return this.http
+        .get<{status:string, data: UsuarioPrestamosDTO[]}>(
+          `${this.apiUrl}/api/prestamos/reporte/estudiantes-atendidos`
+        )
+        .pipe(map(r => r.data ?? []));
+  }
 
 }


### PR DESCRIPTION
## Summary
- add `UsuarioPrestamosDTO` interface for report rows
- type results in `PrestamosService` and report component
- retrieve data using `firstValueFrom`
- add pagination to estudiantes atendidos report
- sort estudiantes atendidos results descending
- sort prestamo report by id desc
- sort estudiantes atendidos by detail id
- coalesce sede name from either user or loan when counting loans

## Testing
- `npm run build` *(fails: could not read package.json)*
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68549b71f78483298176b6a6a12d9a3c