### PR TITLE
Fix usuarios atendidos report

### DIFF
--- a/Backend/login-microsoft365/src/main/java/com/miapp/controller/PrestamoController.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/controller/PrestamoController.java
@@ -169,6 +169,16 @@ public class PrestamoController {
         return ResponseEntity.ok(Map.of("status","0","data", lista));
     }
 
+    /**
+     * Reporte de usuarios atendidos de biblioteca virtual.
+     * Devuelve la cantidad de préstamos aprobados por usuario.
+     */
+    @GetMapping("/reporte/usuarios-atendidos-biblioteca")
+    public ResponseEntity<?> reporteUsuariosAtendidosBiblioteca() {
+        List<com.miapp.model.dto.UsuarioPrestamosDTO> lista = prestamoService.reporteUsuariosAtendidosBiblioteca();
+        return ResponseEntity.ok(Map.of("status","0","data", lista));
+    }
+
     /** Reporte de uso de tiempo de biblioteca virtual */
     @GetMapping("/reporte/uso-tiempo-biblioteca")
     public ResponseEntity<?> reporteUsoTiempoBiblioteca(

--- a/Backend/login-microsoft365/src/main/java/com/miapp/repository/DetallePrestamoRepository.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/repository/DetallePrestamoRepository.java
@@ -56,4 +56,24 @@ public interface DetallePrestamoRepository
             "GROUP BY dp.codigoUsuario, COALESCE(s.descripcion, s2.descripcion) " +
             "ORDER BY MAX(dp.id) DESC" )
     List<com.miapp.model.dto.UsuarioPrestamosDTO> contarPrestamosPorUsuario();
+
+    /**
+     * Devuelve la cantidad de préstamos aprobados por usuario.
+     * Se concatena el nombre completo del usuario en un solo campo y se muestra la sede del usuario.
+     */
+    @org.springframework.data.jpa.repository.Query(
+            "SELECT new com.miapp.model.dto.UsuarioPrestamosDTO(" +
+            " MAX(dp.id)," +
+            " CONCAT(COALESCE(u.nombreUsuario, ''),' '," +
+            "        COALESCE(u.apellidoPaterno, ''),' '," +
+            "        COALESCE(u.apellidoMaterno, ''))," +
+            " s.descripcion," +
+            " COUNT(dp)) " +
+            "FROM DetallePrestamo dp " +
+            "LEFT JOIN Usuario u ON upper(u.login) = upper(dp.codigoUsuario) " +
+            "LEFT JOIN Sede s ON u.idSede = s.id " +
+            "WHERE upper(dp.estado.descripcion) IN ('PRESTADO EN SALA', 'PRESTAMO A DOMICILIO', 'PRESTADO EN SALA Y DOMICILIO') " +
+            "GROUP BY u.nombreUsuario, u.apellidoPaterno, u.apellidoMaterno, s.descripcion " +
+            "ORDER BY MAX(dp.id) DESC" )
+    List<com.miapp.model.dto.UsuarioPrestamosDTO> contarPrestamosAprobadosPorUsuario();
 }

--- a/Backend/login-microsoft365/src/main/java/com/miapp/service/PrestamoService.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/service/PrestamoService.java
@@ -264,6 +264,14 @@ public class PrestamoService {
     }
 
     /**
+     * Reporte de usuarios atendidos en biblioteca virtual.
+     * Considera únicamente los préstamos aprobados.
+     */
+    public List<com.miapp.model.dto.UsuarioPrestamosDTO> reporteUsuariosAtendidosBiblioteca() {
+        return detallePrestamoRepository.contarPrestamosAprobadosPorUsuario();
+    }
+
+    /**
      * Reporte del tiempo de uso de los equipos de biblioteca virtual.
      * Agrupa los préstamos por equipo y calcula la cantidad de préstamos y las
      * horas totales prestadas en el rango indicado.

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/usuarios-atendidos-biblioteca.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/usuarios-atendidos-biblioteca.ts
@@ -4,6 +4,14 @@ import { TooltipModule } from 'primeng/tooltip';
 import { TemplateModule } from '../../template.module';
 import { Sedes } from '../../interfaces/sedes';
 import { ClaseGeneral } from '../../interfaces/clase-general';
+import { PrestamosService } from '../../services/prestamos.service';
+import { UsuarioPrestamosDTO } from '../../interfaces/reportes/usuario-prestamos';
+import { firstValueFrom } from 'rxjs';
+import { HttpClient } from '@angular/common/http';
+import { jsPDF } from 'jspdf';
+import autoTable from 'jspdf-autotable';
+import * as ExcelJS from 'exceljs';
+import { saveAs } from 'file-saver';
 
 @Component({
     selector: 'app-reporte-usuarios-atendidos-biblioteca',
@@ -42,9 +50,9 @@ import { ClaseGeneral } from '../../interfaces/clase-general';
                     <div class="grid grid-cols-7 gap-4">
                     <div class="flex flex-col gap-2 col-span-3 md:col-span-2 lg:col-span-2">
                     <label for="tipoPrestamo" class="block text-sm font-medium">Fecha inicio</label>
-                        <p-datepicker 
+                        <p-datepicker
                             appendTo="body"
-                            formControlName="fechaInicio"
+                            [(ngModel)]="fechaInicio"
                             [ngClass]="'w-full'"
                             [style]="{ width: '100%' }"
                             [readonlyInput]="true"
@@ -53,9 +61,9 @@ import { ClaseGeneral } from '../../interfaces/clase-general';
                     </div>
                     <div class="flex flex-col gap-2 col-span-3 md:col-span-2 lg:col-span-2">
                     <label for="tipoPrestamo" class="block text-sm font-medium">Fecha fin</label>
-                    <p-datepicker 
+                    <p-datepicker
                             appendTo="body"
-                            formControlName="fechaFin"
+                            [(ngModel)]="fechaFin"
                             [ngClass]="'w-full'"
                             [style]="{ width: '100%' }"
                             [readonlyInput]="true"
@@ -77,14 +85,35 @@ import { ClaseGeneral } from '../../interfaces/clase-general';
                
             </div>
        
+        <div class="formgroup-inline">
+            <button pButton icon="pi pi-file-excel" label="XLS" class="mr-2 p-button-danger" (click)="exportExcel()" tooltip="Exportar a Excel"></button>
+            <button pButton icon="pi pi-file-pdf" label="PDF" class="mr-2 p-button-danger" (click)="exportPdf()" tooltip="Exportar a PDF"></button>
+        </div>
+    </div>
     </p-toolbar>
+    <p-table [value]="resultados" [loading]="loading" [paginator]="true" [rows]="10" sortField="id" [sortOrder]="-1">
+        <ng-template pTemplate="header">
+            <tr>
+                <th>Usuario</th>
+                <th>Sede</th>
+                <th>Préstamos</th>
+            </tr>
+        </ng-template>
+        <ng-template pTemplate="body" let-row>
+            <tr>
+                <td>{{ row.usuario }}</td>
+                <td>{{ row.sede || '-' }}</td>
+                <td>{{ row.totalPrestamos }}</td>
+            </tr>
+        </ng-template>
+    </p-table>
 </div>
 `,
-            imports: [TemplateModule, TooltipModule],
-            providers: [MessageService, ConfirmationService]
+    imports: [TemplateModule, TooltipModule],
+    providers: [MessageService, ConfirmationService]
 })
 export class ReporteUsuariosAtendidosBiblioteca {
-    titulo: string = "Usuarios atendidos biblioteca virtual";
+    titulo: string = 'Usuarios atendidos biblioteca virtual';
     dataSede: Sedes[] = [];
     sedeFiltro: Sedes = new Sedes();
     dataPrograma: ClaseGeneral[] = [];
@@ -107,12 +136,79 @@ export class ReporteUsuariosAtendidosBiblioteca {
     tipoPrestamoFiltro: ClaseGeneral = new ClaseGeneral();
     dataEspecialidad: ClaseGeneral[] = [];
     especialidadFiltro: ClaseGeneral = new ClaseGeneral();
-    nroIngreso:string='';
-    tipo:number=1;
+    fechaInicio?: Date;
+    fechaFin?: Date;
+    nroIngreso: string = '';
+    tipo: number = 1;
     loading: boolean = true;
+    resultados: UsuarioPrestamosDTO[] = [];
+
+    constructor(
+        private prestamosService: PrestamosService,
+        private messageService: MessageService,
+        private http: HttpClient
+    ) {}
 
     async ngOnInit() {
         await this.reporte();
     }
-    reporte(){}
+    async reporte() {
+        this.loading = true;
+        try {
+            this.resultados = await firstValueFrom(this.prestamosService.reporteUsuariosAtendidosBiblioteca());
+        } finally {
+            this.loading = false;
+        }
+    }
+
+    async exportExcel() {
+        if (!this.resultados.length) {
+            this.messageService.add({ severity: 'warn', detail: 'No hay datos para exportar.' });
+            return;
+        }
+        const wb = new ExcelJS.Workbook();
+        const ws = wb.addWorksheet('Reporte');
+        const buffer = await this.http.get('/assets/logo.png', { responseType: 'arraybuffer' }).toPromise();
+        const logoId = wb.addImage({ buffer, extension: 'png' });
+        ws.addImage(logoId, { tl: { col: 0.2, row: 0.2 }, ext: { width: 220, height: 80 } });
+        ws.mergeCells('C1', 'F2');
+        const title = ws.getCell('C1');
+        title.value = 'Usuarios atendidos';
+        title.alignment = { vertical: 'middle', horizontal: 'center' };
+        title.font = { size: 16, bold: true };
+        ws.addRow([]);
+        const headerRow = ws.addRow(['Usuario', 'Sede', 'Préstamos']);
+        headerRow.font = { bold: true };
+        headerRow.alignment = { horizontal: 'center' };
+        this.resultados.forEach((r) => ws.addRow([r.usuario, r.sede || '-', r.totalPrestamos]));
+        ws.columns.forEach((col) => (col.width = 25));
+        const buf = await wb.xlsx.writeBuffer();
+        saveAs(new Blob([buf]), 'usuarios_atendidos.xlsx');
+    }
+
+    exportPdf() {
+        if (!this.resultados.length) {
+            this.messageService.add({ severity: 'warn', detail: 'No hay datos para exportar.' });
+            return;
+        }
+        const doc = new jsPDF({ orientation: 'landscape' });
+        const img = new Image();
+        img.src = '/assets/logo.png';
+        img.onload = () => {
+            doc.addImage(img, 'PNG', 10, 10, 60, 25);
+            doc.setFontSize(16);
+            doc.text('Usuarios atendidos', 80, 20);
+            doc.setFontSize(10);
+            const hoy = new Date();
+            doc.text(`Fecha de emisión: ${hoy.toLocaleDateString()}`, 80, 25);
+            autoTable(doc, {
+                head: [['Usuario', 'Sede', 'Préstamos']],
+                body: this.resultados.map((r) => [r.usuario, r.sede || '-', r.totalPrestamos]),
+                startY: 35,
+                styles: { fontSize: 8 },
+                headStyles: { fillColor: [41, 128, 185] }
+            });
+            doc.save('usuarios_atendidos.pdf');
+        };
+    }
 }

--- a/Frontend/sakai-ng-master/src/app/biblioteca/services/prestamos.service.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/services/prestamos.service.ts
@@ -8,6 +8,7 @@ import { DetallePrestamo } from '../interfaces/detalle-prestamo';
 import { map } from 'rxjs/operators';
 import { UsuarioPrestamosDTO } from '../interfaces/reportes/usuario-prestamos';
 import { EquipoUsoTiempoDTO } from '../interfaces/reportes/equipo-uso-tiempo';
+import { UsuarioPrestamosDTO } from '../interfaces/reportes/usuario-prestamos';
 
 @Injectable({
     providedIn: 'root'
@@ -94,6 +95,15 @@ export class PrestamosService {
     /** Obtiene el total de préstamos por usuario */
     reporteEstudiantesAtendidos(): Observable<UsuarioPrestamosDTO[]> {
         return this.http.get<{ status: string; data: UsuarioPrestamosDTO[] }>(`${this.apiUrl}/api/prestamos/reporte/estudiantes-atendidos`).pipe(map((r) => r.data ?? []));
+    }
+
+    /** Obtiene los usuarios atendidos de biblioteca virtual */
+    reporteUsuariosAtendidosBiblioteca(): Observable<UsuarioPrestamosDTO[]> {
+        return this.http
+            .get<{ status: string; data: UsuarioPrestamosDTO[] }>(
+                `${this.apiUrl}/api/prestamos/reporte/usuarios-atendidos-biblioteca`
+            )
+            .pipe(map((r) => r.data ?? []));
     }
 
     /** Obtiene el uso de tiempo de los equipos de biblioteca virtual */


### PR DESCRIPTION
## Summary
- adjust backend query to group loans by user and site only
- remove the equipment field from report DTO and Angular component
- return the user's site for the library user attendance report

## Testing
- `npm test --silent` *(fails: ng not found)*
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_685591aa40e48329b71b869270cf461e