### PR TITLE
Normaliza la búsqueda y lista por tipo de material

### DIFF
--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/mantenimientos/material-bibliografico/material-bibliografico.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/mantenimientos/material-bibliografico/material-bibliografico.ts
@@ -571,9 +571,19 @@ async listar() {
     this.materialBibliograficoService.search_get(endpoint)
       .subscribe(
         (result: any) => {
-          // Supongamos que el endpoint devuelve directamente un array
           console.log(result);
-          const lista = Array.isArray(result) ? result : result.data;
+
+          // Normalizamos la respuesta para trabajar siempre con un arreglo
+          const lista: any[] = Array.isArray(result?.data?.content)
+            ? result.data.content
+            : Array.isArray(result?.content)
+            ? result.content
+            : Array.isArray(result?.data)
+            ? result.data
+            : Array.isArray(result)
+            ? result
+            : [];
+
           this.data = lista.filter((b: any) => Number(b.estadoId) === 2);
           this.loading = false;
         },
@@ -584,66 +594,87 @@ async listar() {
       );
 
   }
-//   else {
-//     // Si no se ingresó palabra clave, se filtra según el tipo de material.
-//     if (this.tipoRecursoFiltro?.tipo?.id === 1) { // Libro
-//       this.lista_libros();
-//     } else if (this.tipoRecursoFiltro?.tipo?.id === 2) { // Revista
-//       this.lista_revistas();
-//     } else {
-//       this.lista_otro();
-//     }
-//   }
+  else {
+    // Si no se ingresó palabra clave, se filtra según el tipo de material.
+    if (this.tipoRecursoFiltro?.tipo?.id === 1) { // Libro
+      this.lista_libros();
+    } else if (this.tipoRecursoFiltro?.tipo?.id === 2) { // Revista
+      this.lista_revistas();
+    } else {
+      this.lista_otro();
+    }
+  }
 }
 
 
-//   lista_libros(){
-//
-//     this.materialBibliograficoService.api_libros_lista('api/material-bibliografico/libros')
-//       .subscribe(
-//         (result: any) => {
-//           this.loading = false;
-//           if (result.status == "0") {
-//             this.data = result.data;
-//           }
-//         }
-//         , (error: HttpErrorResponse) => {
-//           this.loading = false;
-//         }
-//       );
-//   }
-//
-//   lista_revistas(){
-//
-//     this.materialBibliograficoService.api_revistas_lista('api/material-bibliografico/revistas')
-//       .subscribe(
-//         (result: any) => {
-//           this.loading = false;
-//           if (result.status == "0") {
-//             this.data = result.data;
-//           }
-//         }
-//         , (error: HttpErrorResponse) => {
-//           this.loading = false;
-//         }
-//       );
-//   }
-//
-//   lista_otro(){
-//
-//     this.materialBibliograficoService.api_otros_lista(this.modulo + '/lista')
-//       .subscribe(
-//         (result: any) => {console.log(result);
-//           this.loading = false;
-//           if (result.status == "0") {
-//             this.data = result.data;
-//           }
-//         }
-//         , (error: HttpErrorResponse) => {
-//           this.loading = false;
-//         }
-//       );
-//   }
+  lista_libros() {
+    this.materialBibliograficoService
+      .api_libros_lista('api/material-bibliografico/libros')
+      .subscribe(
+        (result: any) => {
+          const lista: any[] = Array.isArray(result?.data?.content)
+            ? result.data.content
+            : Array.isArray(result?.content)
+            ? result.content
+            : Array.isArray(result?.data)
+            ? result.data
+            : Array.isArray(result)
+            ? result
+            : [];
+          this.data = lista.filter((b: any) => Number(b.estadoId) === 2);
+          this.loading = false;
+        },
+        (error: HttpErrorResponse) => {
+          this.loading = false;
+        }
+      );
+  }
+
+  lista_revistas() {
+    this.materialBibliograficoService
+      .api_revistas_lista('api/material-bibliografico/revistas')
+      .subscribe(
+        (result: any) => {
+          const lista: any[] = Array.isArray(result?.data?.content)
+            ? result.data.content
+            : Array.isArray(result?.content)
+            ? result.content
+            : Array.isArray(result?.data)
+            ? result.data
+            : Array.isArray(result)
+            ? result
+            : [];
+          this.data = lista.filter((b: any) => Number(b.estadoId) === 2);
+          this.loading = false;
+        },
+        (error: HttpErrorResponse) => {
+          this.loading = false;
+        }
+      );
+  }
+
+  lista_otro() {
+    this.materialBibliograficoService
+      .api_otros_lista(this.modulo + '/lista')
+      .subscribe(
+        (result: any) => {
+          const lista: any[] = Array.isArray(result?.data?.content)
+            ? result.data.content
+            : Array.isArray(result?.content)
+            ? result.content
+            : Array.isArray(result?.data)
+            ? result.data
+            : Array.isArray(result)
+            ? result
+            : [];
+          this.data = lista.filter((b: any) => Number(b.estadoId) === 2);
+          this.loading = false;
+        },
+        (error: HttpErrorResponse) => {
+          this.loading = false;
+        }
+      );
+  }
   cambiarEstadoRegistro(objeto: Ejemplar) {
     let estado = "";
     if (objeto.activo) {


### PR DESCRIPTION
## Resumen
- Procesa siempre como arreglo los resultados de búsqueda y de listados por tipo
- Muestra los materiales según el tipo seleccionado cuando no hay filtros adicionales
- Acepta respuestas paginadas desde el backend para poblar la tabla

## Pruebas
- `npm test --silent -- --watch=false --browsers=ChromeHeadless` *(falla: No inputs were found in config file 'tsconfig.spec.json')*

------
https://chatgpt.com/codex/tasks/task_e_6890449e61708329bc601122cc5165cc