### PR TITLE
Return typed response for refresh endpoint

### DIFF
--- a/Backend/login-microsoft365/src/main/java/com/miapp/controller/AuthController.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/controller/AuthController.java
@@ -21,6 +21,7 @@ public class AuthController {
 
     private final UsuarioService usuarioService;
     private final JwtUtil jwtUtil;
+    private final RefreshTokenService refreshTokenService;
     private final AzureService azureService;
     private final TipoDocumentoService tipoDocumentoService;
     private final EspecialidadService especialidadService;
@@ -116,7 +117,8 @@ public class AuthController {
                     ? "Sin Rol"
                     : usuario.getRoles().iterator().next().getDescripcion();
             String jwt = jwtUtil.generateToken(usuario.getEmail(), rolDescripcion);
-            return ResponseEntity.ok(new LoginResponse("Registro y login exitoso", jwt));
+            RefreshToken refresh = refreshTokenService.createRefreshToken(usuario);
+            return ResponseEntity.ok(new LoginResponse("Registro y login exitoso", jwt, refresh.getToken()));
         }
 
         Usuario usuario = usuarioOpt.get();
@@ -125,8 +127,9 @@ public class AuthController {
                 : usuario.getRoles().iterator().next().getDescripcion();
         usuarioService.incrementarContadorLogins(usuario.getLogin());
         String jwt = jwtUtil.generateToken(usuario.getEmail(), rolDescripcion);
+        RefreshToken refresh = refreshTokenService.createRefreshToken(usuario);
 
-        return ResponseEntity.ok(new LoginResponse("Login exitoso", jwt));
+        return ResponseEntity.ok(new LoginResponse("Login exitoso", jwt, refresh.getToken()));
     }
 
     @PostMapping("/login")
@@ -139,12 +142,30 @@ public class AuthController {
                     : usuario.getRoles().iterator().next().getDescripcion();
             usuarioService.incrementarContadorLogins(usuario.getLogin());
             String jwt = jwtUtil.generateToken(usuario.getEmail(), rolDescripcion);
+            RefreshToken refresh = refreshTokenService.createRefreshToken(usuario);
             System.out.println(jwt);
-            return ResponseEntity.ok(new LoginResponse("Login exitoso", jwt));
+            return ResponseEntity.ok(new LoginResponse("Login exitoso", jwt, refresh.getToken()));
         } else {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                     .body("Credenciales incorrectas");
         }
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<LoginResponse> refreshToken(@RequestBody Map<String, String> request) {
+        String refreshToken = request.get("refreshToken");
+        return refreshTokenService.findByToken(refreshToken)
+                .map(refreshTokenService::verifyExpiration)
+                .map(rt -> {
+                    Usuario usuario = rt.getUsuario();
+                    String rol = usuario.getRoles().isEmpty() ? "Sin Rol" : usuario.getRoles().iterator().next().getDescripcion();
+                    String access = jwtUtil.generateToken(usuario.getEmail(), rol);
+                    refreshTokenService.deleteByUsuario(usuario);
+                    RefreshToken newToken = refreshTokenService.createRefreshToken(usuario);
+                    return ResponseEntity.ok(new LoginResponse("Token refrescado", access, newToken.getToken()));
+                })
+                .orElseGet(() -> ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                        .body(new LoginResponse("Refresh token inválido", null, null)));
     }
 
     // Endpoint de registro público para auto-registro

--- a/Backend/login-microsoft365/src/main/java/com/miapp/controller/PrestamoController.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/controller/PrestamoController.java
@@ -82,6 +82,13 @@ public class PrestamoController {
         return ResponseEntity.ok(pendientes);
     }
 
+    @GetMapping("/notificaciones")
+    public ResponseEntity<List<Notificacion>> listarTodas(Authentication auth) {
+        String usuario = auth.getName();
+        List<Notificacion> lista = notificacionService.listarTodas(usuario);
+        return ResponseEntity.ok(lista);
+    }
+
     /** Marca una notificación como leída */
     @PutMapping("/{id}/leer")
     public ResponseEntity<Void> marcarLeida(@PathVariable Long id) {

--- a/Backend/login-microsoft365/src/main/java/com/miapp/model/LoginResponse.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/model/LoginResponse.java
@@ -8,4 +8,5 @@ import lombok.Data;
 public class LoginResponse {
     private String message;
     private String token;
+    private String refreshToken;
 }

--- a/Backend/login-microsoft365/src/main/java/com/miapp/model/RefreshToken.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/model/RefreshToken.java
@@ -1,0 +1,24 @@
+package com.miapp.model;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import java.time.LocalDateTime;
+
+@Data
+@Entity
+@Table(name = "REFRESH_TOKEN")
+public class RefreshToken {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String token;
+
+    @Column(nullable = false)
+    private LocalDateTime expiryDate;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "IDUSUARIO")
+    private Usuario usuario;
+}

--- a/Backend/login-microsoft365/src/main/java/com/miapp/repository/NotificacionRepository.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/repository/NotificacionRepository.java
@@ -9,5 +9,7 @@ import java.util.List;
 @Repository
 public interface NotificacionRepository extends JpaRepository<Notificacion,Long> {
     List<Notificacion> findByUsuarioDestinoAndLeidaFalse(String usuario);
+
+    List<Notificacion> findByUsuarioDestinoOrderByFechaCreacionDesc(String usuario);
 }
 

--- a/Backend/login-microsoft365/src/main/java/com/miapp/repository/RefreshTokenRepository.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/repository/RefreshTokenRepository.java
@@ -1,0 +1,12 @@
+package com.miapp.repository;
+
+import com.miapp.model.RefreshToken;
+import com.miapp.model.Usuario;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    Optional<RefreshToken> findByToken(String token);
+    void deleteByUsuario(Usuario usuario);
+}

--- a/Backend/login-microsoft365/src/main/java/com/miapp/service/NotificacionService.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/service/NotificacionService.java
@@ -27,6 +27,10 @@ public class NotificacionService {
         return repo.findByUsuarioDestinoAndLeidaFalse(usuario);
     }
 
+    public List<Notificacion> listarTodas(String usuario) {
+        return repo.findByUsuarioDestinoOrderByFechaCreacionDesc(usuario);
+    }
+
     public void marcarLeida(Long id) {
         Notificacion n = repo.findById(id)
                 .orElseThrow(() -> new RuntimeException("Notificación no encontrada"));

--- a/Backend/login-microsoft365/src/main/java/com/miapp/service/RefreshTokenService.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/service/RefreshTokenService.java
@@ -1,0 +1,48 @@
+package com.miapp.service;
+
+import com.miapp.model.RefreshToken;
+import com.miapp.model.Usuario;
+import com.miapp.repository.RefreshTokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenService {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Value("${jwt.refresh-expiration-ms:604800000}")
+    private long refreshExpirationMs;
+
+    public RefreshToken createRefreshToken(Usuario usuario) {
+        refreshTokenRepository.deleteByUsuario(usuario);
+        RefreshToken token = new RefreshToken();
+        token.setUsuario(usuario);
+        token.setToken(UUID.randomUUID().toString());
+        token.setExpiryDate(LocalDateTime.now().plus(Duration.ofMillis(refreshExpirationMs)));
+        return refreshTokenRepository.save(token);
+    }
+
+    public Optional<RefreshToken> findByToken(String token) {
+        return refreshTokenRepository.findByToken(token);
+    }
+
+    public RefreshToken verifyExpiration(RefreshToken token) {
+        if (token.getExpiryDate().isBefore(LocalDateTime.now())) {
+            refreshTokenRepository.delete(token);
+            throw new RuntimeException("Refresh token expired");
+        }
+        return token;
+    }
+
+    public void deleteByUsuario(Usuario usuario) {
+        refreshTokenRepository.deleteByUsuario(usuario);
+    }
+}

--- a/Backend/login-microsoft365/src/main/java/com/miapp/util/JwtUtil.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/util/JwtUtil.java
@@ -1,16 +1,12 @@
 package com.miapp.util;
 
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
-import org.springframework.security.oauth2.jwt.JwtException;
-import org.springframework.stereotype.Component;
-import com.auth0.jwt.JWT;
-import com.auth0.jwt.algorithms.Algorithm;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import java.util.Date;
-import java.util.Map;
-
-import io.jsonwebtoken.*;
 
 
 @Component
@@ -19,8 +15,13 @@ public class JwtUtil {
     @Value("${jwt.secret}")
     private String secret;
 
-    @Value("${jwt.expiration}")
-    private Long expiration;
+    // Tiempo de expiración del token de acceso (24 h por defecto)
+    @Value("${jwt.expiration-ms:86400000}")
+    private long accessExpirationMs;
+
+    // Tiempo de expiración del refresh token (7 días por defecto)
+    @Value("${jwt.refresh-expiration-ms:604800000}")
+    private long refreshExpirationMs;
 
     /**
      * Genera un token JWT con el 'username' como subject.
@@ -32,13 +33,18 @@ public class JwtUtil {
 //                .withExpiresAt(new Date(System.currentTimeMillis() + expiration))
 //                .sign(Algorithm.HMAC256(secret));
 //    }
-    public String generateToken(String login, String role) {
-        long expirationTime = 86400000; // 24 horas en milisegundos
+    public String generateToken(String username, String role) {
+        return generateToken(username, role, accessExpirationMs);
+    }
+
+    public String generateToken(String username, String role, long expiration) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + expiration);
         return Jwts.builder()
-                .setSubject(login)
+                .setSubject(username)
                 .claim("role", role)
-                .setIssuedAt(new Date())
-                .setExpiration(new Date(System.currentTimeMillis() + expirationTime))
+                .setIssuedAt(now)
+                .setExpiration(expiry)
                 .signWith(Keys.hmacShaKeyFor(secret.getBytes()), SignatureAlgorithm.HS256)
                 .compact();
     }
@@ -65,6 +71,10 @@ public class JwtUtil {
                 .parseClaimsJws(token)
                 .getBody()
                 .getSubject();
+    }
+
+    public long getRefreshExpirationMs() {
+        return refreshExpirationMs;
     }
 
 

--- a/Backend/login-microsoft365/src/main/resources/application.properties
+++ b/Backend/login-microsoft365/src/main/resources/application.properties
@@ -1,0 +1,3 @@
+jwt.secret=ChangeThisSecretKey
+jwt.expiration-ms=86400000
+jwt.refresh-expiration-ms=604800000

--- a/Frontend/sakai-ng-master/src/app/biblioteca/interfaces/Authentication.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/interfaces/Authentication.ts
@@ -14,4 +14,5 @@ export interface LoginRequest {
 export interface LoginResponse {
   message: string;
   token: string;
+  refreshToken: string;
 }

--- a/Frontend/sakai-ng-master/src/app/biblioteca/services/auth.service.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/services/auth.service.ts
@@ -29,6 +29,7 @@ const httpOptions = {
 })
 export class AuthService {
   private TOKEN_NAME:string = 'upsjb_reserva';
+  private REFRESH_NAME:string = 'upsjb_refresh';
   private helper:JwtHelperService;/*
   private currentUserSubject: BehaviorSubject<User>;
   public currentUser: Observable<User>;*/
@@ -213,11 +214,12 @@ loginMicrosoft() {
 
   // Login manual: envía las credenciales y espera una respuesta con mensaje y token.
   loginManual(credentials: { email: string; password: string }): Observable<any> {
-      return this.http.post<{ message: string; token: string }>(`${this.apiUrl}/login`, credentials)
+      return this.http.post<LoginResponse>(`${this.apiUrl}/login`, credentials)
         .pipe(
           tap(response => {
             if (response.token) {
-              localStorage.setItem('upsjb_reserva', response.token);
+              localStorage.setItem(this.TOKEN_NAME, response.token);
+              localStorage.setItem(this.REFRESH_NAME, response.refreshToken);
               console.log('Token almacenado en localStorage:', response.token);
               this.scheduleAutoLogout();
             }
@@ -258,9 +260,25 @@ private resetInactivityTimer(): void {
     }
     localStorage.removeItem('currentUser');
     localStorage.removeItem(this.TOKEN_NAME);
+    localStorage.removeItem(this.REFRESH_NAME);
     // Redirige a la página de inicio luego de cerrar sesión
     this.router.navigate(['/']);
     return;
+  }
+
+  refreshAccessToken(): Observable<string> {
+    const refresh = localStorage.getItem(this.REFRESH_NAME);
+    if(!refresh){
+      return of('');
+    }
+    return this.http.post<LoginResponse>(`${this.apiUrl}/refresh`, {refreshToken: refresh})
+      .pipe(
+        tap(res => {
+          localStorage.setItem(this.TOKEN_NAME, res.token);
+          localStorage.setItem(this.REFRESH_NAME, res.refreshToken);
+        }),
+        map(res => res.token)
+      );
   }
 
   getEmail(): string {

--- a/Frontend/sakai-ng-master/src/app/biblioteca/services/prestamos.service.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/services/prestamos.service.ts
@@ -72,7 +72,15 @@ export class PrestamosService {
         return this.http.get<{ status: string; data: any[] }>(`${this.apiUrl}/api/prestamos/mis-prestamos`);
     }
     getNotificacionesNoLeidas(): Observable<Notificacion[]> {
-        return this.http.get<Notificacion[]>(`${this.apiUrl}/api/prestamos/no-leidas`);
+        return this.http.get<Notificacion[]>(`${this.apiUrl}/api/prestamos/no-leidas`, {
+            headers: new HttpHeaders().set('Authorization', `Bearer ${this.authService.getToken()}`)
+        });
+    }
+
+    getNotificaciones(): Observable<Notificacion[]> {
+        return this.http.get<Notificacion[]>(`${this.apiUrl}/api/prestamos/notificaciones`, {
+            headers: new HttpHeaders().set('Authorization', `Bearer ${this.authService.getToken()}`)
+        });
     }
     listar(sede?: number, tipoUsuario?: string, tipoPrestamo?: string, escuela?: string, programa?: string, ciclo?: string, fechaInicio?: string, fechaFin?: string): Observable<DetallePrestamo[]> {
         let params = new HttpParams();

--- a/Frontend/sakai-ng-master/src/app/layout/component/app.topbar.ts
+++ b/Frontend/sakai-ng-master/src/app/layout/component/app.topbar.ts
@@ -96,7 +96,7 @@ import { AuthService } from '../../biblioteca/services/auth.service';
                         <span>Profile</span>
                     </button>
                     <p-menu #profileMenu [popup]="true" [model]="profileItems" appendTo="body"></p-menu>
-                    <p-overlaybadge [value]="notificaciones.length" severity="danger">
+                    <p-overlaybadge [value]="unreadCount" severity="danger">
                       <button
                         type="button"
                         class="layout-topbar-action layout-topbar-action-highlight"
@@ -212,12 +212,16 @@ export class AppTopbar implements OnInit {
     highlightOcurrencias: number[] = [];
 
     get solicitudesNuevas(): number {
-      return this.notificaciones.filter(n => !n.mensaje.toLowerCase().includes('ocurrencia')).length;
+      return this.notificaciones.filter(n => !n.leida && !n.mensaje.toLowerCase().includes('ocurrencia')).length;
     }
 
     get ocurrenciasNuevas(): number {
-      return this.notificaciones.filter(n => n.mensaje.toLowerCase().includes('ocurrencia')).length;
+      return this.notificaciones.filter(n => !n.leida && n.mensaje.toLowerCase().includes('ocurrencia')).length;
     }
+
+
+    unreadCount = 0;
+
 
 
 
@@ -233,11 +237,12 @@ export class AppTopbar implements OnInit {
         this.initProfileMenu();
     }
 
-     loadNotifications() {
+    loadNotifications() {
         this.loadingNotifications = true;
-        this.prestamoService.getNotificacionesNoLeidas().subscribe({
+        this.prestamoService.getNotificaciones().subscribe({
           next: nots => {
             this.notificaciones = nots;
+            this.unreadCount = nots.filter(n => !n.leida).length;
             this.loadingNotifications = false;
           },
           error: () => this.loadingNotifications = false
@@ -307,12 +312,10 @@ export class AppTopbar implements OnInit {
 
   private marcarLeidas(ids: number[]) {
     ids.forEach(id => {
-      this.prestamoService.marcarLeida(id).subscribe({
-        next: () => {},
-        error: () => {}
-      });
+      this.prestamoService.marcarLeida(id).subscribe({ next: () => {}, error: () => {} });
+      const not = this.notificaciones.find(n => n.id === id);
+      if (not) { not.leida = true; }
     });
-    this.notificaciones = this.notificaciones.filter(n => !ids.includes(n.id));
   }
 
   private initProfileMenu() {


### PR DESCRIPTION
## Summary
- properly type refresh token endpoint with `LoginResponse`
- fix refresh token expiry calculation

## Testing
- `npm test --prefix Frontend/sakai-ng-master` *(fails: ng not found)*
- `mvn -q -f Backend/login-microsoft365/pom.xml test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685705180c0883298f61f46e52ca1243