### PR TITLE
Update report logic

### DIFF
--- a/Backend/login-microsoft365/src/main/java/com/miapp/service/PrestamoService.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/service/PrestamoService.java
@@ -275,6 +275,8 @@ public class PrestamoService {
         List<DetallePrestamo> prestamos = detallePrestamoRepository.findAll(
                 Specification.where(conFetchEquipoYSede())
                         .and(DetallePrestamoSpecs.entreFechas(fechaInicio, fechaFin))
+                        // se ignoran los préstamos en estado "RESERVADO"
+                        .and(DetallePrestamoSpecs.excluirEstadoDescripcion("RESERVADO"))
         );
 
         Map<Equipo, List<DetallePrestamo>> agrupado = prestamos.stream()

--- a/Backend/login-microsoft365/src/main/java/com/miapp/spec/DetallePrestamoSpecs.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/spec/DetallePrestamoSpecs.java
@@ -78,6 +78,20 @@ public class DetallePrestamoSpecs {
                         : cb.equal(root.get("codigoCiclo"), codigoCiclo);
     }
 
+    /**
+     * Excluye los préstamos cuyo estado tenga la descripción indicada.
+     * Útil para ignorar registros en estado pendiente de aprobación
+     * como "RESERVADO".
+     */
+    public static Specification<DetallePrestamo> excluirEstadoDescripcion(String descripcion) {
+        return (root, cq, cb) ->
+                descripcion == null
+                        ? cb.conjunction()
+                        : cb.notEqual(
+                                cb.upper(root.get("estado").get("descripcion")),
+                                descripcion.toUpperCase());
+    }
+
     public static Specification<DetallePrestamo> entreFechas(LocalDateTime inicio, LocalDateTime fin) {
         System.out.println(">> entreFechas: " + inicio + " - " + fin);
         return (root, cq, cb) ->

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/usotiempo-biblioteca.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/usotiempo-biblioteca.ts
@@ -67,7 +67,7 @@ import { EquipoUsoTiempoDTO } from '../../interfaces/reportes/equipo-uso-tiempo'
                         <td>{{ row.nombreEquipo }}</td>
                         <td>{{ row.numeroEquipo }}</td>
                         <td>{{ row.cantidadPrestamos }}</td>
-                        <td>{{ row.horasPrestado }}</td>
+                        <td>{{ row.horasPrestado | number:'1.2-2' }}</td>
                     </tr>
                 </ng-template>
             </p-table>


### PR DESCRIPTION
## Summary
- filter out reserved loans from usage report logic so hours are counted only for approved loans
- format usage hours with two decimals in the report table

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68558af42ca883299471728517497acc