### PR TITLE
Implement login counter based visitor report

### DIFF
--- a/Backend/login-microsoft365/src/main/java/com/miapp/controller/AuthController.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/controller/AuthController.java
@@ -123,6 +123,7 @@ public class AuthController {
         String rolDescripcion = usuario.getRoles().isEmpty()
                 ? "Sin Rol"
                 : usuario.getRoles().iterator().next().getDescripcion();
+        usuarioService.incrementarContadorLogins(usuario.getLogin());
         String jwt = jwtUtil.generateToken(usuario.getEmail(), rolDescripcion);
 
         return ResponseEntity.ok(new LoginResponse("Login exitoso", jwt));
@@ -136,6 +137,7 @@ public class AuthController {
             String rolDescripcion = usuario.getRoles().isEmpty()
                     ? "Sin Rol"
                     : usuario.getRoles().iterator().next().getDescripcion();
+            usuarioService.incrementarContadorLogins(usuario.getLogin());
             String jwt = jwtUtil.generateToken(usuario.getEmail(), rolDescripcion);
             System.out.println(jwt);
             return ResponseEntity.ok(new LoginResponse("Login exitoso", jwt));

--- a/Backend/login-microsoft365/src/main/java/com/miapp/controller/PrestamoController.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/controller/PrestamoController.java
@@ -179,6 +179,13 @@ public class PrestamoController {
         return ResponseEntity.ok(Map.of("status","0","data", lista));
     }
 
+    /** Reporte de visitantes de biblioteca virtual */
+    @GetMapping("/reporte/visitantes-biblioteca-virtual")
+    public ResponseEntity<?> reporteVisitantesBibliotecaVirtual() {
+        List<com.miapp.model.dto.VisitanteBibliotecaVirtualDTO> lista = prestamoService.reporteVisitantesBibliotecaVirtual();
+        return ResponseEntity.ok(Map.of("status","0","data", lista));
+    }
+
     /** Reporte de uso de tiempo de biblioteca virtual */
     @GetMapping("/reporte/uso-tiempo-biblioteca")
     public ResponseEntity<?> reporteUsoTiempoBiblioteca(

--- a/Backend/login-microsoft365/src/main/java/com/miapp/model/Usuario.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/model/Usuario.java
@@ -88,5 +88,10 @@ public class Usuario {
     @Column(name = "DIRECCION")
     private String direccion;
 
+    /** Contador de logeos acumulados */
+    @Column(name = "LOGIN_COUNT")
+    private Long loginCount = 0L;
+
+
 
 }

--- a/Backend/login-microsoft365/src/main/java/com/miapp/model/dto/VisitanteBibliotecaVirtualDTO.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/model/dto/VisitanteBibliotecaVirtualDTO.java
@@ -1,0 +1,18 @@
+package com.miapp.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/** DTO para reporte de visitantes de biblioteca virtual */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class VisitanteBibliotecaVirtualDTO {
+    private String sede;
+    private String tipoDocumento;
+    private String numeroDocumento;
+    private String apellidosNombres;
+    private String tipoUsuario;
+    private Long   totalVisitas;
+}

--- a/Backend/login-microsoft365/src/main/java/com/miapp/repository/OcurrenciaBibliotecaRepository.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/repository/OcurrenciaBibliotecaRepository.java
@@ -4,6 +4,7 @@ import com.miapp.model.OcurrenciaBiblioteca;
 import org.springframework.data.jpa.repository.JpaRepository;
 import com.miapp.model.dto.EjemplarPrestadoDTO;
 import com.miapp.model.dto.EjemplarNoPrestadoDTO;
+import com.miapp.model.dto.VisitanteBibliotecaVirtualDTO;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import java.util.List;
@@ -76,4 +77,5 @@ public interface OcurrenciaBibliotecaRepository
             "JOIN d.biblioteca b " +
             "WHERE coalesce(d.cantidadPrestamos,0) = 0")
     List<EjemplarNoPrestadoDTO> reporteEjemplarNoPrestado();
+
 }

--- a/Backend/login-microsoft365/src/main/java/com/miapp/repository/UsuarioRepository.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/repository/UsuarioRepository.java
@@ -1,6 +1,8 @@
 package com.miapp.repository;
 
 import com.miapp.model.Usuario;
+import com.miapp.model.dto.VisitanteBibliotecaVirtualDTO;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import java.util.List;
@@ -26,5 +28,24 @@ public interface UsuarioRepository extends JpaRepository<Usuario, Long> {
 
     /** Busca usuarios filtrando por email (ignorando mayúsculas/minúsculas) */
     List<Usuario> findByEmailContainingIgnoreCase(String email);
+
+    /** Reporte de visitantes de biblioteca virtual a partir del contador de logeos */
+    @Query(
+            "SELECT new com.miapp.model.dto.VisitanteBibliotecaVirtualDTO(" +
+            " COALESCE(s.descripcion, '-')," +
+            " td.descripcion," +
+            " str(u.numDocumento)," +
+            " CONCAT(COALESCE(u.apellidoPaterno,''),' '," +
+            "        COALESCE(u.apellidoMaterno,''),' '," +
+            "        COALESCE(u.nombreUsuario,''))," +
+            " COALESCE(r.descripcion, 'Sin Rol')," +
+            " COALESCE(u.loginCount,0) )" +
+            "FROM Usuario u " +
+            "LEFT JOIN Sede s ON u.idSede = s.id " +
+            "LEFT JOIN TipoDocumento td ON u.tipodocumento.idTipoDocumento = td.idTipoDocumento " +
+            "LEFT JOIN u.roles r " +
+            "WHERE COALESCE(u.loginCount,0) > 0 " +
+            "ORDER BY COALESCE(u.loginCount,0) DESC")
+    List<VisitanteBibliotecaVirtualDTO> reporteVisitantesBibliotecaVirtual();
 
 }

--- a/Backend/login-microsoft365/src/main/java/com/miapp/service/PrestamoService.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/service/PrestamoService.java
@@ -7,6 +7,8 @@ import com.miapp.model.TipoPrestamo;
 import com.miapp.repository.DetallePrestamoRepository;
 import com.miapp.repository.EquipoRepository;
 import com.miapp.repository.EstadoRepository;
+import com.miapp.repository.OcurrenciaBibliotecaRepository;
+import com.miapp.repository.UsuarioRepository;
 import com.miapp.spec.DetallePrestamoSpecs;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -39,6 +41,8 @@ public class PrestamoService {
     private final SedeService sedeService;
     private final EmailService emailService;
     private final TaskScheduler scheduler;
+    private final OcurrenciaBibliotecaRepository ocurrenciaBibliotecaRepository;
+    private final UsuarioRepository usuarioRepository;
 
     public DetallePrestamo solicitarPrestamo(Long equipoId,
                                              Integer tipoUsuario,
@@ -315,6 +319,14 @@ public class PrestamoService {
         }
 
         return lista;
+    }
+
+    /**
+     * Reporte de visitantes de biblioteca virtual.
+     * Devuelve la cantidad de ocurrencias registradas por usuario.
+     */
+    public List<com.miapp.model.dto.VisitanteBibliotecaVirtualDTO> reporteVisitantesBibliotecaVirtual() {
+        return usuarioRepository.reporteVisitantesBibliotecaVirtual();
     }
 
 }

--- a/Backend/login-microsoft365/src/main/java/com/miapp/service/UsuarioService.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/service/UsuarioService.java
@@ -270,4 +270,13 @@ public class UsuarioService {
         }
         return usuarioRepository.findByLoginContainingIgnoreCaseOrEmailContainingIgnoreCase(q, q);
     }
+
+    /** Incrementa el contador de logeos del usuario. */
+    public void incrementarContadorLogins(String login) {
+        usuarioRepository.findByLoginIgnoreCase(login).ifPresent(u -> {
+            long count = u.getLoginCount() == null ? 0L : u.getLoginCount();
+            u.setLoginCount(count + 1);
+            usuarioRepository.save(u);
+        });
+    }
 }

--- a/Frontend/sakai-ng-master/src/app/biblioteca/interfaces/reportes/visitante-biblioteca-virtual.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/interfaces/reportes/visitante-biblioteca-virtual.ts
@@ -1,0 +1,8 @@
+export interface VisitanteBibliotecaVirtualDTO {
+    sede: string;
+    tipoDocumento: string;
+    numeroDocumento: string;
+    apellidosNombres: string;
+    tipoUsuario: string;
+    totalVisitas: number;
+}

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/visitantes-biblioteca-virtual.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/visitantes-biblioteca-virtual.ts
@@ -1,9 +1,12 @@
 import { Component } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
 import { MessageService, ConfirmationService } from 'primeng/api';
 import { TooltipModule } from 'primeng/tooltip';
 import { TemplateModule } from '../../template.module';
 import { Sedes } from '../../interfaces/sedes';
 import { ClaseGeneral } from '../../interfaces/clase-general';
+import { PrestamosService } from '../../services/prestamos.service';
+import { VisitanteBibliotecaVirtualDTO } from '../../interfaces/reportes/visitante-biblioteca-virtual';
 
 @Component({
     selector: 'app-reporte-visitantes-biblioteca',
@@ -78,6 +81,28 @@ import { ClaseGeneral } from '../../interfaces/clase-general';
             </div>
        
     </p-toolbar>
+    <p-table [value]="resultados" [paginator]="true" [rows]="10" [loading]="loading">
+        <ng-template pTemplate="header">
+            <tr>
+                <th>Sede</th>
+                <th>Tipo documento</th>
+                <th>N° documento</th>
+                <th>Apellidos y nombres</th>
+                <th>Tipo usuario</th>
+                <th>Visitas</th>
+            </tr>
+        </ng-template>
+        <ng-template pTemplate="body" let-row>
+            <tr>
+                <td>{{ row.sede }}</td>
+                <td>{{ row.tipoDocumento }}</td>
+                <td>{{ row.numeroDocumento }}</td>
+                <td>{{ row.apellidosNombres }}</td>
+                <td>{{ row.tipoUsuario }}</td>
+                <td>{{ row.totalVisitas }}</td>
+            </tr>
+        </ng-template>
+    </p-table>
 </div>
 `,
             imports: [TemplateModule, TooltipModule],
@@ -104,9 +129,23 @@ export class ReporteVisitantesBibliotecaVirtual {
     dataTipoPrestamo: ClaseGeneral[] = [];
     tipoPrestamoFiltro: ClaseGeneral = new ClaseGeneral();
     loading: boolean = true;
+    resultados: VisitanteBibliotecaVirtualDTO[] = [];
+
+    constructor(private svc: PrestamosService, private messageService: MessageService) {}
 
     async ngOnInit() {
         await this.reporte();
     }
-    reporte(){}
+    async reporte() {
+        this.loading = true;
+        try {
+            this.resultados =
+                (await firstValueFrom(this.svc.reporteVisitantesBibliotecaVirtual())) ?? [];
+        } catch (error: any) {
+            const msg = error?.status === 403 ? 'No autorizado para ver el reporte.' : 'No fue posible cargar los datos.';
+            this.messageService.add({ severity: 'error', detail: msg });
+        } finally {
+            this.loading = false;
+        }
+    }
 }

--- a/Frontend/sakai-ng-master/src/app/biblioteca/services/prestamos.service.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/services/prestamos.service.ts
@@ -9,6 +9,7 @@ import { map } from 'rxjs/operators';
 import { UsuarioPrestamosDTO } from '../interfaces/reportes/usuario-prestamos';
 import { EquipoUsoTiempoDTO } from '../interfaces/reportes/equipo-uso-tiempo';
 import { UsuarioPrestamosDTO } from '../interfaces/reportes/usuario-prestamos';
+import { VisitanteBibliotecaVirtualDTO } from '../interfaces/reportes/visitante-biblioteca-virtual';
 
 @Injectable({
     providedIn: 'root'
@@ -117,6 +118,15 @@ export class PrestamosService {
                 headers: new HttpHeaders().set('Authorization', `Bearer ${this.authService.getToken()}`),
                 params
             })
+            .pipe(map((resp) => resp.data ?? []));
+    }
+
+    /** Obtiene los visitantes de biblioteca virtual */
+    reporteVisitantesBibliotecaVirtual(): Observable<VisitanteBibliotecaVirtualDTO[]> {
+        return this.http
+            .get<{ status: string; data: VisitanteBibliotecaVirtualDTO[] }>(
+                `${this.apiUrl}/api/prestamos/reporte/visitantes-biblioteca-virtual`
+            )
             .pipe(map((resp) => resp.data ?? []));
     }
 }


### PR DESCRIPTION
## Summary
- track login count in `Usuario` entity
- log each successful login in `AuthController`
- query visitor statistics via `UsuarioRepository`
- expose visitor report through `PrestamoService`
- remove old query from `OcurrenciaBibliotecaRepository`
- **update** visitor report to fetch role from user roles and removed `tipoUsuario` field

## Testing
- `npm test` *(fails: ng not found)*
- `mvn test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_685674f1c6088329a5574c0bc8b45463