### PR TITLE
Fix refresh token deletion transaction error

### DIFF
--- a/Backend/login-microsoft365/src/main/java/com/miapp/service/RefreshTokenService.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/service/RefreshTokenService.java
@@ -6,6 +6,7 @@ import com.miapp.repository.RefreshTokenRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
@@ -14,6 +15,7 @@ import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class RefreshTokenService {
 
     private final RefreshTokenRepository refreshTokenRepository;


### PR DESCRIPTION
## Summary
- mark `RefreshTokenService` as `@Transactional`

## Testing
- `mvn -q -DskipTests package` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685a0a76ed588329a97d382abe8a5b40