### PR TITLE
feat: localize dashboard and load real data

### DIFF
--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/dashboard/components/bestsellingwidget.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/dashboard/components/bestsellingwidget.ts
@@ -9,7 +9,7 @@ import { MenuModule } from 'primeng/menu';
     imports: [CommonModule, ButtonModule, MenuModule],
     template: ` <div class="card">
         <div class="flex justify-between items-center mb-6">
-            <div class="font-semibold text-xl">Best Selling Products</div>
+            <div class="font-semibold text-xl">Productos más vendidos</div>
             <div>
                 <button pButton type="button" icon="pi pi-ellipsis-v" class="p-button-rounded p-button-text p-button-plain" (click)="menu.toggle($event)"></button>
                 <p-menu #menu [popup]="true" [model]="items"></p-menu>
@@ -95,7 +95,7 @@ export class BestSellingWidget {
     menu = null;
 
     items = [
-        { label: 'Add New', icon: 'pi pi-fw pi-plus' },
-        { label: 'Remove', icon: 'pi pi-fw pi-trash' }
+        { label: 'Agregar', icon: 'pi pi-fw pi-plus' },
+        { label: 'Eliminar', icon: 'pi pi-fw pi-trash' }
     ];
 }

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/dashboard/components/notificationswidget.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/dashboard/components/notificationswidget.ts
@@ -8,14 +8,14 @@ import { MenuModule } from 'primeng/menu';
     imports: [ButtonModule, MenuModule],
     template: `<div class="card">
         <div class="flex items-center justify-between mb-6">
-            <div class="font-semibold text-xl">Notifications</div>
+            <div class="font-semibold text-xl">Notificaciones</div>
             <div>
                 <button pButton type="button" icon="pi pi-ellipsis-v" class="p-button-rounded p-button-text p-button-plain" (click)="menu.toggle($event)"></button>
                 <p-menu #menu [popup]="true" [model]="items"></p-menu>
             </div>
         </div>
 
-        <span class="block text-muted-color font-medium mb-4">TODAY</span>
+        <span class="block text-muted-color font-medium mb-4">HOY</span>
         <ul class="p-0 mx-0 mt-0 mb-6 list-none">
             <li class="flex items-center py-2 border-b border-surface">
                 <div class="w-12 h-12 flex items-center justify-center bg-blue-100 dark:bg-blue-400/10 rounded-full mr-4 shrink-0">
@@ -34,7 +34,7 @@ import { MenuModule } from 'primeng/menu';
             </li>
         </ul>
 
-        <span class="block text-muted-color font-medium mb-4">YESTERDAY</span>
+        <span class="block text-muted-color font-medium mb-4">AYER</span>
         <ul class="p-0 m-0 list-none mb-6">
             <li class="flex items-center py-2 border-b border-surface">
                 <div class="w-12 h-12 flex items-center justify-center bg-blue-100 dark:bg-blue-400/10 rounded-full mr-4 shrink-0">
@@ -55,7 +55,7 @@ import { MenuModule } from 'primeng/menu';
                 </span>
             </li>
         </ul>
-        <span class="block text-muted-color font-medium mb-4">LAST WEEK</span>
+        <span class="block text-muted-color font-medium mb-4">LA SEMANA PASADA</span>
         <ul class="p-0 m-0 list-none">
             <li class="flex items-center py-2 border-b border-surface">
                 <div class="w-12 h-12 flex items-center justify-center bg-green-100 dark:bg-green-400/10 rounded-full mr-4 shrink-0">
@@ -74,7 +74,7 @@ import { MenuModule } from 'primeng/menu';
 })
 export class NotificationsWidget {
     items = [
-        { label: 'Add New', icon: 'pi pi-fw pi-plus' },
-        { label: 'Remove', icon: 'pi pi-fw pi-trash' }
+        { label: 'Agregar', icon: 'pi pi-fw pi-plus' },
+        { label: 'Eliminar', icon: 'pi pi-fw pi-trash' }
     ];
 }

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/dashboard/components/recentsaleswidget.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/dashboard/components/recentsaleswidget.ts
@@ -3,45 +3,44 @@ import { RippleModule } from 'primeng/ripple';
 import { TableModule } from 'primeng/table';
 import { ButtonModule } from 'primeng/button';
 import { CommonModule } from '@angular/common';
-import { ProductService, Product } from '../../../../pages/service/product.service';
+import { DashboardService } from '../../../services/dashboard.service';
 
 @Component({
     standalone: true,
     selector: 'app-recent-sales-widget',
     imports: [CommonModule, TableModule, ButtonModule, RippleModule],
     template: `<div class="card !mb-8">
-        <div class="font-semibold text-xl mb-4">Recent Sales</div>
-        <p-table [value]="products" [paginator]="true" [rows]="5" responsiveLayout="scroll">
+        <div class="font-semibold text-xl mb-4">Ventas recientes</div>
+        <p-table [value]="productos" [paginator]="true" [rows]="5" responsiveLayout="scroll">
             <ng-template #header>
                 <tr>
-                    <th>Image</th>
-                    <th pSortableColumn="name">Name <p-sortIcon field="name"></p-sortIcon></th>
-                    <th pSortableColumn="price">Price <p-sortIcon field="price"></p-sortIcon></th>
-                    <th>View</th>
+                    <th>Imagen</th>
+                    <th pSortableColumn="nombre">Nombre <p-sortIcon field="nombre"></p-sortIcon></th>
+                    <th pSortableColumn="precio">Precio <p-sortIcon field="precio"></p-sortIcon></th>
+                    <th>Ver</th>
                 </tr>
             </ng-template>
-            <ng-template #body let-product>
+            <ng-template #body let-producto>
                 <tr>
                     <td style="width: 15%; min-width: 5rem;">
-                        <img src="https://primefaces.org/cdn/primevue/images/product/{{ product.image }}" class="shadow-lg" alt="{{ product.name }}" width="50" />
+                        <img [src]="producto.imagen" class="shadow-lg" [alt]="producto.nombre" width="50" />
                     </td>
-                    <td style="width: 35%; min-width: 7rem;">{{ product.name }}</td>
-                    <td style="width: 35%; min-width: 8rem;">{{ product.price | currency: 'USD' }}</td>
+                    <td style="width: 35%; min-width: 7rem;">{{ producto.nombre }}</td>
+                    <td style="width: 35%; min-width: 8rem;">{{ producto.precio | currency: 'USD' }}</td>
                     <td style="width: 15%;">
                         <button pButton pRipple type="button" icon="pi pi-search" class="p-button p-component p-button-text p-button-icon-only"></button>
                     </td>
                 </tr>
             </ng-template>
         </p-table>
-    </div>`,
-    providers: [ProductService]
+    </div>`
 })
 export class RecentSalesWidget {
-    products!: Product[];
+    productos: any[] = [];
 
-    constructor(private productService: ProductService) {}
+    constructor(private dashboardService: DashboardService) {}
 
     ngOnInit() {
-        this.productService.getProductsSmall().then((data) => (this.products = data));
+        this.dashboardService.recientes().subscribe((res) => (this.productos = res));
     }
 }

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/dashboard/components/revenuestreamwidget.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/dashboard/components/revenuestreamwidget.ts
@@ -2,13 +2,14 @@ import { Component } from '@angular/core';
 import { ChartModule } from 'primeng/chart';
 import { debounceTime, Subscription } from 'rxjs';
 import { LayoutService } from '../../../../layout/service/layout.service';
+import { DashboardService } from '../../../services/dashboard.service';
 
 @Component({
     standalone: true,
     selector: 'app-revenue-stream-widget',
     imports: [ChartModule],
     template: `<div class="card !mb-8">
-        <div class="font-semibold text-xl mb-4">Revenue Stream</div>
+        <div class="font-semibold text-xl mb-4">Flujo de ingresos</div>
         <p-chart type="bar" [data]="chartData" [options]="chartOptions" class="h-80" />
     </div>`
 })
@@ -19,90 +20,78 @@ export class RevenueStreamWidget {
 
     subscription!: Subscription;
 
-    constructor(public layoutService: LayoutService) {
+    constructor(public layoutService: LayoutService, private dashboardService: DashboardService) {
         this.subscription = this.layoutService.configUpdate$.pipe(debounceTime(25)).subscribe(() => {
-            this.initChart();
+            this.cargarDatos();
         });
     }
 
     ngOnInit() {
-        this.initChart();
+        this.cargarDatos();
     }
 
-    initChart() {
+    private cargarDatos() {
         const documentStyle = getComputedStyle(document.documentElement);
         const textColor = documentStyle.getPropertyValue('--text-color');
         const borderColor = documentStyle.getPropertyValue('--surface-border');
         const textMutedColor = documentStyle.getPropertyValue('--text-color-secondary');
 
-        this.chartData = {
-            labels: ['Q1', 'Q2', 'Q3', 'Q4'],
-            datasets: [
-                {
-                    type: 'bar',
-                    label: 'Subscriptions',
-                    backgroundColor: documentStyle.getPropertyValue('--p-primary-400'),
-                    data: [4000, 10000, 15000, 4000],
-                    barThickness: 32
-                },
-                {
-                    type: 'bar',
-                    label: 'Advertising',
-                    backgroundColor: documentStyle.getPropertyValue('--p-primary-300'),
-                    data: [2100, 8400, 2400, 7500],
-                    barThickness: 32
-                },
-                {
-                    type: 'bar',
-                    label: 'Affiliate',
-                    backgroundColor: documentStyle.getPropertyValue('--p-primary-200'),
-                    data: [4100, 5200, 3400, 7400],
-                    borderRadius: {
-                        topLeft: 8,
-                        topRight: 8,
-                        bottomLeft: 0,
-                        bottomRight: 0
+        this.dashboardService.ingresos().subscribe((res) => {
+            this.chartData = {
+                labels: res.labels,
+                datasets: [
+                    {
+                        type: 'bar',
+                        label: 'Biblioteca',
+                        backgroundColor: documentStyle.getPropertyValue('--p-primary-400'),
+                        data: res.biblioteca,
+                        barThickness: 32
                     },
-                    borderSkipped: false,
-                    barThickness: 32
-                }
-            ]
-        };
+                    {
+                        type: 'bar',
+                        label: 'Cómputo',
+                        backgroundColor: documentStyle.getPropertyValue('--p-primary-300'),
+                        data: res.computo,
+                        barThickness: 32
+                    }
+                ]
+            };
 
-        this.chartOptions = {
-            maintainAspectRatio: false,
-            aspectRatio: 0.8,
-            plugins: {
-                legend: {
-                    labels: {
-                        color: textColor
-                    }
-                }
-            },
-            scales: {
-                x: {
-                    stacked: true,
-                    ticks: {
-                        color: textMutedColor
-                    },
-                    grid: {
-                        color: 'transparent',
-                        borderColor: 'transparent'
+            this.chartOptions = {
+                maintainAspectRatio: false,
+                aspectRatio: 0.8,
+                plugins: {
+                    legend: {
+                        labels: {
+                            color: textColor
+                        }
                     }
                 },
-                y: {
-                    stacked: true,
-                    ticks: {
-                        color: textMutedColor
+                scales: {
+                    x: {
+                        stacked: true,
+                        ticks: {
+                            color: textMutedColor
+                        },
+                        grid: {
+                            color: 'transparent',
+                            borderColor: 'transparent'
+                        }
                     },
-                    grid: {
-                        color: borderColor,
-                        borderColor: 'transparent',
-                        drawTicks: false
+                    y: {
+                        stacked: true,
+                        ticks: {
+                            color: textMutedColor
+                        },
+                        grid: {
+                            color: borderColor,
+                            borderColor: 'transparent',
+                            drawTicks: false
+                        }
                     }
                 }
-            }
-        };
+            };
+        });
     }
 
     ngOnDestroy() {

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/dashboard/components/statswidget.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/dashboard/components/statswidget.ts
@@ -1,69 +1,99 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { DashboardService } from '../../../services/dashboard.service';
+
+interface Estadisticas {
+  materiales: number;
+  prestadosMateriales: number;
+  equipos: number;
+  prestadosEquipos: number;
+  usuarios: number;
+  nuevosUsuarios: number;
+  comentarios: number;
+  comentariosRespondidos: number;
+}
 
 @Component({
     standalone: true,
     selector: 'app-stats-widget',
     imports: [CommonModule],
     template: `
-    
-    <div class="col-span-12 lg:col-span-6 xl:col-span-3">
+        <div class="col-span-12 lg:col-span-6 xl:col-span-3">
             <div class="card mb-0">
                 <div class="flex justify-between mb-4">
                     <div>
-                        <span class="block text-muted-color font-medium mb-4">Material Bibliografico</span>
-                        <div class="text-surface-900 dark:text-surface-0 font-medium text-xl">152</div>
+                        <span class="block text-muted-color font-medium mb-4">Material bibliográfico</span>
+                        <div class="text-surface-900 dark:text-surface-0 font-medium text-xl">{{ datos.materiales }}</div>
                     </div>
                     <div class="flex items-center justify-center bg-blue-100 dark:bg-blue-400/10 rounded-border" style="width: 2.5rem; height: 2.5rem">
                         <i class="pi pi-shopping-cart text-blue-500 !text-xl"></i>
                     </div>
                 </div>
-                <span class="text-primary font-medium">24 Prestados</span>
+                <span class="text-primary font-medium">{{ datos.prestadosMateriales }} </span>
+                <span class="text-muted-color">prestados</span>
             </div>
         </div>
         <div class="col-span-12 lg:col-span-6 xl:col-span-3">
             <div class="card mb-0">
                 <div class="flex justify-between mb-4">
                     <div>
-                        <span class="block text-muted-color font-medium mb-4">Equipos de c&oacute;mputo</span>
-                        <div class="text-surface-900 dark:text-surface-0 font-medium text-xl">100</div>
+                        <span class="block text-muted-color font-medium mb-4">Equipos de cómputo</span>
+                        <div class="text-surface-900 dark:text-surface-0 font-medium text-xl">{{ datos.equipos }}</div>
                     </div>
                     <div class="flex items-center justify-center bg-orange-100 dark:bg-orange-400/10 rounded-border" style="width: 2.5rem; height: 2.5rem">
-                        <i class="pi pi-dollar text-orange-500 !text-xl"></i>
+                        <i class="pi pi-desktop text-orange-500 !text-xl"></i>
                     </div>
                 </div>
-                <span class="text-primary font-medium">52 Prestados</span>
+                <span class="text-primary font-medium">{{ datos.prestadosEquipos }} </span>
+                <span class="text-muted-color">prestados</span>
             </div>
         </div>
         <div class="col-span-12 lg:col-span-6 xl:col-span-3">
             <div class="card mb-0">
                 <div class="flex justify-between mb-4">
                     <div>
-                        <span class="block text-muted-color font-medium mb-4">Customers</span>
-                        <div class="text-surface-900 dark:text-surface-0 font-medium text-xl">28441</div>
+                        <span class="block text-muted-color font-medium mb-4">Usuarios</span>
+                        <div class="text-surface-900 dark:text-surface-0 font-medium text-xl">{{ datos.usuarios }}</div>
                     </div>
                     <div class="flex items-center justify-center bg-cyan-100 dark:bg-cyan-400/10 rounded-border" style="width: 2.5rem; height: 2.5rem">
                         <i class="pi pi-users text-cyan-500 !text-xl"></i>
                     </div>
                 </div>
-                <span class="text-primary font-medium">520 </span>
-                <span class="text-muted-color">newly registered</span>
+                <span class="text-primary font-medium">{{ datos.nuevosUsuarios }} </span>
+                <span class="text-muted-color">registrados</span>
             </div>
         </div>
         <div class="col-span-12 lg:col-span-6 xl:col-span-3">
             <div class="card mb-0">
                 <div class="flex justify-between mb-4">
                     <div>
-                        <span class="block text-muted-color font-medium mb-4">Comments</span>
-                        <div class="text-surface-900 dark:text-surface-0 font-medium text-xl">152 Unread</div>
+                        <span class="block text-muted-color font-medium mb-4">Comentarios</span>
+                        <div class="text-surface-900 dark:text-surface-0 font-medium text-xl">{{ datos.comentarios }}</div>
                     </div>
                     <div class="flex items-center justify-center bg-purple-100 dark:bg-purple-400/10 rounded-border" style="width: 2.5rem; height: 2.5rem">
                         <i class="pi pi-comment text-purple-500 !text-xl"></i>
                     </div>
                 </div>
-                <span class="text-primary font-medium">85 </span>
-                <span class="text-muted-color">responded</span>
+                <span class="text-primary font-medium">{{ datos.comentariosRespondidos }} </span>
+                <span class="text-muted-color">respondidos</span>
             </div>
         </div>`
 })
-export class StatsWidget {}
+export class StatsWidget {
+    datos: Estadisticas = {
+        materiales: 0,
+        prestadosMateriales: 0,
+        equipos: 0,
+        prestadosEquipos: 0,
+        usuarios: 0,
+        nuevosUsuarios: 0,
+        comentarios: 0,
+        comentariosRespondidos: 0
+    };
+
+    constructor(private dashboardService: DashboardService) {}
+
+    ngOnInit() {
+        this.dashboardService.stats().subscribe((res) => (this.datos = res));
+    }
+}

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/dashboard/dashboard.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/dashboard/dashboard.ts
@@ -47,7 +47,7 @@ export class Dashboard {
     }
   async ListaSede() {
     try {
-      const result: any = await this.genericoService.sedes_get('conf/tipo-lista').toPromise();
+      const result: any = await this.genericoService.sedes_get('sede/lista-activo').toPromise();
       if (result.status === "0") {
         
         this.dataSedesFiltro = result.data;

--- a/Frontend/sakai-ng-master/src/app/biblioteca/services/dashboard.service.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/services/dashboard.service.ts
@@ -1,0 +1,39 @@
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { AuthService } from './auth.service';
+import { environment } from '../../../environments/environment';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class DashboardService {
+  private apiUrl: string;
+
+  constructor(private http: HttpClient, private authService: AuthService) {
+    this.apiUrl = environment.apiUrl;
+  }
+
+  private authHeaders() {
+    const token = this.authService.getToken();
+    return new HttpHeaders().set('Authorization', `Bearer ${token}`);
+  }
+
+  stats(): Observable<any> {
+    return this.http.get<any>(`${this.apiUrl}/api/dashboard/estadisticas`, {
+      headers: this.authHeaders()
+    });
+  }
+
+  ingresos(): Observable<any> {
+    return this.http.get<any>(`${this.apiUrl}/api/dashboard/ingresos`, {
+      headers: this.authHeaders()
+    });
+  }
+
+  recientes(): Observable<any[]> {
+    return this.http.get<any[]>(`${this.apiUrl}/api/recursos/recientes`, {
+      headers: this.authHeaders()
+    });
+  }
+}

--- a/Frontend/sakai-ng-master/src/app/biblioteca/services/generico.service.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/services/generico.service.ts
@@ -14,11 +14,15 @@ export class GenericoService {
     this.apiUrl = environment.apiUrl;
   }
 
-  conf_event_get(url: string):Observable<any>{
-    /*return this.http.get<any[]>(`${this.apiUrl}/${modulo}`
-    ,{ headers: new HttpHeaders().set('Authorization',`Bearer ${this.authService.getToken()}`)}
-    );*/
-    return this.http.get<any[]>(`${environment.apiUrl}/${url}`);
+  private authHeaders() {
+    const token = this.authService.getToken();
+    return new HttpHeaders().set('Authorization', `Bearer ${token}`);
+  }
+
+  conf_event_get(url: string): Observable<any> {
+    return this.http.get<any[]>(`${this.apiUrl}/${url}`,
+      { headers: this.authHeaders() }
+    );
   }
   conf_event_post(request: any,modulo: any):Observable<any>{
     return this.http.post<any>(`${this.apiUrl}/${modulo}`
@@ -47,11 +51,10 @@ export class GenericoService {
     );
   }
 
-  roles_get(url: string):Observable<any>{
-    /*return this.http.get<any[]>(`${this.apiUrl}/${modulo}`
-    ,{ headers: new HttpHeaders().set('Authorization',`Bearer ${this.authService.getToken()}`)}
-    );*/
-    return this.http.get<any[]>(`${environment.apiUrl}/${url}`);
+  roles_get(url: string): Observable<any> {
+    return this.http.get<any[]>(`${this.apiUrl}/${url}`,
+      { headers: this.authHeaders() }
+    );
   }
 
   sedes_get(modulo: any):Observable<any>{
@@ -61,18 +64,16 @@ export class GenericoService {
 //     return this.http.get<any[]>('assets/demo/biblioteca/sedes.json');
   }
 
-  tipodocumento_get(modulo: any):Observable<any>{
-    /*return this.http.get<any[]>(`${this.apiUrl}/${modulo}`
-    ,{ headers: new HttpHeaders().set('Authorization',`Bearer ${this.authService.getToken()}`)}
-    );*/
-    return this.http.get<any[]>('assets/demo/biblioteca/tipos-documento.json');
+  tipodocumento_get(modulo: any): Observable<any> {
+    return this.http.get<any[]>(`${this.apiUrl}/${modulo}`,
+      { headers: this.authHeaders() }
+    );
   }
 
-  tipo_get(modulo: any):Observable<any>{
-    /*return this.http.get<any[]>(`${this.apiUrl}/${modulo}`
-    ,{ headers: new HttpHeaders().set('Authorization',`Bearer ${this.authService.getToken()}`)}
-    );*/
-    return this.http.get<any[]>('assets/demo/biblioteca/tipo.json');
+  tipo_get(modulo: any): Observable<any> {
+    return this.http.get<any[]>(`${this.apiUrl}/${modulo}`,
+      { headers: this.authHeaders() }
+    );
   }
 
   tiporecurso_get(modulo: any):Observable<any>{
@@ -82,10 +83,9 @@ export class GenericoService {
 //     return this.http.get<any[]>('assets/demo/biblioteca/tipos-recurso.json');
   }
 
-  categoriarecurso_get(modulo: any):Observable<any>{
-    /*return this.http.get<any[]>(`${this.apiUrl}/${modulo}`
-    ,{ headers: new HttpHeaders().set('Authorization',`Bearer ${this.authService.getToken()}`)}
-    );*/
-    return this.http.get<any[]>('assets/demo/biblioteca/categoria-recurso.json');
+  categoriarecurso_get(modulo: any): Observable<any> {
+    return this.http.get<any[]>(`${this.apiUrl}/${modulo}`,
+      { headers: this.authHeaders() }
+    );
   }
 }

--- a/Frontend/sakai-ng-master/src/app/biblioteca/services/ocurrencias.service.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/services/ocurrencias.service.ts
@@ -9,15 +9,19 @@ import { environment } from '../../../environments/environment';
 })
 export class OcurrenciasService {
   private apiUrl:string;
-  constructor(private http:HttpClient, private authService:AuthService) { 
+  constructor(private http:HttpClient, private authService:AuthService) {
     this.apiUrl = environment.apiUrl;
   }
-  
-  conf_event_get(modulo: any):Observable<any>{
-    /*return this.http.get<any[]>(`${this.apiUrl}/${modulo}`
-    ,{ headers: new HttpHeaders().set('Authorization',`Bearer ${this.authService.getToken()}`)}
-    );*/
-    return this.http.get<any[]>('assets/demo/biblioteca/data.json');
+
+  private authHeaders() {
+    const token = this.authService.getToken();
+    return new HttpHeaders().set('Authorization', `Bearer ${token}`);
+  }
+
+  conf_event_get(modulo: any): Observable<any> {
+    return this.http.get<any[]>(`${this.apiUrl}/${modulo}`,
+      { headers: this.authHeaders() }
+    );
   }
   conf_event_post(request: any,modulo: any):Observable<any>{
     return this.http.post<any>(`${this.apiUrl}/${modulo}`
@@ -88,23 +92,20 @@ export class OcurrenciasService {
     );
   }
 
-  api_ocurrencias_prestamos_lista(modulo: any):Observable<any>{
-    /*return this.http.get<any[]>(`${this.apiUrl}/${modulo}`
-    ,{ headers: new HttpHeaders().set('Authorization',`Bearer ${this.authService.getToken()}`)}
-    );*/
-    return this.http.get<any[]>('assets/demo/biblioteca/ocurrenciasPrestamos.json');
+  api_ocurrencias_prestamos_lista(modulo: any): Observable<any> {
+    return this.http.get<any[]>(`${this.apiUrl}/${modulo}`,
+      { headers: this.authHeaders() }
+    );
   }
-  api_prestamos_lista(modulo: any):Observable<any>{
-    /*return this.http.get<any[]>(`${this.apiUrl}/${modulo}`
-    ,{ headers: new HttpHeaders().set('Authorization',`Bearer ${this.authService.getToken()}`)}
-    );*/
-    return this.http.get<any[]>('assets/demo/biblioteca/prestamos.json');
+  api_prestamos_lista(modulo: any): Observable<any> {
+    return this.http.get<any[]>(`${this.apiUrl}/${modulo}`,
+      { headers: this.authHeaders() }
+    );
   }
-  api_situacion_lista(modulo: any):Observable<any>{
-    /*return this.http.get<any[]>(`${this.apiUrl}/${modulo}`
-    ,{ headers: new HttpHeaders().set('Authorization',`Bearer ${this.authService.getToken()}`)}
-    );*/
-    return this.http.get<any[]>('assets/demo/biblioteca/situacionOcurrencia.json');
+  api_situacion_lista(modulo: any): Observable<any> {
+    return this.http.get<any[]>(`${this.apiUrl}/${modulo}`,
+      { headers: this.authHeaders() }
+    );
   }
   
   api_constancias(search: string):Observable<any>{

--- a/Frontend/sakai-ng-master/src/app/biblioteca/services/portal.service.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/services/portal.service.ts
@@ -36,11 +36,10 @@ export class PortalService {
     const token = this.authService.getToken();
     return new HttpHeaders().set('Authorization', `Bearer ${token}`);
   }
-  conf_event_get(modulo: any):Observable<any>{
-    /*return this.http.get<any[]>(`${this.apiUrl}/${modulo}`
-    ,{ headers: new HttpHeaders().set('Authorization',`Bearer ${this.authService.getToken()}`)}
-    );*/
-    return this.http.get<any[]>('assets/demo/biblioteca/data.json');
+  conf_event_get(modulo: any): Observable<any> {
+    return this.http.get<any[]>(`${this.apiUrl}/${modulo}`,
+      { headers: this.authHeaders() }
+    );
   }
   conf_event_post(request: any,modulo: any):Observable<any>{
     return this.http.post<any>(`${this.apiUrl}/${modulo}`
@@ -62,36 +61,31 @@ export class PortalService {
         }
     );
   }
-  api_libros_electronicos_lista(modulo: any):Observable<any>{
-    /*return this.http.get<any[]>(`${this.apiUrl}/${modulo}`
-    ,{ headers: new HttpHeaders().set('Authorization',`Bearer ${this.authService.getToken()}`)}
-    );*/
-    return this.http.get<any[]>('assets/demo/biblioteca/librosElectronicos.json');
+  api_libros_electronicos_lista(modulo: any): Observable<any> {
+    return this.http.get<any[]>(`${this.apiUrl}/${modulo}`,
+      { headers: this.authHeaders() }
+    );
   }
 
-  tipo_get(modulo: any):Observable<any>{
-    /*return this.http.get<any[]>(`${this.apiUrl}/${modulo}`
-    ,{ headers: new HttpHeaders().set('Authorization',`Bearer ${this.authService.getToken()}`)}
-    );*/
-    return this.http.get<any[]>('assets/demo/biblioteca/tipoRecursosElectronicos.json');
+  tipo_get(modulo: any): Observable<any> {
+    return this.http.get<any[]>(`${this.apiUrl}/${modulo}`,
+      { headers: this.authHeaders() }
+    );
   }
-  api_horarios_lista(modulo: any):Observable<any>{
-    /*return this.http.get<any[]>(`${this.apiUrl}/${modulo}`
-    ,{ headers: new HttpHeaders().set('Authorization',`Bearer ${this.authService.getToken()}`)}
-    );*/
-    return this.http.get<any[]>('assets/demo/biblioteca/portalHorarios.json');
+  api_horarios_lista(modulo: any): Observable<any> {
+    return this.http.get<any[]>(`${this.apiUrl}/${modulo}`,
+      { headers: this.authHeaders() }
+    );
   }
-  api_catalogo_enlinea(modulo: any):Observable<any>{
-    /*return this.http.get<any[]>(`${this.apiUrl}/${modulo}`
-    ,{ headers: new HttpHeaders().set('Authorization',`Bearer ${this.authService.getToken()}`)}
-    );*/
-    return this.http.get<any[]>('assets/demo/biblioteca/portalCatalogo.json');
+  api_catalogo_enlinea(modulo: any): Observable<any> {
+    return this.http.get<any[]>(`${this.apiUrl}/${modulo}`,
+      { headers: this.authHeaders() }
+    );
   }
-  api_recursos_electronicos(modulo: any):Observable<any>{
-    /*return this.http.get<any[]>(`${this.apiUrl}/${modulo}`
-    ,{ headers: new HttpHeaders().set('Authorization',`Bearer ${this.authService.getToken()}`)}
-    );*/
-    return this.http.get<any[]>('assets/demo/biblioteca/portalRecursosElectronicos.json');
+  api_recursos_electronicos(modulo: any): Observable<any> {
+    return this.http.get<any[]>(`${this.apiUrl}/${modulo}`,
+      { headers: this.authHeaders() }
+    );
   }
   api_noticias(busqueda?: string): Observable<ListDTO<PortalNoticia[]>> {
     const params = busqueda ? `?q=${encodeURIComponent(busqueda)}` : '';

--- a/Frontend/sakai-ng-master/src/app/biblioteca/services/recursos.service.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/services/recursos.service.ts
@@ -9,15 +9,19 @@ import { environment } from '../../../environments/environment';
 })
 export class RecursosService {
   private apiUrl:string;
-  constructor(private http:HttpClient, private authService:AuthService) { 
+  constructor(private http:HttpClient, private authService:AuthService) {
     this.apiUrl = environment.apiUrl;
   }
-  
-  conf_event_get(modulo: any):Observable<any>{
-    /*return this.http.get<any[]>(`${this.apiUrl}/${modulo}`
-    ,{ headers: new HttpHeaders().set('Authorization',`Bearer ${this.authService.getToken()}`)}
-    );*/
-    return this.http.get<any[]>('assets/demo/biblioteca/data.json');
+
+  private authHeaders() {
+    const token = this.authService.getToken();
+    return new HttpHeaders().set('Authorization', `Bearer ${token}`);
+  }
+
+  conf_event_get(modulo: any): Observable<any> {
+    return this.http.get<any[]>(`${this.apiUrl}/${modulo}`,
+      { headers: this.authHeaders() }
+    );
   }
   conf_event_post(request: any,modulo: any):Observable<any>{
     return this.http.post<any>(`${this.apiUrl}/${modulo}`
@@ -39,52 +43,44 @@ export class RecursosService {
         }
     );
   }
-  api_recursos_lista(modulo: any):Observable<any>{
-    /*return this.http.get<any[]>(`${this.apiUrl}/${modulo}`
-    ,{ headers: new HttpHeaders().set('Authorization',`Bearer ${this.authService.getToken()}`)}
-    );*/
-    return this.http.get<any[]>('assets/demo/biblioteca/recursos.json');
+  api_recursos_lista(modulo: any): Observable<any> {
+    return this.http.get<any[]>(`${this.apiUrl}/${modulo}`,
+      { headers: this.authHeaders() }
+    );
   }
-  api_ejemplares_lista(modulo: any):Observable<any>{
-    /*return this.http.get<any[]>(`${this.apiUrl}/${modulo}`
-    ,{ headers: new HttpHeaders().set('Authorization',`Bearer ${this.authService.getToken()}`)}
-    );*/
-    return this.http.get<any[]>('assets/demo/biblioteca/ejemplar.json');
+  api_ejemplares_lista(modulo: any): Observable<any> {
+    return this.http.get<any[]>(`${this.apiUrl}/${modulo}`,
+      { headers: this.authHeaders() }
+    );
   }
-  filtros(modulo: any):Observable<any>{
-    /*return this.http.get<any[]>(`${this.apiUrl}/${modulo}`
-    ,{ headers: new HttpHeaders().set('Authorization',`Bearer ${this.authService.getToken()}`)}
-    );*/
-    return this.http.get<any[]>('assets/demo/biblioteca/opcionFiltroBiblioteca.json');
+  filtros(modulo: any): Observable<any> {
+    return this.http.get<any[]>(`${this.apiUrl}/${modulo}`,
+      { headers: this.authHeaders() }
+    );
   }
-  lista_estados(modulo: any):Observable<any>{
-    /*return this.http.get<any[]>(`${this.apiUrl}/${modulo}`
-    ,{ headers: new HttpHeaders().set('Authorization',`Bearer ${this.authService.getToken()}`)}
-    );*/
-    return this.http.get<any[]>('assets/demo/biblioteca/estado-recurso.json');
+  lista_estados(modulo: any): Observable<any> {
+    return this.http.get<any[]>(`${this.apiUrl}/${modulo}`,
+      { headers: this.authHeaders() }
+    );
   }
-  lista_tipoEjemplar(modulo: any):Observable<any>{
-    /*return this.http.get<any[]>(`${this.apiUrl}/${modulo}`
-    ,{ headers: new HttpHeaders().set('Authorization',`Bearer ${this.authService.getToken()}`)}
-    );*/
-    return this.http.get<any[]>('assets/demo/biblioteca/tipo-ejemplar.json');
+  lista_tipoEjemplar(modulo: any): Observable<any> {
+    return this.http.get<any[]>(`${this.apiUrl}/${modulo}`,
+      { headers: this.authHeaders() }
+    );
   }
-  lista_autor(modulo: any):Observable<any>{
-    /*return this.http.get<any[]>(`${this.apiUrl}/${modulo}`
-    ,{ headers: new HttpHeaders().set('Authorization',`Bearer ${this.authService.getToken()}`)}
-    );*/
-    return this.http.get<any[]>('assets/demo/biblioteca/data.json');
+  lista_autor(modulo: any): Observable<any> {
+    return this.http.get<any[]>(`${this.apiUrl}/${modulo}`,
+      { headers: this.authHeaders() }
+    );
   }
-  lista_editorial(modulo: any):Observable<any>{
-    /*return this.http.get<any[]>(`${this.apiUrl}/${modulo}`
-    ,{ headers: new HttpHeaders().set('Authorization',`Bearer ${this.authService.getToken()}`)}
-    );*/
-    return this.http.get<any[]>('assets/demo/biblioteca/data.json');
+  lista_editorial(modulo: any): Observable<any> {
+    return this.http.get<any[]>(`${this.apiUrl}/${modulo}`,
+      { headers: this.authHeaders() }
+    );
   }
-  lista_tipoActivo(modulo: any):Observable<any>{
-    /*return this.http.get<any[]>(`${this.apiUrl}/${modulo}`
-    ,{ headers: new HttpHeaders().set('Authorization',`Bearer ${this.authService.getToken()}`)}
-    );*/
-    return this.http.get<any[]>('assets/demo/biblioteca/tipo-activo.json');
+  lista_tipoActivo(modulo: any): Observable<any> {
+    return this.http.get<any[]>(`${this.apiUrl}/${modulo}`,
+      { headers: this.authHeaders() }
+    );
   }
 }

--- a/Frontend/sakai-ng-master/src/app/biblioteca/services/reservas.service.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/services/reservas.service.ts
@@ -9,15 +9,19 @@ import { environment } from '../../../environments/environment';
 })
 export class ReservasService {
   private apiUrl:string;
-  constructor(private http:HttpClient, private authService:AuthService) { 
+  constructor(private http:HttpClient, private authService:AuthService) {
     this.apiUrl = environment.apiUrl;
   }
-  
-  conf_event_get(modulo: any):Observable<any>{
-    /*return this.http.get<any[]>(`${this.apiUrl}/${modulo}`
-    ,{ headers: new HttpHeaders().set('Authorization',`Bearer ${this.authService.getToken()}`)}
-    );*/
-    return this.http.get<any[]>('assets/demo/biblioteca/data.json');
+
+  private authHeaders() {
+    const token = this.authService.getToken();
+    return new HttpHeaders().set('Authorization', `Bearer ${token}`);
+  }
+
+  conf_event_get(modulo: any): Observable<any> {
+    return this.http.get<any[]>(`${this.apiUrl}/${modulo}`,
+      { headers: this.authHeaders() }
+    );
   }
   conf_event_post(request: any,modulo: any):Observable<any>{
     return this.http.post<any>(`${this.apiUrl}/${modulo}`
@@ -39,22 +43,19 @@ export class ReservasService {
         }
     );
   }
-  api_reservas_lista(modulo: any):Observable<any>{
-    /*return this.http.get<any[]>(`${this.apiUrl}/${modulo}`
-    ,{ headers: new HttpHeaders().set('Authorization',`Bearer ${this.authService.getToken()}`)}
-    );*/
-    return this.http.get<any[]>('assets/demo/biblioteca/reservas.json');
+  api_reservas_lista(modulo: any): Observable<any> {
+    return this.http.get<any[]>(`${this.apiUrl}/${modulo}`,
+      { headers: this.authHeaders() }
+    );
   }
-  api_prestamos_lista(modulo: any):Observable<any>{
-    /*return this.http.get<any[]>(`${this.apiUrl}/${modulo}`
-    ,{ headers: new HttpHeaders().set('Authorization',`Bearer ${this.authService.getToken()}`)}
-    );*/
-    return this.http.get<any[]>('assets/demo/biblioteca/prestamos.json');
+  api_prestamos_lista(modulo: any): Observable<any> {
+    return this.http.get<any[]>(`${this.apiUrl}/${modulo}`,
+      { headers: this.authHeaders() }
+    );
   }
-  api_situacion_lista(modulo: any):Observable<any>{
-    /*return this.http.get<any[]>(`${this.apiUrl}/${modulo}`
-    ,{ headers: new HttpHeaders().set('Authorization',`Bearer ${this.authService.getToken()}`)}
-    );*/
-    return this.http.get<any[]>('assets/demo/biblioteca/situacionReserva.json');
+  api_situacion_lista(modulo: any): Observable<any> {
+    return this.http.get<any[]>(`${this.apiUrl}/${modulo}`,
+      { headers: this.authHeaders() }
+    );
   }
 }

--- a/Frontend/sakai-ng-master/src/app/biblioteca/services/usuarios.service.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/services/usuarios.service.ts
@@ -13,11 +13,15 @@ export class UsuarioService {
     this.apiUrl = environment.apiUrl;
   }
 
-  conf_event_get(url: string):Observable<any>{
-    /*return this.http.get<any[]>(`${this.apiUrl}/${modulo}`
-    ,{ headers: new HttpHeaders().set('Authorization',`Bearer ${this.authService.getToken()}`)}
-    );*/
-    return this.http.get<any[]>(`${environment.apiUrl}/${url}`);
+  private authHeaders() {
+    const token = this.authService.getToken();
+    return new HttpHeaders().set('Authorization', `Bearer ${token}`);
+  }
+
+  conf_event_get(url: string): Observable<any> {
+    return this.http.get<any[]>(`${this.apiUrl}/${url}`,
+      { headers: this.authHeaders() }
+    );
   }
   conf_event_post(request: any,modulo: any):Observable<any>{
     return this.http.post<any>(`${this.apiUrl}/${modulo}`
@@ -45,10 +49,9 @@ export class UsuarioService {
     );*/
     return this.http.get<any>(`${environment.apiUrl}/${url}`);
   }
-  api_roles_lista(modulo: any):Observable<any>{
-    /*return this.http.get<any[]>(`${this.apiUrl}/${modulo}`
-    ,{ headers: new HttpHeaders().set('Authorization',`Bearer ${this.authService.getToken()}`)}
-    );*/
-    return this.http.get<any[]>('assets/demo/biblioteca/roles.json');
+  api_roles_lista(modulo: any): Observable<any> {
+    return this.http.get<any[]>(`${this.apiUrl}/${modulo}`,
+      { headers: this.authHeaders() }
+    );
   }
 }


### PR DESCRIPTION
## Summary
- show active "Local/Filial" options from API on dashboard
- replace sample dashboard widgets with data from authenticated backend calls
- translate dashboard components to Spanish
- route dashboard data requests through `/api` endpoints to prevent authorization errors

## Testing
- `npm test` (fails: error TS18003 no inputs were found)


------
https://chatgpt.com/codex/tasks/task_e_68993d7df0d08329bcd3583ada6266ee