### PR TITLE
feat: integrar noticias reales y ajustes en recursos electrónicos

### DIFF
--- a/Frontend/sakai-ng-master/src/app/biblioteca/services/portal.service.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/services/portal.service.ts
@@ -93,11 +93,12 @@ export class PortalService {
     );*/
     return this.http.get<any[]>('assets/demo/biblioteca/portalRecursosElectronicos.json');
   }
-  api_noticias(modulo: any):Observable<any>{
-    /*return this.http.get<any[]>(`${this.apiUrl}/${modulo}`
-    ,{ headers: new HttpHeaders().set('Authorization',`Bearer ${this.authService.getToken()}`)}
-    );*/
-    return this.http.get<any[]>('assets/demo/biblioteca/portalNoticias.json');
+  api_noticias(busqueda?: string): Observable<ListDTO<PortalNoticia[]>> {
+    const params = busqueda ? `?q=${encodeURIComponent(busqueda)}` : '';
+    return this.http.get<ListDTO<PortalNoticia[]>>(
+      `${this.apiUrl}/api/noticias/listar${params}`,
+      { headers: this.authHeaders() }
+    );
   }
 
     // Listar, con parámetros opcionales ?start=yyyy-MM-dd&end=yyyy-MM-dd

--- a/Frontend/sakai-ng-master/src/app/biblioteca/web/noticias/noticias-lista.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/web/noticias/noticias-lista.ts
@@ -10,7 +10,8 @@ import { Table } from 'primeng/table';
 import { Menu } from 'primeng/menu';
 import { HttpErrorResponse } from '@angular/common/http';
 import { PortalService } from '../../services/portal.service';
-import { Material } from '../../interfaces/material-bibliografico/material';
+import { PortalNoticia } from '../../interfaces/portalNoticias';
+import { environment } from '../../../../environments/environment';
 
 @Component({
     selector: 'noticias-lista',
@@ -34,7 +35,7 @@ import { Material } from '../../interfaces/material-bibliografico/material';
         
         <div class="flex flex-col flex-1 gap-2">
             <label for="palabra-clave" class="block text-sm font-medium text-muted-color">Buscar noticia</label>
-            <input pInputText id="palabra-clave" type="text" />
+            <input pInputText id="palabra-clave" type="text" [(ngModel)]="palabraClave" (keydown.enter)="listar()" />
         </div>
         
         <div class="flex items-end">
@@ -170,8 +171,8 @@ import { Material } from '../../interfaces/material-bibliografico/material';
 export class NoticiasLista implements OnInit {
     layout: 'list' | 'grid' = 'grid';
     options = ['list', 'grid'];
-    modulo: string = "catalogo";
-    data: Material[] = [];
+    data: PortalNoticia[] = [];
+    palabraClave: string = '';
     @ViewChild('menu') menu!: Menu;
     @ViewChild('filter') filter!: ElementRef;
     items: MenuItem[] | undefined;
@@ -202,22 +203,42 @@ export class NoticiasLista implements OnInit {
     }
 
     listar() {
-
         this.loading = true;
-        this.portalService.api_noticias(this.modulo)
-            .subscribe(
-                (result: any) => {
-                    this.loading = false;
-                    if (result.status == "0") {
-                        this.data = result.data;
-                    }
-                    this.loading = false;
-                }
-                , (error: HttpErrorResponse) => {
-                    this.loading = false;
-                }
-            );
+        this.portalService.api_noticias(this.palabraClave).subscribe({
+            next: (result: any) => {
+                const noticias: PortalNoticia[] = result?.data ?? [];
+                this.data = noticias.map(n => new PortalNoticia({
+                    ...n,
+                    titulo: n.titular ?? n.titulo,
+                    detalle: n.descripcion ?? n.detalle,
+                    anunciante: n.autor ?? n.anunciante,
+                    link: n.enlace ?? n.link,
+                    fecha: n.fechacreacion ?? n.fecha,
+                    urlPortada: this.buildImageUrl(n)
+                }));
 
+                if (this.palabraClave) {
+                    const term = this.palabraClave.toLowerCase();
+                    this.data = this.data.filter(n =>
+                        n.titulo.toLowerCase().includes(term) ||
+                        n.detalle.toLowerCase().includes(term)
+                    );
+                }
+
+                this.loading = false;
+            },
+            error: (_error: HttpErrorResponse) => {
+                this.loading = false;
+            }
+        });
+    }
+
+    private buildImageUrl(n: PortalNoticia): string {
+        const raw = n.urlPortada || (n as any).imagenUrl || n.imagen;
+        if (!raw) {
+            return 'assets/logo.png';
+        }
+        return raw.startsWith('http') ? raw : `${environment.filesUrl}/uploads/noticias/${raw}`;
     }
     async ListaSituacion() {
         try {

--- a/Frontend/sakai-ng-master/src/app/biblioteca/web/portal-landing/components/portal-footer.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/web/portal-landing/components/portal-footer.ts
@@ -66,6 +66,14 @@ import { Router, RouterModule } from '@angular/router';
                 </div>
             </div>
         </div>
+        <div class="mt-8 flex flex-col items-center text-center">
+            <p>❓¿Tienes un reclamo?<br/>
+                <a href="https://libroreclamaciones.upsjb.edu.pe/#/formulario" class="underline text-pink-400">Ingresa aquí</a>
+            </p>
+            <a href="https://libroreclamaciones.upsjb.edu.pe/#/formulario">
+                <img src="assets/libroreclamaciones.png" class="h-12 mt-2" alt="Libro de Reclamaciones" />
+            </a>
+        </div>
         </div>
     `
 })

--- a/Frontend/sakai-ng-master/src/app/biblioteca/web/portal-landing/components/portal-recursos-electronicos.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/web/portal-landing/components/portal-recursos-electronicos.ts
@@ -24,20 +24,9 @@ import { RecursoDigitalDTO } from '../../../interfaces/RecursoDigitalDTO';
     template: ` <div id="portal-recursos-electronicos" class="py-6 px-6 lg:px-20 mt-8 mx-0 lg:mx-20">
     <div class="grid grid-cols-12 gap-4 justify-center">
 
-    <div class="col-span-12 flex justify-between items-center mt-20 mb-6">
-
+    <div class="col-span-12 flex justify-center items-center mt-20 mb-6">
     <div class="text-surface-900 dark:text-surface-0 font-normal mb-2 text-4xl">Recursos electr&oacute;nicos</div>
-
-            <button (click)="recursos()"
-    class="px-4 py-2 text-base font-medium border-2 border-gray-300 text-gray-700
-        bg-white rounded-full shadow-md transition-all duration-300
-        hover:bg-gray-100 hover:shadow-lg
-        dark:bg-primary dark:text-white dark:border-primary
-        dark:hover:bg-primary dark:hover:border-primary dark:hover:text-white">
-    Ver Todo →
-</button>
-
-        </div>
+    </div>
         <div class="col-span-12 md:col-span-12 lg:col-span-12 p-0 lg:pb-8 mt-6 lg:mt-0">
         <p-tabs [value]="activeIndex" scrollable (valueChange)="cambiarTipo($event)">
                             <p-tablist>
@@ -101,9 +90,6 @@ export class PortalRecursosElectronicos implements OnInit{
    }
 
 
-      recursos() {
-        this.router.navigate(['/recursos-electronicos']);
-      }
       cambiarTipo(index: any){
         const i = Number(index);
         this.activeIndex = i;


### PR DESCRIPTION
## Summary
- consumir noticias desde el backend con opción de búsqueda
- enlazar barra de búsqueda y filtrar noticias en el cliente
- transformar la respuesta del backend para mostrar noticias reales en la tabla
- centrar el encabezado de recursos electrónicos y quitar el botón Ver Todo
- reubicar el enlace al Libro de Reclamaciones en el pie de página

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` (falla: No inputs were found in tsconfig.spec.json)
- `npm run build` (falla: Application bundle generation failed)


------
https://chatgpt.com/codex/tasks/task_e_68911d3e96888329a5efa905e5f34b47