### PR TITLE
feat: enable remember me and password recovery

### DIFF
--- a/Backend/login-microsoft365/src/main/java/com/miapp/config/SecurityConfig.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/config/SecurityConfig.java
@@ -3,18 +3,17 @@ package com.miapp.config;
 
 import com.miapp.util.JwtUtil;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -27,6 +26,9 @@ import java.util.List;
 @RequiredArgsConstructor
 public class SecurityConfig {
 
+    @Value("${app.cors.allowed-origins}")
+    private List<String> allowedOrigins;
+
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http,  JwtUtil jwtUtil) throws Exception {
         JwtAuthenticationFilter jwtFilter = new JwtAuthenticationFilter(jwtUtil);
@@ -36,6 +38,9 @@ public class SecurityConfig {
                     .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll() // Permite OPTIONS en todas las rutas
                     .requestMatchers("/auth/login-microsoft",
                             "/auth/login",
+                            "/auth/forgot-password",
+                            "/reset-password",
+                            "/reset-password/**",
                             "/auth/register",
                             "/auth/listaPorRol/**",
                             "/auth/lista-activo",
@@ -80,7 +85,7 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(List.of("http://localhost:4200"));
+        configuration.setAllowedOrigins(allowedOrigins);
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(List.of("*"));
         configuration.setAllowCredentials(true);

--- a/Backend/login-microsoft365/src/main/java/com/miapp/controller/AuthController.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/controller/AuthController.java
@@ -5,7 +5,6 @@ import com.miapp.model.*;
 import com.miapp.repository.RolRepository;
 import com.miapp.service.*;
 import com.miapp.util.JwtUtil;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -26,6 +25,7 @@ public class AuthController {
     private final TipoDocumentoService tipoDocumentoService;
     private final EspecialidadService especialidadService;
     private final TipoMaterialService tipoMaterialService;
+    private final PasswordResetService passwordResetService;
 
     /**
      * Endpoint al que redirige Azure AD después de un login exitoso.
@@ -149,6 +149,20 @@ public class AuthController {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                     .body("Credenciales incorrectas");
         }
+    }
+
+    @PostMapping("/forgot-password")
+    public ResponseEntity<Map<String, String>> forgotPassword(@RequestBody Map<String, String> request) {
+        String email = request.get("email");
+        return usuarioService.buscarPorEmail(email)
+                .map(usuario -> {
+                    String token = passwordResetService.createToken(usuario);
+                    return ResponseEntity.ok(Map.of(
+                            "token", token,
+                            "message", "Token generado"));
+                })
+                .orElseGet(() -> ResponseEntity.status(HttpStatus.NOT_FOUND)
+                        .body(Map.of("message", "Correo no encontrado")));
     }
 
     @PostMapping("/refresh")

--- a/Backend/login-microsoft365/src/main/java/com/miapp/controller/PasswordResetController.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/controller/PasswordResetController.java
@@ -1,0 +1,51 @@
+package com.miapp.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import com.miapp.service.PasswordResetService;
+import com.miapp.service.UsuarioService;
+
+import java.util.Map;
+
+/**
+ * Endpoint público para procesar enlaces de restablecimiento de contraseña.
+ * Valida el token recibido y devuelve una respuesta sencilla.
+ * En una implementación real se debería verificar el token y permitir
+ * establecer una nueva contraseña.
+ */
+@RestController
+@RequiredArgsConstructor
+public class PasswordResetController {
+
+    private final PasswordResetService passwordResetService;
+    private final UsuarioService usuarioService;
+
+    @GetMapping("/reset-password")
+    public ResponseEntity<Map<String, String>> validateToken(@RequestParam String token) {
+        if (passwordResetService.isValid(token)) {
+            return ResponseEntity.ok(Map.of("message", "Token válido"));
+        }
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(Map.of("message", "Token inválido o expirado"));
+    }
+
+    @PostMapping("/reset-password")
+    public ResponseEntity<Map<String, String>> resetPassword(@RequestBody Map<String, String> request) {
+        String token = request.get("token");
+        String newPassword = request.get("password");
+        return passwordResetService.consumeToken(token)
+                .map(usuario -> {
+                    usuarioService.actualizarPassword(usuario, newPassword);
+                    return ResponseEntity.ok(Map.of("message", "Contraseña actualizada"));
+                })
+                .orElseGet(() -> ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                        .body(Map.of("message", "Token inválido o expirado")));
+    }
+}

--- a/Backend/login-microsoft365/src/main/java/com/miapp/model/PasswordResetToken.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/model/PasswordResetToken.java
@@ -1,0 +1,26 @@
+package com.miapp.model;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@Entity
+@Table(name = "PASSWORD_RESET_TOKEN")
+public class PasswordResetToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String token;
+
+    @Column(nullable = false)
+    private LocalDateTime expiryDate;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "IDUSUARIO")
+    private Usuario usuario;
+}

--- a/Backend/login-microsoft365/src/main/java/com/miapp/repository/PasswordResetTokenRepository.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/repository/PasswordResetTokenRepository.java
@@ -1,0 +1,12 @@
+package com.miapp.repository;
+
+import com.miapp.model.PasswordResetToken;
+import com.miapp.model.Usuario;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PasswordResetTokenRepository extends JpaRepository<PasswordResetToken, Long> {
+    Optional<PasswordResetToken> findByToken(String token);
+    void deleteByUsuario(Usuario usuario);
+}

--- a/Backend/login-microsoft365/src/main/java/com/miapp/service/PasswordResetService.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/service/PasswordResetService.java
@@ -1,0 +1,54 @@
+package com.miapp.service;
+
+import com.miapp.model.PasswordResetToken;
+import com.miapp.model.Usuario;
+import com.miapp.repository.PasswordResetTokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Servicio para gestionar tokens de restablecimiento de contraseña
+ * persistidos en base de datos con fecha de expiración.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PasswordResetService {
+
+    private final PasswordResetTokenRepository tokenRepository;
+
+    @Value("${app.reset-token-expiration-minutes:30}")
+    private long expirationMinutes;
+
+    public String createToken(Usuario usuario) {
+        tokenRepository.deleteByUsuario(usuario);
+        PasswordResetToken token = new PasswordResetToken();
+        token.setUsuario(usuario);
+        token.setToken(UUID.randomUUID().toString());
+        token.setExpiryDate(LocalDateTime.now().plusMinutes(expirationMinutes));
+        tokenRepository.save(token);
+        return token.getToken();
+    }
+
+    public boolean isValid(String token) {
+        return tokenRepository.findByToken(token)
+                .filter(t -> t.getExpiryDate().isAfter(LocalDateTime.now()))
+                .isPresent();
+    }
+
+    public Optional<Usuario> consumeToken(String token) {
+        return tokenRepository.findByToken(token)
+                .filter(t -> t.getExpiryDate().isAfter(LocalDateTime.now()))
+                .map(t -> {
+                    Usuario usuario = t.getUsuario();
+                    tokenRepository.delete(t);
+                    return usuario;
+                });
+    }
+}

--- a/Backend/login-microsoft365/src/main/java/com/miapp/service/UsuarioService.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/service/UsuarioService.java
@@ -115,6 +115,11 @@ public class UsuarioService {
         return Optional.empty();
     }
 
+    public void actualizarPassword(Usuario usuario, String nuevaPassword) {
+        usuario.setPassword(passwordEncoder.encode(nuevaPassword));
+        usuarioRepository.save(usuario);
+    }
+
     // Buscar usuario por email
     public Optional<Usuario> buscarPorEmail(String email) {
         return usuarioRepository.findByEmail(email);

--- a/Backend/login-microsoft365/src/main/resources/application.properties
+++ b/Backend/login-microsoft365/src/main/resources/application.properties
@@ -1,3 +1,5 @@
 jwt.secret=ChangeThisSecretKey
 jwt.expiration-ms=86400000
 jwt.refresh-expiration-ms=604800000
+app.reset-token-expiration-minutes=30
+app.cors.allowed-origins=http://localhost:4200

--- a/Frontend/sakai-ng-master/src/app/biblioteca/services/auth.service.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/services/auth.service.ts
@@ -255,6 +255,36 @@ loginMicrosoft() {
         );
     }
 
+  forgotPassword(email: string): Observable<any> {
+    return this.http.post<any>(`${this.apiUrl}/forgot-password`, { email })
+      .pipe(
+        catchError(err => {
+          console.error('Error en forgotPassword:', err);
+          throw err;
+        })
+      );
+  }
+
+  validateResetToken(token: string): Observable<any> {
+    return this.http.get<any>(`${environment.filesUrl}/reset-password`, { params: { token } })
+      .pipe(
+        catchError(err => {
+          console.error('Error en validateResetToken:', err);
+          throw err;
+        })
+      );
+  }
+
+  resetPassword(token: string, password: string): Observable<any> {
+    return this.http.post<any>(`${environment.filesUrl}/reset-password`, { token, password })
+      .pipe(
+        catchError(err => {
+          console.error('Error en resetPassword:', err);
+          throw err;
+        })
+      );
+  }
+
 // Registro manual: envía los datos del usuario
 register(userData: any): Observable<any> {
     return this.http.post<any>(`${this.apiUrl}/register`, userData);

--- a/Frontend/sakai-ng-master/src/app/pages/auth/auth.routes.ts
+++ b/Frontend/sakai-ng-master/src/app/pages/auth/auth.routes.ts
@@ -2,9 +2,11 @@ import { Routes } from '@angular/router';
 import { Access } from './access';
 import { Login } from './login';
 import { Error } from './error';
+import { ResetPassword } from './reset-password';
 
 export default [
     { path: 'access', component: Access },
     { path: 'error', component: Error },
-    { path: 'login', component: Login }
+    { path: 'login', component: Login },
+    { path: 'reset-password', component: ResetPassword }
 ] as Routes;

--- a/Frontend/sakai-ng-master/src/app/pages/auth/login.ts
+++ b/Frontend/sakai-ng-master/src/app/pages/auth/login.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
 import { ButtonModule } from 'primeng/button';
@@ -59,9 +59,9 @@ export interface LoginCredentials {
                             <div class="flex items-center justify-between mt-2 mb-8 gap-8">
                                 <div class="flex items-center">
                                     <p-checkbox [(ngModel)]="checked" id="rememberme1" binary class="mr-2"></p-checkbox>
-                                    <label for="rememberme1">Remember me</label>
+                                    <label for="rememberme1">Recordarme</label>
                                 </div>
-                                <span class="font-medium no-underline ml-2 text-right cursor-pointer text-primary">Forgot password?</span>
+                                <span class="font-medium no-underline ml-2 text-right cursor-pointer text-primary" (click)="onForgotPassword()">¿Olvidaste tu contraseña?</span>
                             </div>
                             <p-button label="Iniciar sesión" styleClass="w-full" (click)="onLogin()"></p-button>
                         </div>
@@ -71,7 +71,7 @@ export interface LoginCredentials {
         </div>
     `
 })
-export class Login {
+export class Login implements OnInit {
     email: string = '';
 
     password: string = '';
@@ -79,29 +79,60 @@ export class Login {
     checked: boolean = false;
     credentials: LoginCredentials = { email: '', password: '' };
 
-    constructor(private msalService:MsalService, private authService: AuthService, private router: Router) {}
+    constructor(private msalService: MsalService, private authService: AuthService, private router: Router) {}
 
      loginWithMicrosoft() {
         this.authService.loginMicrosoft();
      }
+    ngOnInit(): void {
+        const remembered = localStorage.getItem('rememberedEmail');
+        if (remembered) {
+            this.credentials.email = remembered;
+            this.checked = true;
+        }
+    }
 
     onLogin(): void {
-        // Aquí puedes agregar validaciones adicionales o confiar en el formulario
         if (this.credentials.email && this.credentials.password) {
-          this.authService.loginManual(this.credentials).subscribe({
-            next: (response) => {
-                this.authService.setAuthentication(response.token);
-                this.authService.openPendingResource();
-                this.router.navigate(['/main']);
+            this.authService.loginManual(this.credentials).subscribe({
+                next: (response) => {
+                    this.authService.setAuthentication(response.token);
+                    this.authService.openPendingResource();
+                    if (this.checked) {
+                        localStorage.setItem('rememberedEmail', this.credentials.email);
+                    } else {
+                        localStorage.removeItem('rememberedEmail');
+                    }
+                    this.router.navigate(['/main']);
+                },
+                error: (err) => {
+                    alert('Credenciales incorrectas');
+                    console.error('Error en login manual:', err);
+                }
+            });
+        } else {
+            alert('Por favor ingresa email y contraseña');
+        }
+    }
+
+    onForgotPassword(): void {
+        if (!this.credentials.email) {
+            alert('Ingresa tu email para recuperar la contraseña');
+            return;
+        }
+        this.authService.forgotPassword(this.credentials.email).subscribe({
+            next: (res) => {
+                if (res.token) {
+                    this.router.navigate(['/auth/reset-password'], { queryParams: { token: res.token } });
+                } else {
+                    alert(res.message || 'No se pudo generar el token');
+                }
             },
             error: (err) => {
-              alert('Credenciales incorrectas');
-              console.error('Error en login manual:', err);
+                const msg = err.error?.message || 'Error al solicitar recuperación de contraseña';
+                alert(msg);
             }
-          });
-        } else {
-          alert('Por favor ingresa email y contraseña');
-        }
-      }
+        });
+    }
 
 }

--- a/Frontend/sakai-ng-master/src/app/pages/auth/reset-password.ts
+++ b/Frontend/sakai-ng-master/src/app/pages/auth/reset-password.ts
@@ -1,0 +1,73 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute, RouterModule, Router } from '@angular/router';
+import { FormsModule } from '@angular/forms';
+import { CommonModule } from '@angular/common';
+import { ButtonModule } from 'primeng/button';
+import { PasswordModule } from 'primeng/password';
+import { RippleModule } from 'primeng/ripple';
+import { AppFloatingConfigurator } from '../../layout/component/app.floatingconfigurator';
+import { AuthService } from '../../biblioteca/services/auth.service';
+
+@Component({
+    selector: 'app-reset-password',
+    standalone: true,
+    imports: [ButtonModule, PasswordModule, FormsModule, RouterModule, RippleModule, AppFloatingConfigurator, CommonModule],
+    template: `
+        <app-floating-configurator />
+        <div class="bg-surface-50 dark:bg-surface-950 flex items-center justify-center min-h-screen min-w-[100vw] overflow-hidden">
+            <div class="w-full bg-surface-0 dark:bg-surface-900 p-8 sm:p-12" style="max-width:400px;border-radius:53px;">
+                <h2 class="text-center text-2xl font-medium mb-6">Restablecer contraseña</h2>
+                <div *ngIf="!valid">
+                    <p class="text-center text-red-500">{{message || 'Token inválido o expirado'}}</p>
+                </div>
+                <div *ngIf="valid">
+                    <label class="block mb-2">Nueva contraseña</label>
+                    <p-password [(ngModel)]="password" placeholder="Nueva contraseña" [toggleMask]="true" [feedback]="false" styleClass="mb-4" [fluid]="true"></p-password>
+                    <label class="block mb-2">Confirmar contraseña</label>
+                    <p-password [(ngModel)]="confirm" placeholder="Confirmar contraseña" [toggleMask]="true" [feedback]="false" styleClass="mb-4" [fluid]="true"></p-password>
+                    <p-button label="Actualizar contraseña" styleClass="w-full" (click)="onSubmit()"></p-button>
+                </div>
+            </div>
+        </div>
+    `
+})
+export class ResetPassword implements OnInit {
+    token: string = '';
+    password: string = '';
+    confirm: string = '';
+    valid: boolean = false;
+    message: string | null = null;
+
+    constructor(private route: ActivatedRoute, private authService: AuthService, private router: Router) {}
+
+    ngOnInit(): void {
+        this.route.queryParamMap.subscribe(params => {
+            this.token = params.get('token') || '';
+            if (this.token) {
+                this.authService.validateResetToken(this.token).subscribe({
+                    next: () => this.valid = true,
+                    error: err => this.message = err.error?.message || 'Token inválido o expirado'
+                });
+            } else {
+                this.message = 'Token inválido o expirado';
+            }
+        });
+    }
+
+    onSubmit(): void {
+        if (this.password !== this.confirm) {
+            alert('Las contraseñas no coinciden');
+            return;
+        }
+        this.authService.resetPassword(this.token, this.password).subscribe({
+            next: res => {
+                alert(res.message || 'Contraseña actualizada');
+                this.router.navigate(['/auth/login']);
+            },
+            error: err => {
+                const msg = err.error?.message || 'Error al actualizar contraseña';
+                alert(msg);
+            }
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- Evitar envío de correo al recuperar contraseña devolviendo el token al cliente
- Simplificar validación y actualización de contraseña en el backend
- Navegar a la interfaz de restablecimiento usando el token generado

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` (falla: error TS18003, No inputs were found in config file)
- `mvn -q test` (falla: Non-resolvable parent POM, Network is unreachable)


------
https://chatgpt.com/codex/tasks/task_e_68915e369bec8329b607a62002f45ee6