### PR TITLE
Bloquear edicion de ocurrencias aprobadas

### DIFF
--- a/Frontend/sakai-ng-master/src/app/biblioteca/interfaces/ocurrenciaDTO.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/interfaces/ocurrenciaDTO.ts
@@ -32,6 +32,8 @@ export interface OcurrenciaDTO {
   tipoMaterial?: string;
   /** Estado del costo */
   estadoCosto?: number;
+  /** Indica si la ocurrencia está regularizada */
+  regulariza?: number;
   /** Indica si la ocurrencia pertenece a la biblioteca */
   esBiblioteca?: boolean;
   }

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/biblioteca/ocurrencias-biblioteca.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/biblioteca/ocurrencias-biblioteca.ts
@@ -97,7 +97,7 @@ import { OcurrenciaEventService } from '../../services/ocurrencia-event.service'
                                 <tr [ngClass]="{ 'highlight-row': objeto.highlight }">
                                     <td>
                                     <div class="flex flex-wrap justify-center gap-2">
-                                <p-button outlined icon="pi pi-pencil" pTooltip="Actualizar" tooltipPosition="bottom" (click)="editar(objeto)"/>
+                                <p-button outlined icon="pi pi-pencil" pTooltip="Actualizar" tooltipPosition="bottom" (click)="editar(objeto)" [disabled]="objeto.regulariza === 1"/>
                                                            </div>
                                     </td>
                                 <td>{{objeto.id}}</td>
@@ -108,7 +108,7 @@ import { OcurrenciaEventService } from '../../services/ocurrencia-event.service'
                                     <td>
                                         <div class="flex flex-wrap justify-center gap-2">
                                             <p-button outlined icon="pi pi-align-justify" pTooltip="Ver detalle" tooltipPosition="bottom" (click)="verDetalle(objeto)"/>
-                                            <p-button outlined icon="pi pi-dollar" pTooltip="Registrar costo" tooltipPosition="bottom" (click)="costear(objeto)"/>
+                                            <p-button outlined icon="pi pi-dollar" pTooltip="Registrar costo" tooltipPosition="bottom" (click)="costear(objeto)" [disabled]="objeto.regulariza === 1"/>
                                         </div>
                                     </td>
                                 </tr>
@@ -209,12 +209,18 @@ export class OcurrenciasBiblioteca implements OnInit {
         this.modalDetalleOcurrencia.openModal(obj.id!, false);
       }
         editar(obj: OcurrenciaDTO) {
+          if (obj.regulariza === 1) {
+            return;
+          }
           this.modalNuevoOcurrencia.openForEdit(obj);
         }
       nuevoRegistro(){
 //         this.modalNuevoOcurrencia.openModal();
       }
       costear(obj: OcurrenciaDTO) {
+        if (obj.regulariza === 1) {
+          return;
+        }
         // abrimos el modal en modo “costear”
         this.modalDetalleOcurrencia.openModal(obj.id!, true);
       }

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/laboratorio-computo/ocurrencias.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/laboratorio-computo/ocurrencias.ts
@@ -98,7 +98,7 @@ import { OcurrenciaEventService } from '../../services/ocurrencia-event.service'
                                 <tr [ngClass]="{ 'highlight-row': objeto.highlight }">
                                     <td>
                                     <div class="flex flex-wrap justify-center gap-2">
-                                <p-button outlined icon="pi pi-pencil" pTooltip="Actualizar" tooltipPosition="bottom" (click)="editar(objeto)"/>
+                                <p-button outlined icon="pi pi-pencil" pTooltip="Actualizar" tooltipPosition="bottom" (click)="editar(objeto)" [disabled]="objeto.regulariza === 1"/>
                                                            </div>
                                     </td>
                                 <td>{{objeto.id}}
@@ -123,7 +123,7 @@ import { OcurrenciaEventService } from '../../services/ocurrencia-event.service'
                                     <td>
                                         <div class="flex flex-wrap justify-center gap-2">
                                             <p-button outlined icon="pi pi-align-justify" pTooltip="Ver detalle" tooltipPosition="bottom" (click)="verDetalle(objeto)"/>
-                                            <p-button outlined icon="pi pi-dollar" pTooltip="Registrar costo" tooltipPosition="bottom" (click)="costear(objeto)"/>
+                                            <p-button outlined icon="pi pi-dollar" pTooltip="Registrar costo" tooltipPosition="bottom" (click)="costear(objeto)" [disabled]="objeto.regulariza === 1"/>
                                         </div>
                                     </td>
                                 </tr>
@@ -217,12 +217,18 @@ export class OcurrenciasLaboratorio {
         this.modalDetalleOcurrencia.openModal(obj.id!, false);
       }
         editar(obj: OcurrenciaDTO) {
+          if (obj.regulariza === 1) {
+            return;
+          }
           this.modalNuevoOcurrencia.openForEdit(obj);
         }
       nuevoRegistro(){
 //         this.modalNuevoOcurrencia.openModal();
       }
   costear(obj: OcurrenciaDTO) {
+    if (obj.regulariza === 1) {
+      return;
+    }
     // abrimos el modal en modo “costear”
     this.modalDetalleOcurrencia.openModal(obj.id!, true);
   }


### PR DESCRIPTION
## Summary
- add `regulariza` field to `OcurrenciaDTO`
- disable botones de editar y costear cuando la ocurrencia ya fue regularizada
- prevenir apertura de modales si el registro está aprobado

## Testing
- `npx prettier -w Frontend/sakai-ng-master/src/app/biblioteca/interfaces/ocurrenciaDTO.ts`
- `npx prettier -w Frontend/sakai-ng-master/src/app/biblioteca/modulos/biblioteca/ocurrencias-biblioteca.ts`
- `npx prettier -w Frontend/sakai-ng-master/src/app/biblioteca/modulos/laboratorio-computo/ocurrencias.ts`
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a2d42fbc883298df84c7a7d5921f5