### PR TITLE
Fix bulk delete id handling

### DIFF
--- a/Backend/login-microsoft365/src/main/java/com/miapp/controller/EquipoController.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/controller/EquipoController.java
@@ -62,6 +62,12 @@ public class EquipoController {
         }
     }
 
+    @PostMapping("/delete-bulk")
+    public ResponseEntity<?> eliminarEquipos(@RequestBody List<Long> ids) {
+        equipoService.eliminarEquipos(ids);
+        return ResponseEntity.ok(Map.of("status", 0, "message", "Registros eliminados correctamente"));
+    }
+
     @GetMapping("/list")
     public ResponseEntity<?> listarEquipos() {
         List<Equipo> lista = equipoService.listarEquipos();

--- a/Backend/login-microsoft365/src/main/java/com/miapp/service/EquipoService.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/service/EquipoService.java
@@ -104,4 +104,10 @@ public class EquipoService {
         }
         return equipoRepository.search(q);
     }
+
+    public void eliminarEquipos(List<Long> ids) {
+        List<Equipo> registros = equipoRepository.findAllById(ids);
+        equipoRepository.deleteAllInBatch(registros);
+        equipoRepository.flush();
+    }
 }

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/mantenimientos/biblioteca-virtual/biblioteca-vritual.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/mantenimientos/biblioteca-virtual/biblioteca-vritual.ts
@@ -81,23 +81,28 @@ import { Estado } from '../../../interfaces/biblioteca-virtual/estado';
 
 
 
-                        <p-table #dt1 [value]="data" dataKey="id" selectionMode="single" [(selection)]="selectedEquipo" [rows]="10"
+                        <p-table #dt1 [value]="data" dataKey="idEquipo" selectionMode="multiple" [(selection)]="selectedRows" [rows]="10"
                         [showCurrentPageReport]="true"
                         currentPageReportTemplate="Mostrando {first} a {last} de {totalRecords} registros"
                         [rowsPerPageOptions]="[10, 25, 50]" [loading]="loading" [rowHover]="true" styleClass="p-datatable-gridlines" [paginator]="true"
-                        [globalFilterFields]="['id','sede.descripcion','nombreEquipo','numeroEquipo','ip','estado.descripcion']" responsiveLayout="scroll">
+                        [globalFilterFields]="['idEquipo','sede.descripcion','nombreEquipo','numeroEquipo','ip','estado.descripcion']" responsiveLayout="scroll">
                         <ng-template pTemplate="caption">
 
                        <div class="flex items-center justify-between">
                <p-button [outlined]="true" icon="pi pi-filter-slash" label="Limpiar" (click)="clear(dt1)" />
 
-               <p-iconfield>
-                   <input pInputText type="text" placeholder="Filtrar" #filter (input)="onGlobalFilter(dt1, $event)"/>
-               </p-iconfield>
+               <div class="flex items-center gap-2">
+                   <p-iconfield>
+                       <input pInputText type="text" placeholder="Filtrar" #filter (input)="onGlobalFilter(dt1, $event)"/>
+                   </p-iconfield>
+                   <button pButton type="button" class="p-button-danger" label="Eliminar seleccionados" icon="pi pi-trash"
+                           (click)="deleteSelected()" [disabled]="!selectedRows.length"></button>
+               </div>
            </div>
                        </ng-template>
                             <ng-template pTemplate="header">
                                 <tr>
+                                <th style="width:3rem"><p-tableHeaderCheckbox></p-tableHeaderCheckbox></th>
                                 <th pSortableColumn="sede.descripcion" style="width: 8rem">Sede<p-sortIcon field="sede.descripcion"></p-sortIcon></th>
                                     <th pSortableColumn="nombreEquipo"  style="min-width:200px">Nombre de equipo<p-sortIcon field="nombreEquipo"></p-sortIcon></th>
                                     <th pSortableColumn="numeroEquipo"  style="min-width:200px">N&uacute;mero equipo<p-sortIcon field="numeroEquipo"></p-sortIcon></th>
@@ -108,7 +113,8 @@ import { Estado } from '../../../interfaces/biblioteca-virtual/estado';
                                 </tr>
                             </ng-template>
                             <ng-template pTemplate="body" let-objeto>
-                                <tr>
+                                <tr [pSelectableRow]="objeto">
+                                    <td><p-tableCheckbox [value]="objeto"></p-tableCheckbox></td>
                                     <td>
                                        {{ objeto.sede?.descripcion || '—' }}
 
@@ -127,7 +133,6 @@ import { Estado } from '../../../interfaces/biblioteca-virtual/estado';
                                         {{ objeto.estado.descripcion }}
                                         </td>
                                     <td class="text-center">
-                                    <td class="text-center">
                                         <div style="position: relative;">
                                             <button pButton type="button" icon="pi pi-ellipsis-v"
                                                 class="p-button-rounded p-button-text p-button-plain"
@@ -140,12 +145,12 @@ import { Estado } from '../../../interfaces/biblioteca-virtual/estado';
                             </ng-template>
                             <ng-template pTemplate="emptymessage">
                                 <tr>
-                                    <td colspan="8">No se encontraron registros.</td>
+                                    <td colspan="9">No se encontraron registros.</td>
                                 </tr>
                             </ng-template>
                             <ng-template pTemplate="loadingbody">
                                 <tr>
-                                    <td colspan="8">Cargando datos. Espere por favor.</td>
+                                    <td colspan="9">Cargando datos. Espere por favor.</td>
                                 </tr>
                             </ng-template>
                         </p-table>
@@ -216,7 +221,7 @@ export class BibliotecaVirtual implements OnInit {
 
       @ViewChild('modalEquipo') modalEquipo!: FormEquipo;
       @ViewChild('dt1') dt!: Table;
-      selectedEquipo!: Equipo;
+      selectedRows: Equipo[] = [];
       displayChangeState: boolean = false;
       discapacidadFiltro: boolean = false;
 
@@ -452,6 +457,37 @@ private mapToEquipo(obj: any): Equipo {
               this.messageService.add({ severity: 'error', summary: 'Error', detail: 'Ocurrio un error. Intentelo más tarde' });
               this.loading = false;
             });
+      }
+    });
+  }
+
+  deleteSelected() {
+    if (!this.selectedRows.length) {
+      return;
+    }
+    this.confirmationService.confirm({
+      message: '¿Estás seguro(a) de eliminar los seleccionados?',
+      header: 'Confirmar',
+      icon: 'pi pi-exclamation-triangle',
+      acceptLabel: 'SI',
+      rejectLabel: 'NO',
+      accept: () => {
+        const ids = this.selectedRows
+          .map(item => item.id ?? item.idEquipo)
+          .filter((id): id is number => id !== undefined);
+        this.loading = true;
+        this.bibliotecaVirtualService.eliminarEquipos(ids).subscribe({
+          next: () => {
+            this.messageService.add({ severity: 'success', summary: 'Satisfactorio', detail: 'Registros eliminados.' });
+            this.selectedRows = [];
+            this.filtrarPorSede();
+            this.loading = false;
+          },
+          error: () => {
+            this.messageService.add({ severity: 'error', summary: 'Error', detail: 'No se pudo realizar el proceso.' });
+            this.loading = false;
+          }
+        });
       }
     });
   }

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/mantenimientos/material-bibliografico/material-bibliografico.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/mantenimientos/material-bibliografico/material-bibliografico.ts
@@ -76,10 +76,6 @@ interface Column {
         (click)="limpiar()"pTooltip="Limpiar" tooltipPosition="bottom">
     </button>
         </div>
-        <div class="flex items-end">
-        <button pButton type="button" class="p-button-rounded p-button-danger" icon="pi pi-trash"
-                (click)="deleteSelected()" [disabled]="!selectedRows.length" pTooltip="Eliminar seleccionados" tooltipPosition="bottom"></button>
-        </div>
 
                     </div>
             </ng-template>
@@ -103,9 +99,13 @@ interface Column {
                        <div class="flex items-center justify-between">
                <p-button [outlined]="true" icon="pi pi-filter-slash" label="Limpiar" (click)="clear(dt1)" />
 
-               <p-iconfield>
-                   <input pInputText type="text" placeholder="Filtrar" #filter (input)="onGlobalFilter(dt1, $event)"/>
-               </p-iconfield>
+               <div class="flex items-center gap-2">
+                   <p-iconfield>
+                       <input pInputText type="text" placeholder="Filtrar" #filter (input)="onGlobalFilter(dt1, $event)"/>
+                   </p-iconfield>
+                   <button pButton type="button" class="p-button-danger" label="Eliminar seleccionados" icon="pi pi-trash"
+                           (click)="deleteSelected()" [disabled]="!selectedRows.length"></button>
+               </div>
            </div>
                        </ng-template>
                             <ng-template pTemplate="header">

--- a/Frontend/sakai-ng-master/src/app/biblioteca/services/biblioteca-virtual.service.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/services/biblioteca-virtual.service.ts
@@ -35,9 +35,13 @@ export class BibliotecaVirtualService {
       return this.http.put<any>(`${this.apisUrl}/update/${id}`, equipo);
     }
 
-    eliminarEquipo(id: number): Observable<any> {
-      return this.http.delete<any>(`${this.apisUrl}/delete/${id}`);
-    }
+  eliminarEquipo(id: number): Observable<any> {
+    return this.http.delete<any>(`${this.apisUrl}/delete/${id}`);
+  }
+
+  eliminarEquipos(ids: number[]): Observable<any> {
+    return this.http.post<any>(`${this.apisUrl}/delete-bulk`, ids);
+  }
 
     listarEquipos(): Observable<any> {
       return this.http.get<any>(`${this.apisUrl}/listWithoutEnProceso`);


### PR DESCRIPTION
## Summary
- ensure undefined IDs are filtered when sending bulk delete request
- use `idEquipo` as the unique key for table selection
- move bulk delete buttons beside the filter fields so they show a label

## Testing
- `mvn -q test` *(fails: command not found)*
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68599d8f985c83299ce469bcca22953a