### PR TITLE
Fix SPA routing 404s in Docker

### DIFF
--- a/Frontend/sakai-ng-master/.dockerignore
+++ b/Frontend/sakai-ng-master/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+.git
+.gitignore
+npm-debug.log

--- a/Frontend/sakai-ng-master/Dockerfile
+++ b/Frontend/sakai-ng-master/Dockerfile
@@ -1,0 +1,15 @@
+# Stage 1: Build the Angular app
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci --silent
+COPY . .
+RUN npm run build -- --configuration production
+
+# Stage 2: Serve the app with Nginx
+FROM nginx:stable-alpine
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+RUN rm -rf /usr/share/nginx/html/*
+COPY --from=build /app/dist/sakai-ng /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/Frontend/sakai-ng-master/README.md
+++ b/Frontend/sakai-ng-master/README.md
@@ -57,3 +57,16 @@ Angular CLI does not come with an end-to-end testing framework by default. You c
 ## Additional Resources
 
 For more information on using the Angular CLI, including detailed command references, visit the [Angular CLI Overview and Command Reference](https://angular.dev/tools/cli) page.
+
+## Docker deployment
+
+This project includes a multi-stage `Dockerfile` that builds the Angular application and serves it using Nginx. The provided `nginx.conf` ensures SPA routing works correctly by redirecting unknown paths to `index.html`.
+
+Build and run the container from this directory with:
+
+```bash
+docker build -t sakai-ng .
+docker run -p 8080:80 sakai-ng
+```
+
+After running the container, navigate to `http://localhost:8080`. You can reload any page without getting 404 errors.

--- a/Frontend/sakai-ng-master/nginx.conf
+++ b/Frontend/sakai-ng-master/nginx.conf
@@ -1,0 +1,11 @@
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
## Summary
- add a production `Dockerfile` for the Angular app
- configure nginx with SPA routing so reloading pages returns `index.html`
- ignore development artifacts in build context
- document how to build and run the container
- remove default nginx assets before copying built files

## Testing
- `mvn -q test` *(fails: `mvn` not found)*
- `npm test -- -w=false --browsers=ChromeHeadless` *(fails: package.json not found in repo root)*

------
https://chatgpt.com/codex/tasks/task_e_6860123426648329ab43ff3ebaa4d55d