### PR TITLE
Fix date picker inputs

### DIFF
--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/estudiantes-atendidos.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/estudiantes-atendidos.ts
@@ -50,9 +50,9 @@ import { saveAs } from 'file-saver';
                     <div class="grid grid-cols-7 gap-4">
                     <div class="flex flex-col gap-2 col-span-3 md:col-span-2 lg:col-span-2">
                     <label for="tipoPrestamo" class="block text-sm font-medium">Fecha inicio</label>
-                        <p-datepicker 
+                        <p-datepicker
                             appendTo="body"
-                            formControlName="fechaInicio"
+                            [(ngModel)]="fechaInicio"
                             [ngClass]="'w-full'"
                             [style]="{ width: '100%' }"
                             [readonlyInput]="true"
@@ -61,9 +61,9 @@ import { saveAs } from 'file-saver';
                     </div>
                     <div class="flex flex-col gap-2 col-span-3 md:col-span-2 lg:col-span-2">
                     <label for="tipoPrestamo" class="block text-sm font-medium">Fecha fin</label>
-                    <p-datepicker 
+                    <p-datepicker
                             appendTo="body"
-                            formControlName="fechaFin"
+                            [(ngModel)]="fechaFin"
                             [ngClass]="'w-full'"
                             [style]="{ width: '100%' }"
                             [readonlyInput]="true"
@@ -142,6 +142,8 @@ export class ReporteEstudiantesAtendidos implements OnInit {
     tipoPrestamoFiltro: ClaseGeneral = new ClaseGeneral();
     dataEspecialidad: ClaseGeneral[] = [];
     especialidadFiltro: ClaseGeneral = new ClaseGeneral();
+    fechaInicio?: Date;
+    fechaFin?: Date;
     nroIngreso:string='';
     tipo:number=1;
     loading: boolean = true;


### PR DESCRIPTION
## Summary
- use `ngModel` instead of `formControlName` for `fechaInicio` and `fechaFin`
- add date variables to the Estudiantes Atendidos report

## Testing
- `npm test` *(fails: No inputs were found in config file)*

------
https://chatgpt.com/codex/tasks/task_e_68558e9f291c8329a33223781a76d7df