### PR TITLE
Add duplicate validation for user registration

### DIFF
--- a/Backend/login-microsoft365/src/main/java/com/miapp/config/SecurityConfig.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/config/SecurityConfig.java
@@ -55,6 +55,7 @@ public class SecurityConfig {
                             "/auth/api/recursos-digitales/listar/tipo/**",
                             "/auth/api/tipos-recursos-digitales/listar",
                             "/auth/api/noticias/listar",
+                            "/auth/api/documento/**",
                             "/uploads/**").permitAll()
                     .anyRequest().authenticated()
             )

--- a/Backend/login-microsoft365/src/main/java/com/miapp/controller/DocumentoController.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/controller/DocumentoController.java
@@ -1,0 +1,29 @@
+package com.miapp.controller;
+
+import com.miapp.service.external.DocumentoLookupService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/auth/api/documento")
+public class DocumentoController {
+    private final DocumentoLookupService documentoLookupService;
+
+    public DocumentoController(DocumentoLookupService documentoLookupService) {
+        this.documentoLookupService = documentoLookupService;
+    }
+
+    @GetMapping("/consultar/{tipo}/{numero}")
+    public ResponseEntity<?> consultar(@PathVariable String tipo, @PathVariable String numero) {
+        Map<String, Object> data = documentoLookupService.consultar(tipo, numero);
+        if (data == null) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(data);
+    }
+}

--- a/Backend/login-microsoft365/src/main/java/com/miapp/model/Usuario.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/model/Usuario.java
@@ -1,6 +1,7 @@
 package com.miapp.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import lombok.Data;
 import java.time.LocalDateTime;
@@ -17,6 +18,7 @@ public class Usuario {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "IDUSUARIO")
+    @JsonProperty("id")
     private Long idUsuario;
 
     // Clave foránea a SEDE
@@ -42,6 +44,7 @@ public class Usuario {
     private String apellidoMaterno;
 
     @Column(name = "FECHANACIMIENTO")
+    @JsonFormat(pattern = "yyyy-MM-dd")
     private LocalDateTime fechaNacimiento;
 
     @Column(name = "EMAIL", length = 100)
@@ -91,6 +94,74 @@ public class Usuario {
     /** Contador de logeos acumulados */
     @Column(name = "LOGIN_COUNT")
     private Long loginCount = 0L;
+
+    @JsonProperty("EMPLID")
+    @Column(name = "EMPLID")
+    private String emplid;
+
+    @JsonProperty("NATIONAL_ID_TYPE")
+    @Column(name = "NATIONAL_ID_TYPE")
+    private String nationalIdType;
+
+    @JsonProperty("NATIONAL_ID")
+    @Column(name = "NATIONAL_ID")
+    private String nationalId;
+
+    @JsonProperty("NAME")
+    @Column(name = "NAME")
+    private String name;
+
+    @JsonProperty("PROGRAM")
+    @Column(name = "PROGRAM")
+    private String program;
+
+    @JsonProperty("CAMPUS")
+    @Column(name = "CAMPUS")
+    private String campus;
+
+    @JsonProperty("FEC_NAC")
+    @Column(name = "FEC_NAC")
+    private String fecNac;
+
+    @JsonProperty("COUNTRY")
+    @Column(name = "COUNTRY")
+    private String country;
+
+    @JsonProperty("STATE")
+    @Column(name = "STATE")
+    private String state;
+
+    @JsonProperty("COUNTY")
+    @Column(name = "COUNTY")
+    private String county;
+
+    @JsonProperty("CITY")
+    @Column(name = "CITY")
+    private String city;
+
+    @JsonProperty("ADDRESS")
+    @Column(name = "ADDRESS")
+    private String address;
+
+    @JsonProperty("PHONE")
+    @Column(name = "PHONE")
+    private String phone;
+
+    @JsonProperty("CELL")
+    @Column(name = "CELL")
+    private String cell;
+
+    @JsonProperty("SEX")
+    @Column(name = "SEX")
+    private String sex;
+
+    @JsonProperty("AGE")
+    @Column(name = "AGE")
+    private Integer age;
+
+    @JsonProperty("EMAIL_INST")
+    @Column(name = "EMAIL_INST")
+    private String emailInst;
 
 
 

--- a/Backend/login-microsoft365/src/main/java/com/miapp/repository/UsuarioRepository.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/repository/UsuarioRepository.java
@@ -19,6 +19,8 @@ public interface UsuarioRepository extends JpaRepository<Usuario, Long> {
 
     Optional<Usuario> findByEmail(String email);
 
+    Optional<Usuario> findByNumDocumento(Long numDocumento);
+
 //    List<Usuario> findByRol_IdRol(Long idRol);
 
     List<Usuario> findByRoles_IdRol(Long idrol);

--- a/Backend/login-microsoft365/src/main/java/com/miapp/service/UsuarioService.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/service/UsuarioService.java
@@ -44,12 +44,21 @@ public class UsuarioService {
     public Usuario registrarUsuario(Usuario usuario) {
         if (usuario.getIdUsuario() != null && usuario.getIdUsuario() == 0) {
             usuario.setIdUsuario(null);
+        } else if (usuario.getIdUsuario() != null && !usuarioRepository.existsById(usuario.getIdUsuario())) {
+            // Si el ID enviado no existe en la base de datos, se trata como un nuevo registro
+            usuario.setIdUsuario(null);
         }
 
         System.out.println(usuario.getEmail());
         // Verificar si el email ya existe
         if (usuarioRepository.findByEmail(usuario.getEmail()).isPresent()) {
             throw new RuntimeException("El email ya existe.");
+        }
+
+        // Verificar si el número de documento ya existe
+        if (usuario.getNumDocumento() != null &&
+                usuarioRepository.findByNumDocumento(usuario.getNumDocumento()).isPresent()) {
+            throw new RuntimeException("El número de documento ya existe.");
         }
 
         // Establecer el login como email

--- a/Backend/login-microsoft365/src/main/java/com/miapp/service/external/DocumentoLookupService.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/service/external/DocumentoLookupService.java
@@ -1,0 +1,40 @@
+package com.miapp.service.external;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+import java.util.Map;
+
+@Service
+public class DocumentoLookupService {
+    private final RestTemplate restTemplate;
+
+    public DocumentoLookupService() {
+        this.restTemplate = new RestTemplate();
+    }
+
+    public Map<String, Object> consultar(String tipo, String numero) {
+        String url = "https://app.upsjb.edu.pe/api-campus/PSIGW/RESTListeningConnector/PSFT_CS/SJB_CONSULTA_DNI_OPE_SERV.v1/Param/" + tipo + "/" + numero;
+        try {
+            ResponseEntity<Map> response = restTemplate.getForEntity(url, Map.class);
+            Map<String, Object> body = response.getBody();
+            if (body == null) {
+                return null;
+            }
+            Map<String, Object> wrapper = (Map<String, Object>) body.get("SJB_CONSULTA_DNI_RESP");
+            if (wrapper == null) {
+                return null;
+            }
+            List<Map<String, Object>> list = (List<Map<String, Object>>) wrapper.get("SJB_CONSULTA_DNI");
+            if (list == null || list.isEmpty()) {
+                return null;
+            }
+            return list.get(0);
+        } catch (RestClientException ex) {
+            return null;
+        }
+    }
+}

--- a/Frontend/sakai-ng-master/src/app/biblioteca/input-validation.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/input-validation.ts
@@ -4,13 +4,15 @@ import { FormGroup } from '@angular/forms';
 @Component({
     selector: 'app-input-validation',
     standalone: true,
-    template: ` <div class="invalid-feedback">
-    @for (error of errores; track error.error) {
-      @if (form?.get(modelo)?.hasError(error.error) &&
-          (form?.get(modelo)?.touched || form?.get(modelo)?.dirty)) {
-        <div class="text-red-500">{{ error.mensaje }}</div>
-      }
-    }
+    template: `
+  <div class="invalid-feedback">
+    <ng-container *ngFor="let error of errores">
+      <div *ngIf="form?.get(modelo)?.hasError(error.error) &&
+                  (form?.get(modelo)?.touched || form?.get(modelo)?.dirty)"
+           class="text-red-500">
+        {{ error.mensaje }}
+      </div>
+    </ng-container>
   </div>
   `
 })

--- a/Frontend/sakai-ng-master/src/app/biblioteca/services/documento.service.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/services/documento.service.ts
@@ -1,0 +1,17 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { environment } from '../../../environments/environment';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class DocumentoService {
+  private apiUrl = environment.apiUrl;
+  constructor(private http: HttpClient) {}
+
+  consultar(tipo: string, numero: string): Observable<any> {
+    const url = `${this.apiUrl}/api/documento/consultar/${tipo}/${numero}`;
+    return this.http.get<any>(url);
+  }
+}

--- a/Frontend/sakai-ng-master/src/app/biblioteca/web/interfaces/registro.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/web/interfaces/registro.ts
@@ -1,5 +1,7 @@
 
 export class Registro {
+    tipoDocumento: string;
+    numDocumento: string;
     id: number;
     nombreUsuario:String;
     apellidoMaterno:String;
@@ -7,8 +9,27 @@ export class Registro {
     fechaNacimiento:String;
     email:String;
     password: string;
+    ADDRESS?: string;
+    AGE?: number;
+    CAMPUS?: string;
+    CELL?: string;
+    CITY?: string;
+    COUNTRY?: string;
+    COUNTY?: string;
+    EMAIL_INST?: string;
+    EMPLID?: string;
+    FEC_NAC?: string;
+    NAME?: string;
+    NATIONAL_ID?: string;
+    NATIONAL_ID_TYPE?: string;
+    PHONE?: string;
+    PROGRAM?: string;
+    SEX?: string;
+    STATE?: string;
 
     constructor(init?: Partial<Registro>) {
+        this.tipoDocumento = '';
+        this.numDocumento = '';
         this.id = 0;
         this.nombreUsuario = '';
         this.apellidoMaterno = '';
@@ -16,6 +37,23 @@ export class Registro {
         this.fechaNacimiento = '';
         this.email = '';
         this.password = '';
+        this.ADDRESS = '';
+        this.AGE = 0;
+        this.CAMPUS = '';
+        this.CELL = '';
+        this.CITY = '';
+        this.COUNTRY = '';
+        this.COUNTY = '';
+        this.EMAIL_INST = '';
+        this.EMPLID = '';
+        this.FEC_NAC = '';
+        this.NAME = '';
+        this.NATIONAL_ID = '';
+        this.NATIONAL_ID_TYPE = '';
+        this.PHONE = '';
+        this.PROGRAM = '';
+        this.SEX = '';
+        this.STATE = '';
 
         // Inicialización opcional si se pasa un objeto
         Object.assign(this, init);

--- a/Frontend/sakai-ng-master/src/app/biblioteca/web/registrate/registrate.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/web/registrate/registrate.ts
@@ -14,6 +14,7 @@ import { FormsModule } from '@angular/forms';
 import { InputValidation } from '../../input-validation';
 import { TemplateModule } from '../../template.module';
 import { AuthService } from '../../../biblioteca/services/auth.service';
+import { DocumentoService } from '../../../biblioteca/services/documento.service';
 
 @Component({
     selector: 'app-registrate',
@@ -29,6 +30,12 @@ import { AuthService } from '../../../biblioteca/services/auth.service';
         InputValidation,
         TemplateModule,
         FormsModule],
+    styles: [`
+        .disabled-input {
+            background-color: #e9ecef;
+            cursor: not-allowed;
+        }
+    `],
     template: `
         <app-floating-configurator />
         <div class="bg-surface-0 dark:bg-surface-900">
@@ -59,54 +66,109 @@ import { AuthService } from '../../../biblioteca/services/auth.service';
                             <div class="text-surface-900 dark:text-surface-0 text-3xl font-medium mb-4">Biblioteca</div>
                             <span class="text-muted-color font-medium">Registrate</span>
                         </div>
-                        @if(!registrado){
+                        <div *ngIf="!registrado">
 
-                        <form [formGroup]="form">
+                        <form [formGroup]="form" class="grid grid-cols-1 md:grid-cols-5 gap-4">
 
-                        <div>
+                        <div class="flex flex-col gap-2">
+                            <label for="tipoDocumento" class="block text-surface-900 dark:text-surface-0 font-medium text-xl mb-2">Tipo documento</label>
+                            <p-dropdown id="tipoDocumento" [options]="tiposDocumento" optionLabel="label" optionValue="code" formControlName="tipoDocumento" placeholder="Seleccione"></p-dropdown>
+                            <app-input-validation [form]="form" modelo="tipoDocumento" ver="Tipo documento"></app-input-validation>
+                        </div>
+
+                        <div class="flex flex-col gap-2">
+                            <label for="numDocumento" class="block text-surface-900 dark:text-surface-0 font-medium text-xl mb-2">Número documento</label>
+                            <input pInputText id="numDocumento" type="text" placeholder="Número" formControlName="numDocumento" (blur)="consultarDocumento()" />
+                            <app-input-validation [form]="form" modelo="numDocumento" ver="Número documento"></app-input-validation>
+                        </div>
+
+                        <div class="flex flex-col gap-2">
                             <label for="nombres" class="block text-surface-900 dark:text-surface-0 font-medium text-xl mb-2">Nombres</label>
-                            <input pInputText id="nombreUsuario" type="text" placeholder="Nombre" class="w-full md:w-[30rem] mb-2" formControlName="nombreUsuario" />
+                            <input pInputText id="nombreUsuario" type="text" placeholder="Nombre" formControlName="nombreUsuario" [readonly]="fieldsDisabled" [ngClass]="{'disabled-input': fieldsDisabled}" />
                             <app-input-validation [form]="form" modelo="nombreUsuario" ver="nombreUsuario"></app-input-validation>
+                        </div>
 
-                            <div class="flex flex-col gap-4">
-                                <div class="flex flex-wrap gap-6">
-                                    <div class="flex flex-col grow basis-0 gap-2">
-                                        <label for="apellidoMaterno" class="block text-surface-900 dark:text-surface-0 font-medium text-xl mb-2">Apellido Materno</label>
-                                        <input pInputText id="apellidoMaterno" type="text" placeholder="Apellido Materno" class="w-full md:w-[30rem] mb-2" formControlName="apellidoMaterno" />
-                                        <app-input-validation [form]="form" modelo="apellidoMaterno" ver="Apellido Materno"></app-input-validation>
-                                    </div>
-                                    <div class="flex flex-col grow basis-0 gap-2">
-                                        <label for="apellidoPaterno" class="block text-surface-900 dark:text-surface-0 font-medium text-xl mb-2">Apellido Paterno</label>
-                                        <input pInputText id="apellidoPaterno" type="text" placeholder="Apellidos" class="w-full md:w-[30rem] mb-2" formControlName="apellidoPaterno" />
-                                        <app-input-validation [form]="form" modelo="apellidoPaterno" ver="Apellido Paterno"></app-input-validation>
-                                    </div>
-                                </div>
+                        <div class="flex flex-col gap-2">
+                            <label for="apellidoMaterno" class="block text-surface-900 dark:text-surface-0 font-medium text-xl mb-2">Apellido Materno</label>
+                            <input pInputText id="apellidoMaterno" type="text" placeholder="Apellido Materno" formControlName="apellidoMaterno" [readonly]="fieldsDisabled" [ngClass]="{'disabled-input': fieldsDisabled}" />
+                            <app-input-validation [form]="form" modelo="apellidoMaterno" ver="Apellido Materno"></app-input-validation>
+                        </div>
+                        <div class="flex flex-col gap-2">
+                            <label for="apellidoPaterno" class="block text-surface-900 dark:text-surface-0 font-medium text-xl mb-2">Apellido Paterno</label>
+                            <input pInputText id="apellidoPaterno" type="text" placeholder="Apellidos" formControlName="apellidoPaterno" [readonly]="fieldsDisabled" [ngClass]="{'disabled-input': fieldsDisabled}" />
+                            <app-input-validation [form]="form" modelo="apellidoPaterno" ver="Apellido Paterno"></app-input-validation>
+                        </div>
+
+
+                            <div class="flex flex-col gap-2">
+                                <label for="fechaNacimiento" class="block text-surface-900 dark:text-surface-0 font-medium text-xl mb-2">Fecha nacimiento</label>
+                                <p-datePicker formControlName="fechaNacimiento"
+                                             dateFormat="yy-mm-dd"
+                                             placeholder="YYYY-MM-DD"
+                                             [readonlyInput]="fieldsDisabled"
+                                             [disabled]="fieldsDisabled"
+                                             [inputStyleClass]="fieldsDisabled ? 'disabled-input' : ''"></p-datePicker>
+                            </div>
+                            <div class="flex flex-col gap-2">
+                                <label for="email" class="block text-surface-900 dark:text-surface-0 font-medium text-xl mb-2">Email</label>
+                                <input pInputText id="email" type="text" placeholder="Email" formControlName="email" [readonly]="fieldsDisabled" [ngClass]="{'disabled-input': fieldsDisabled}" />
+                                <app-input-validation [form]="form" modelo="email" ver="Email"></app-input-validation>
                             </div>
 
-
-                            <div class="flex flex-col gap-4">
-                                <div class="flex flex-wrap gap-6">
-                                    <div class="flex flex-col grow basis-0 gap-2">
-                                        <label for="fechaNacimiento" class="block text-surface-900 dark:text-surface-0 font-medium text-xl mb-2">Fecha nacimiento</label>
-                                        <p-datePicker
-                                          formControlName="fechaNacimiento"
-                                          dateFormat="yy-mm-dd"
-                                          placeholder="YYYY-MM-DD">
-                                        </p-datePicker>
-
-
-                                    </div>
-                                    <div class="flex flex-col grow basis-0 gap-2">
-                                        <label for="email" class="block text-surface-900 dark:text-surface-0 font-medium text-xl mb-2">Email</label>
-                                        <input pInputText id="email" type="text" placeholder="Email" formControlName="email" />
-                                        <app-input-validation [form]="form" modelo="email" ver="Email"></app-input-validation>
-                                    </div>
-                                </div>
+                            <div class="flex flex-col gap-2">
+                                <label for="address" class="block text-surface-900 dark:text-surface-0 font-medium text-xl mb-2">Dirección</label>
+                                <input pInputText id="address" type="text" placeholder="Dirección" formControlName="ADDRESS" [readonly]="fieldsDisabled" [ngClass]="{'disabled-input': fieldsDisabled}" />
+                            </div>
+                            <div class="flex flex-col gap-2">
+                                <label for="phone" class="block text-surface-900 dark:text-surface-0 font-medium text-xl mb-2">Teléfono</label>
+                                <input pInputText id="phone" type="text" placeholder="Teléfono" formControlName="PHONE" [readonly]="fieldsDisabled" [ngClass]="{'disabled-input': fieldsDisabled}" />
+                            </div>
+                            <div class="flex flex-col gap-2">
+                                <label for="cell" class="block text-surface-900 dark:text-surface-0 font-medium text-xl mb-2">Celular</label>
+                                <input pInputText id="cell" type="text" placeholder="Celular" formControlName="CELL" [readonly]="fieldsDisabled" [ngClass]="{'disabled-input': fieldsDisabled}" />
+                            </div>
+                            <div class="flex flex-col gap-2">
+                                <label for="program" class="block text-surface-900 dark:text-surface-0 font-medium text-xl mb-2">Programa</label>
+                                <input pInputText id="program" type="text" placeholder="Programa" formControlName="PROGRAM" [readonly]="fieldsDisabled" [ngClass]="{'disabled-input': fieldsDisabled}" />
+                            </div>
+                            <div class="flex flex-col gap-2">
+                                <label for="campus" class="block text-surface-900 dark:text-surface-0 font-medium text-xl mb-2">Campus</label>
+                                <input pInputText id="campus" type="text" placeholder="Campus" formControlName="CAMPUS" [readonly]="fieldsDisabled" [ngClass]="{'disabled-input': fieldsDisabled}" />
+                            </div>
+                            <div class="flex flex-col gap-2">
+                                <label for="country" class="block text-surface-900 dark:text-surface-0 font-medium text-xl mb-2">País</label>
+                                <input pInputText id="country" type="text" placeholder="País" formControlName="COUNTRY" [readonly]="fieldsDisabled" [ngClass]="{'disabled-input': fieldsDisabled}" />
+                            </div>
+                            <div class="flex flex-col gap-2">
+                                <label for="state" class="block text-surface-900 dark:text-surface-0 font-medium text-xl mb-2">Estado</label>
+                                <input pInputText id="state" type="text" placeholder="Estado" formControlName="STATE" [readonly]="fieldsDisabled" [ngClass]="{'disabled-input': fieldsDisabled}" />
+                            </div>
+                            <div class="flex flex-col gap-2">
+                                <label for="city" class="block text-surface-900 dark:text-surface-0 font-medium text-xl mb-2">Ciudad</label>
+                                <input pInputText id="city" type="text" placeholder="Ciudad" formControlName="CITY" [readonly]="fieldsDisabled" [ngClass]="{'disabled-input': fieldsDisabled}" />
+                            </div>
+                            <div class="flex flex-col gap-2">
+                                <label for="county" class="block text-surface-900 dark:text-surface-0 font-medium text-xl mb-2">Provincia</label>
+                                <input pInputText id="county" type="text" placeholder="Provincia" formControlName="COUNTY" [readonly]="fieldsDisabled" [ngClass]="{'disabled-input': fieldsDisabled}" />
+                            </div>
+                            <div class="flex flex-col gap-2">
+                                <label for="age" class="block text-surface-900 dark:text-surface-0 font-medium text-xl mb-2">Edad</label>
+                                <input pInputText id="age" type="text" placeholder="Edad" formControlName="AGE" [readonly]="fieldsDisabled" [ngClass]="{'disabled-input': fieldsDisabled}" />
+                            </div>
+                            <div class="flex flex-col gap-2">
+                                <label for="sex" class="block text-surface-900 dark:text-surface-0 font-medium text-xl mb-2">Sexo</label>
+                                <input pInputText id="sex" type="text" placeholder="Sexo" formControlName="SEX" [readonly]="fieldsDisabled" [ngClass]="{'disabled-input': fieldsDisabled}" />
+                            </div>
+                            <div class="flex flex-col gap-2">
+                                <label for="emailInst" class="block text-surface-900 dark:text-surface-0 font-medium text-xl mb-2">Email Inst.</label>
+                                <input pInputText id="emailInst" type="text" placeholder="Email Institucional" formControlName="EMAIL_INST" [readonly]="fieldsDisabled" [ngClass]="{'disabled-input': fieldsDisabled}" />
                             </div>
 
-                            <label for="password" class="block text-surface-900 dark:text-surface-0 font-medium text-xl mb-2">Contraseña</label>
-                            <input pInputText id="password" type="text" placeholder="Contraseña" class="w-full md:w-[30rem] mb-2" formControlName="password" />
-                            <app-input-validation [form]="form" modelo="password" ver="Contraseña"></app-input-validation>
+                            <div class="flex flex-col gap-2">
+                                <label for="password" class="block text-surface-900 dark:text-surface-0 font-medium text-xl mb-2 mt-4">Contraseña</label>
+                                <input pInputText id="password" type="password" placeholder="Contraseña" formControlName="password" />
+                                <app-input-validation [form]="form" modelo="password" ver="Contraseña"></app-input-validation>
+                            </div>
 
 
 
@@ -114,14 +176,13 @@ import { AuthService } from '../../../biblioteca/services/auth.service';
                             </div>
 
                             <p-button label="Continuar" styleClass="w-full" (click)="registrar()" [disabled]="form.invalid"></p-button>
-                        </div>
                         </form>
-                        }
+                        </div>
+                        </div>
                     </div>
                 </div>
             </div>
         </div>
-            </div>
         </div>
 
 <p-toast></p-toast>
@@ -134,8 +195,23 @@ export class PortalRegistrate implements OnInit {
     msgs: ToastMessageOptions[] | null = [];
     objeto!: Registro;
     form!: FormGroup;
-    constructor(private router: Router,private fb: FormBuilder,private messageService: MessageService, private confirmationService: ConfirmationService, private authService: AuthService) {
+    fieldsDisabled = true;
+    tiposDocumento = [
+        { code: '01', label: 'DNI' },
+        { code: '04', label: 'Carnet de ext.' },
+        { code: '07', label: 'Pasaporte' },
+        { code: '06', label: 'RUC' },
+        { code: '00', label: 'Otros' }
+    ];
+    constructor(private router: Router,
+                private fb: FormBuilder,
+                private messageService: MessageService,
+                private confirmationService: ConfirmationService,
+                private authService: AuthService,
+                private documentoService: DocumentoService) {
         this.form = this.fb.group({
+            tipoDocumento: ['', Validators.required],
+            numDocumento: ['', Validators.required],
             id: [0, [Validators.required]],
             nombreUsuario: [ '', [Validators.required, Validators.maxLength(100), Validators.minLength(3),Validators.pattern('^[a-zA-ZáéíóúÁÉÍÓÚñÑ,.;-\\s]+$')]],
             apellidoMaterno: [ '', [Validators.required, Validators.maxLength(100), Validators.minLength(3),Validators.pattern('^[a-zA-ZáéíóúÁÉÍÓÚñÑ,.;-\\s]+$')]],
@@ -151,36 +227,98 @@ export class PortalRegistrate implements OnInit {
         this.formValidar();
     }
     limpiarObjeto() {
+        this.fieldsDisabled = true;
         this.objeto = {
+            tipoDocumento: '',
+            numDocumento: '',
             id: 0,
             nombreUsuario: '',
             apellidoMaterno: '',
             apellidoPaterno: '',
             fechaNacimiento: '',
             email: '',
-            password: ''
+            password: '',
+            ADDRESS: '',
+            AGE: 0,
+            CAMPUS: '',
+            CELL: '',
+            CITY: '',
+            COUNTRY: '',
+            COUNTY: '',
+            EMAIL_INST: '',
+            EMPLID: '',
+            FEC_NAC: '',
+            NAME: '',
+            NATIONAL_ID: '',
+            NATIONAL_ID_TYPE: '',
+            PHONE: '',
+            PROGRAM: '',
+            SEX: '',
+            STATE: ''
         }
     }
 
     formValidar() {
         let dataObjeto = {
+            tipoDocumento: this.objeto.tipoDocumento,
+            numDocumento: this.objeto.numDocumento,
             id: this.objeto.id,
             nombreUsuario: this.objeto.nombreUsuario,
             apellidoMaterno: this.objeto.apellidoMaterno,
             apellidoPaterno: this.objeto.apellidoPaterno,
             fechaNacimiento: this.objeto.fechaNacimiento,
             email: this.objeto.email,
-            password: this.objeto.password
+            password: this.objeto.password,
+            ADDRESS: this.objeto.ADDRESS,
+            AGE: this.objeto.AGE,
+            CAMPUS: this.objeto.CAMPUS,
+            CELL: this.objeto.CELL,
+            CITY: this.objeto.CITY,
+            COUNTRY: this.objeto.COUNTRY,
+            COUNTY: this.objeto.COUNTY,
+            EMAIL_INST: this.objeto.EMAIL_INST,
+            EMPLID: this.objeto.EMPLID,
+            FEC_NAC: this.objeto.FEC_NAC,
+            NAME: this.objeto.NAME,
+            NATIONAL_ID: this.objeto.NATIONAL_ID,
+            NATIONAL_ID_TYPE: this.objeto.NATIONAL_ID_TYPE,
+            PHONE: this.objeto.PHONE,
+            PROGRAM: this.objeto.PROGRAM,
+            SEX: this.objeto.SEX,
+            STATE: this.objeto.STATE
         };
         this.form = this.fb.group({
+            tipoDocumento: [dataObjeto.tipoDocumento, [Validators.required]],
+            numDocumento: [dataObjeto.numDocumento, [Validators.required]],
             id: [dataObjeto.id, [Validators.required]],
             nombreUsuario: [dataObjeto.nombreUsuario, [Validators.required, Validators.maxLength(100), Validators.minLength(3),Validators.pattern('^[a-zA-ZáéíóúÁÉÍÓÚñÑ,.;-\\s]+$')]],
             apellidoMaterno: [ dataObjeto.apellidoMaterno , [Validators.required, Validators.maxLength(80), Validators.minLength(3),Validators.pattern('^[a-zA-ZáéíóúÁÉÍÓÚñÑ,.;-\\s]+$')]],
             apellidoPaterno: [ dataObjeto.apellidoMaterno , [Validators.required, Validators.maxLength(80), Validators.minLength(3),Validators.pattern('^[a-zA-ZáéíóúÁÉÍÓÚñÑ,.;-\\s]+$')]],
             fechaNacimiento: [ dataObjeto.fechaNacimiento],
             email: [ dataObjeto.email , [Validators.maxLength(150),Validators.pattern('^[a-zA-Z0-9áéíóúÁÉÍÓÚñÑ,.;-@\\s\\-()]+$')]],
-            password: [ dataObjeto.password , [Validators.maxLength(150),Validators.pattern('^[a-zA-Z0-9áéíóúÁÉÍÓÚñÑ,.;-\\s\\-()]+$')]]
+            password: [ dataObjeto.password , [Validators.maxLength(150),Validators.pattern('^[a-zA-Z0-9áéíóúÁÉÍÓÚñÑ,.;-\\s\\-()]+$')]],
+            ADDRESS: [dataObjeto.ADDRESS],
+            AGE: [dataObjeto.AGE],
+            CAMPUS: [dataObjeto.CAMPUS],
+            CELL: [dataObjeto.CELL],
+            CITY: [dataObjeto.CITY],
+            COUNTRY: [dataObjeto.COUNTRY],
+            COUNTY: [dataObjeto.COUNTY],
+            EMAIL_INST: [dataObjeto.EMAIL_INST],
+            EMPLID: [dataObjeto.EMPLID],
+            FEC_NAC: [dataObjeto.FEC_NAC],
+            NAME: [dataObjeto.NAME],
+            NATIONAL_ID: [dataObjeto.NATIONAL_ID],
+            NATIONAL_ID_TYPE: [dataObjeto.NATIONAL_ID_TYPE],
+            PHONE: [dataObjeto.PHONE],
+            PROGRAM: [dataObjeto.PROGRAM],
+            SEX: [dataObjeto.SEX],
+            STATE: [dataObjeto.STATE]
         });
+
+        if (this.fieldsDisabled) {
+            this.form.get('fechaNacimiento')?.disable();
+        }
     }
 
     registrar() {
@@ -207,15 +345,91 @@ export class PortalRegistrate implements OnInit {
                 this.router.navigate(['/login']);
               },
               error: (err) => {
-                this.messageService.add({ severity: 'error', summary: 'Error', detail: 'Error al registrar usuario.' });
+                const detalle = err.error?.p_mensaje || 'Error al registrar usuario.';
+                this.messageService.add({ severity: 'error', summary: 'Error', detail: detalle });
                 console.error('Error en el registro:', err);
               }
             });
           },
-          reject: () => {
-            this.messageService.add({ severity: 'info', summary: 'Cancelado', detail: 'Registro cancelado.' });
-          }
-        });
+      reject: () => {
+        this.messageService.add({ severity: 'info', summary: 'Cancelado', detail: 'Registro cancelado.' });
       }
+    });
+  }
+
+  consultarDocumento() {
+      const tipo = this.form.get('tipoDocumento')?.value;
+      const numero = this.form.get('numDocumento')?.value;
+      if (!tipo || !numero) {
+          return;
+      }
+      this.documentoService.consultar(tipo, numero).subscribe({
+          next: (data) => {
+              const nombres = data.NAME ? data.NAME.split(',')[1]?.trim() || '' : '';
+              const apellidos = data.NAME ? data.NAME.split(',')[0]?.trim() || '' : '';
+              const apellidoParts = apellidos.split(' ');
+              const apellidoPaterno = apellidoParts.shift() || '';
+              const apellidoMaterno = apellidoParts.join(' ');
+
+              this.form.patchValue({
+                  nombreUsuario: nombres,
+                  apellidoPaterno: apellidoPaterno,
+                  apellidoMaterno: apellidoMaterno,
+                  fechaNacimiento: data.FEC_NAC ? data.FEC_NAC.substring(0,10) : '',
+                  email: data.EMAIL_INST || '',
+                  ADDRESS: data.ADDRESS || '',
+                  AGE: data.AGE || 0,
+                  CAMPUS: data.CAMPUS || '',
+                  CELL: data.CELL || '',
+                  CITY: data.CITY || '',
+                  COUNTRY: data.COUNTRY || '',
+                  COUNTY: data.COUNTY || '',
+                  EMAIL_INST: data.EMAIL_INST || '',
+                  EMPLID: data.EMPLID || '',
+                  FEC_NAC: data.FEC_NAC || '',
+                  NAME: data.NAME || '',
+                  NATIONAL_ID: data.NATIONAL_ID || '',
+                  NATIONAL_ID_TYPE: data.NATIONAL_ID_TYPE || '',
+                  PHONE: data.PHONE || '',
+                  PROGRAM: data.PROGRAM || '',
+                  SEX: data.SEX || '',
+                  STATE: data.STATE || ''
+              });
+              // Mantener los campos bloqueados cuando se encuentra el documento
+              this.fieldsDisabled = true;
+              this.form.get('fechaNacimiento')?.disable();
+          },
+          error: () => {
+              this.form.patchValue({
+                  id: 0,
+                  nombreUsuario: '',
+                  apellidoPaterno: '',
+                  apellidoMaterno: '',
+                  fechaNacimiento: '',
+                  email: '',
+                  ADDRESS: '',
+                  AGE: 0,
+                  CAMPUS: '',
+                  CELL: '',
+                  CITY: '',
+                  COUNTRY: '',
+                  COUNTY: '',
+                  EMAIL_INST: '',
+                  EMPLID: '',
+                  FEC_NAC: '',
+                  NAME: '',
+                  NATIONAL_ID: '',
+                  NATIONAL_ID_TYPE: '',
+                  PHONE: '',
+                  PROGRAM: '',
+                  SEX: '',
+                  STATE: ''
+              });
+              this.messageService.add({severity:'warn', summary:'Sin resultados', detail:'Documento no encontrado. Complete los datos manualmente.'});
+              this.fieldsDisabled = false;
+              this.form.get('fechaNacimiento')?.enable();
+          }
+      });
+  }
 
 }


### PR DESCRIPTION
## Summary
- check DNI and email duplicates in `UsuarioService`
- expose `findByNumDocumento` in `UsuarioRepository`
- show backend validation message in the registration form
- handle missing user IDs on registration lookups

## Testing
- `npm test` *(fails: ng not found)*
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ad4c941b48329b1f8dcac31b28943