### PR TITLE
Mejoras en módulo de noticias

### DIFF
--- a/Frontend/sakai-ng-master/src/app/biblioteca/interfaces/portalNoticias.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/interfaces/portalNoticias.ts
@@ -16,6 +16,7 @@ export class PortalNoticia {
       autor?:     string;
       descripcion?: string;
       imagen?:     string;
+      imagenUrl?:  string;
       enlace?:    string;
       estadoId?:  number;
       estadoDescripcion?: string;

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/portal/noticias.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/portal/noticias.ts
@@ -98,12 +98,12 @@ import { InputValidation } from '../../input-validation';
                             <ng-template pTemplate="body" let-objeto>
                                 <tr>
                                 <td>
-                                <img [src]="objeto.imagenUrl" [alt]="objeto.titulo" width="50" class="shadow-lg" />
+                                <img [src]="objeto.urlPortada || objeto.imagenUrl || objeto.imagen" [alt]="objeto.titulo" width="50" class="shadow-lg" />
                                     </td>
                                 <td>{{objeto.titular}}
                                     </td>
                                     <td>
-                                        {{objeto.fechacreacion}}
+                                        {{ objeto.fecha || (objeto.fechacreacion | date:'dd/MM/yyyy') }}
 
                                     </td>
                                     <td>
@@ -143,7 +143,12 @@ import { InputValidation } from '../../input-validation';
                 <div class="flex flex-col md:flex-row gap-x-4 gap-y-2">
                       <div class="flex flex-col gap-2 w-full md:w-1/4">
                       <label for="fecha">Fecha</label>
-                                <input pInputText id="fecha" type="text" formControlName="fecha"  />
+                                <p-datepicker
+                                  id="fecha"
+                                  formControlName="fecha"
+                                  appendTo="body"
+                                  [readonlyInput]="true"
+                                  dateFormat="dd/mm/yy"></p-datepicker>
                                 <app-input-validation
                   [form]="form"
                   modelo="fecha"
@@ -304,8 +309,7 @@ export class Noticias implements OnInit{
         this.filter.nativeElement.value = '';
       }
        cambiarEstadoRegistro(n: PortalNoticia) {
-           const decoded = this.authService.getUser();
-             const usuario = decoded.sub;
+           const usuario = this.authService.getUser()?.sub ?? 0;
          // Por ejemplo: si está en 2 lo ponemos en 5, y viceversa
          const nuevoEstadoId = n.estadoId === 2 ? 5 : 2;
 // conviertes a descripción con un ternario
@@ -339,33 +343,26 @@ export class Noticias implements OnInit{
 
 
           formValidar() {
-            let dataObjeto = JSON.parse(JSON.stringify(this.objeto));
-
+            const dataObjeto = JSON.parse(JSON.stringify(this.objeto));
             this.form = this.fb.group({
               id: [dataObjeto.id],
-
               adjunto: [''],
               link: [dataObjeto.link ?? null, [Validators.required]],
               titulo: [dataObjeto.titular, [Validators.required, Validators.maxLength(100), Validators.pattern('^[a-zA-Z0-9áéíóúÁÉÍÓÚñÑ\\s\\-()]+$')]],
-              subtitulo: [dataObjeto.subtitulo, [ Validators.maxLength(200), Validators.pattern('^[a-zA-Z0-9áéíóúÁÉÍÓÚñÑ\\s\\-()]+$')]],
+              subtitulo: [dataObjeto.subtitulo, [Validators.maxLength(200), Validators.pattern('^[a-zA-Z0-9áéíóúÁÉÍÓÚñÑ\\s\\-()]+$')]],
               detalle: [dataObjeto.detalle, [Validators.required, Validators.maxLength(600)]],
-              fecha: [dataObjeto.fecha, [Validators.required]],
+              fecha: [dataObjeto.fecha ? this.toDate(dataObjeto.fecha) : null, [Validators.required]],
               anunciante: [dataObjeto.anunciante, [Validators.required, Validators.maxLength(100), Validators.pattern('^[a-zA-Z0-9áéíóúÁÉÍÓÚñÑ\\s\\-()]+$')]],
-
             });
           }
+
   editarRegistro(objeto: PortalNoticia) {
-    // 1) Prepara string vacío por defecto
-      let fechaFormValue = '';
-
-      // 2) Si viene definida, conviértela
-      if (objeto.fechacreacion) {
-        const d    = new Date(objeto.fechacreacion);
-        const pad  = (n: number) => n < 10 ? '0' + n : n.toString();
-        fechaFormValue = `${pad(d.getDate())}/${pad(d.getMonth()+1)}/${d.getFullYear()}`;
+      let fechaFormValue: Date | null = null;
+      if (objeto.fecha) {
+        fechaFormValue = this.toDate(objeto.fecha);
+      } else if (objeto.fechacreacion) {
+        fechaFormValue = new Date(objeto.fechacreacion);
       }
-
-      // 3) Parchea todos los campos
       this.form.patchValue({
         id:         objeto.idnoticia,
         fecha:      fechaFormValue,
@@ -374,9 +371,7 @@ export class Noticias implements OnInit{
         anunciante: objeto.autor,
         link:       objeto.enlace,
         detalle:    objeto.descripcion
-        // adjunto:   no lo rellenamos aquí
       });
-
       this.objetoDialog = true;
   }
           deleteRegistro(objeto: PortalNoticia) {
@@ -446,10 +441,17 @@ this.confirmationService.confirm({
                 }, _=> this.loading=false);
             }
 
-          toIso(d: Date) {
-              const pad = (n:number)=>(n<10?'0':'')+n;
-              return `${d.getFullYear()}-${pad(d.getMonth()+1)}-${pad(d.getDate())}`;
-          }
+  toIso(d: Date) {
+      const pad = (n:number)=>(n<10?'0':'')+n;
+      return `${d.getFullYear()}-${pad(d.getMonth()+1)}-${pad(d.getDate())}`;
+  }
+
+  private toDate(fecha: string): Date | null {
+      if (!fecha) return null;
+      const partes = fecha.split('/');
+      if (partes.length !== 3) return null;
+      return new Date(+partes[2], +partes[1] - 1, +partes[0]);
+  }
           nuevoRegistro(){
             this.formValidar();
             this.objetoDialog = true;
@@ -459,16 +461,18 @@ this.confirmationService.confirm({
           }
           guardar(){
             this.loading = true;
+            // Verificar que exista un token de sesión válido antes de enviar la petición
+            if (!this.authService.getToken()) {
+              this.messageService.add({ severity: 'warn', summary: 'Sesión no válida', detail: 'Debe iniciar sesión' });
+              this.loading = false;
+              return;
+            }
 
-            // 1) Convertir la fecha dd/MM/yyyy a ISO (si tu back espera LocalDateTime)
-              const partes = this.form.get('fecha')!.value.split('/');
-              const fechaIso = new Date(
-                +partes[2],      // año
-                +partes[1] - 1,  // mes (0-11)
-                +partes[0]       // día
-              ).toISOString();
-              const decoded = this.authService.getUser();
-              const usuario = decoded.sub;
+            const fechaControl = this.form.get('fecha')!.value;
+            const fechaIso = fechaControl instanceof Date
+              ? fechaControl.toISOString()
+              : new Date(fechaControl).toISOString();
+              const usuario = this.authService.getUser()?.sub ?? 0;
               // 2) Construir el DTO completo
               const data = {
                 idnoticia:    this.form.get('id')?.value || 0,

--- a/Frontend/sakai-ng-master/src/app/biblioteca/web/noticias/noticias-lista.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/web/noticias/noticias-lista.ts
@@ -10,7 +10,8 @@ import { Table } from 'primeng/table';
 import { Menu } from 'primeng/menu';
 import { HttpErrorResponse } from '@angular/common/http';
 import { PortalService } from '../../services/portal.service';
-import { Material } from '../../interfaces/material-bibliografico/material';
+import { PortalNoticia } from '../../interfaces/portalNoticias';
+import { environment } from '../../../../environments/environment';
 
 @Component({
     selector: 'noticias-lista',
@@ -34,7 +35,7 @@ import { Material } from '../../interfaces/material-bibliografico/material';
         
         <div class="flex flex-col flex-1 gap-2">
             <label for="palabra-clave" class="block text-sm font-medium text-muted-color">Buscar noticia</label>
-            <input pInputText id="palabra-clave" type="text" />
+            <input pInputText id="palabra-clave" type="text" [(ngModel)]="palabraClave" (keydown.enter)="listar()" />
         </div>
         
         <div class="flex items-end">
@@ -67,23 +68,33 @@ import { Material } from '../../interfaces/material-bibliografico/material';
                         <div *ngFor="let item of items; let i = index">
                             <div class="flex flex-col sm:flex-row sm:items-center p-6 gap-4 " [ngClass]="{ 'border-t border-surface': i !== 0 }">
                                 <div class="md:w-40 relative ">
-                                <a [href]="item.link" target="_blank">
-                                <img 
+                                <a *ngIf="item.link || item.enlace; else imgSinEnlace" [href]="item.link || item.enlace" target="_blank">
+                                <img
   class="block xl:block mx-auto rounded w-full transition-transform duration-300 transform hover:scale-110 hover:shadow-lg"
-  [src]="item.urlPortada" 
-  [alt]="item.titulo" 
+  [src]="item.urlPortada || item.imagenUrl || item.imagen"
+  [alt]="item.titulo"
 />
                                 </a>
+                                <ng-template #imgSinEnlace>
+                                <img
+  class="block xl:block mx-auto rounded w-full transition-transform duration-300 transform hover:scale-110 hover:shadow-lg"
+  [src]="item.urlPortada || item.imagenUrl || item.imagen"
+  [alt]="item.titulo"
+/>
+                                </ng-template>
                                 </div>
                                 <div class="flex flex-col md:flex-row justify-between md:items-center flex-1 gap-6">
                                     <div class="flex flex-row md:flex-col justify-between items-start gap-2">
                                         <div>
-                                        <span class="font-medium text-surface-500 dark:text-surface-400 text-sm"><i class="pi pi-fw pi-calendar !text-2xl text-primary"></i> {{ item.fecha }}</span>
-                                        
+                                        <span class="font-medium text-surface-500 dark:text-surface-400 text-sm"><i class="pi pi-fw pi-calendar !text-2xl text-primary"></i> {{ item.fecha || (item.fechacreacion | date:'dd/MM/yyyy') }}</span>
+
                                             <div class="text-lg font-medium mt-2">
-                                                <a [href]="item.link" target="_blank" class="hover:text-primary focus:text-primary transition-colors">
+                                                <ng-container *ngIf="item.link || item.enlace; else tituloPlano">
+                                                <a [href]="item.link || item.enlace" target="_blank" class="hover:text-primary focus:text-primary transition-colors">
                                                 {{ item.titulo }}
                                                 </a>
+                                                </ng-container>
+                                                <ng-template #tituloPlano>{{ item.titulo }}</ng-template>
                                             </div>
                                             <p class="text-gray-500 mt-2"> {{ item.detalle }}</p>
                                             <p class="text-gray-500 mt-2"> Por:{{ item.anunciante }}</p>
@@ -92,9 +103,14 @@ import { Material } from '../../interfaces/material-bibliografico/material';
                                     </div>
                                     <div class="flex flex-col md:items-end gap-8">
                                         <div class="flex flex-row-reverse md:flex-row gap-2">
-                                        <a [href]="item.link" target="_blank" class="flex-auto md:flex-initial whitespace-nowrap">
+                                        <ng-container *ngIf="item.link || item.enlace; else botonDeshabilitado">
+                                        <a [href]="item.link || item.enlace" target="_blank" class="flex-auto md:flex-initial whitespace-nowrap">
                                             <p-button icon="pi pi-arrow-right" label="Leer más"></p-button>
                                         </a>
+                                        </ng-container>
+                                        <ng-template #botonDeshabilitado>
+                                            <p-button icon="pi pi-arrow-right" label="Leer más" [disabled]="true"></p-button>
+                                        </ng-template>
                                         </div>
                                     </div>
                                 </div>
@@ -107,20 +123,31 @@ import { Material } from '../../interfaces/material-bibliografico/material';
                 <div class="grid grid-cols-12 gap-4 justify-between mt-20 md:mt-0">
                 <div class="col-span-12 md:col-span-6 lg:col-span-4 p-0 md:p-4" *ngFor="let item of items; let i = index">
                     <div class="p-4 flex flex-col border-surface-200 dark:border-surface-600 pricing-card cursor-pointer border-2 hover:border-primary duration-300 transition-all" style="border-radius: 10px">
-                    <a [href]="item.link" target="_blank">   
-                    <img class="w-full h-56 object-cover" [src]="item.urlPortada" [alt]="item.titulo">  
-                    </a>                      
-                    
+                    <a *ngIf="item.link || item.enlace; else imgGridSinEnlace" [href]="item.link || item.enlace" target="_blank">
+                    <img class="w-full h-56 object-cover" [src]="item.urlPortada || item.imagenUrl || item.imagen" [alt]="item.titulo">
+                    </a>
+                    <ng-template #imgGridSinEnlace>
+                    <img class="w-full h-56 object-cover" [src]="item.urlPortada || item.imagenUrl || item.imagen" [alt]="item.titulo">
+                    </ng-template>
+
                         <p-divider class="w-full bg-surface-200"></p-divider>
                         <div class="p-6">
-            <i class="pi pi-fw pi-calendar !text-2xl text-primary"></i> {{ item.fecha }} 
+            <i class="pi pi-fw pi-calendar !text-2xl text-primary"></i> {{ item.fecha || (item.fechacreacion | date:'dd/MM/yyyy') }}
                 <h3 class="text-xl font-semibold text-gray-900">
-                <a [href]="item.link" target="_blank" class="hover:text-primary focus:text-primary transition-colors">
+                <ng-container *ngIf="item.link || item.enlace; else tituloGridPlano">
+                <a [href]="item.link || item.enlace" target="_blank" class="hover:text-primary focus:text-primary transition-colors">
                 {{ item.titulo }}
-                </a>    </h3>
+                </a>
+                </ng-container>
+                <ng-template #tituloGridPlano>{{ item.titulo }}</ng-template>    </h3>
                 <p class="text-gray-500 mt-2">{{ item.detalle }}</p>
                 <p class="text-gray-500 mt-2"> Por:{{ item.anunciante }}</p>
-                <a [href]="item.link" target="_blank"  class="text-primary mt-4 inline-flex items-center">Leer m&aacute;s <span class="ml-2">→</span></a>
+                <ng-container *ngIf="item.link || item.enlace; else leerMasTexto">
+                <a [href]="item.link || item.enlace" target="_blank"  class="text-primary mt-4 inline-flex items-center">Leer m&aacute;s <span class="ml-2">→</span></a>
+                </ng-container>
+                <ng-template #leerMasTexto>
+                <span class="text-primary mt-4 inline-flex items-center opacity-50 cursor-not-allowed">Leer m&aacute;s <span class="ml-2">→</span></span>
+                </ng-template>
             </div>
                        
                     </div>
@@ -170,8 +197,8 @@ import { Material } from '../../interfaces/material-bibliografico/material';
 export class NoticiasLista implements OnInit {
     layout: 'list' | 'grid' = 'grid';
     options = ['list', 'grid'];
-    modulo: string = "catalogo";
-    data: Material[] = [];
+    data: PortalNoticia[] = [];
+    palabraClave: string = '';
     @ViewChild('menu') menu!: Menu;
     @ViewChild('filter') filter!: ElementRef;
     items: MenuItem[] | undefined;
@@ -202,22 +229,50 @@ export class NoticiasLista implements OnInit {
     }
 
     listar() {
-
         this.loading = true;
-        this.portalService.api_noticias(this.modulo)
-            .subscribe(
-                (result: any) => {
-                    this.loading = false;
-                    if (result.status == "0") {
-                        this.data = result.data;
-                    }
-                    this.loading = false;
-                }
-                , (error: HttpErrorResponse) => {
-                    this.loading = false;
-                }
-            );
+        this.portalService.api_noticias(this.palabraClave).subscribe({
+            next: (result: any) => {
+                const noticias: PortalNoticia[] = result?.data ?? [];
+                this.data = noticias
+                    .filter(n => this.esDisponible(n))
+                    .map(n => new PortalNoticia({
+                        ...n,
+                        titulo: n.titular ?? n.titulo,
+                        detalle: n.descripcion ?? n.detalle,
+                        anunciante: n.autor ?? n.anunciante,
+                        link: n.enlace ?? n.link,
+                        fecha: n.fechacreacion ?? n.fecha,
+                        urlPortada: this.buildImageUrl(n)
+                    }));
 
+                if (this.palabraClave) {
+                    const term = this.palabraClave.toLowerCase();
+                    this.data = this.data.filter(n =>
+                        n.titulo.toLowerCase().includes(term) ||
+                        n.detalle.toLowerCase().includes(term)
+                    );
+                }
+
+                this.loading = false;
+            },
+            error: (_error: HttpErrorResponse) => {
+                this.loading = false;
+            }
+        });
+    }
+
+    private esDisponible(n: any): boolean {
+        const id = Number(n.estadoId ?? n.estado ?? n.idestado ?? n.idEstado ?? n.estado_id);
+        const desc = (n.estadoDescripcion ?? n.estado ?? '').toString().trim().toUpperCase();
+        return id === 2 || desc === 'DISPONIBLE';
+    }
+
+    private buildImageUrl(n: PortalNoticia): string {
+        const raw = n.urlPortada || (n as any).imagenUrl || n.imagen;
+        if (!raw) {
+            return 'assets/logo.png';
+        }
+        return raw.startsWith('http') ? raw : `${environment.filesUrl}/uploads/noticias/${raw}`;
     }
     async ListaSituacion() {
         try {

--- a/Frontend/sakai-ng-master/src/app/biblioteca/web/portal-landing/components/portal-noticias.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/web/portal-landing/components/portal-noticias.ts
@@ -11,8 +11,8 @@ import { Product, ProductService } from '../../../../pages/service/product.servi
 import { PhotoService } from '../../../../pages/service/photo.service';
 import { DividerModule } from 'primeng/divider';
 import { PortalService } from '../../../services/portal.service';
-import { HttpErrorResponse } from '@angular/common/http';
 import { PortalNoticia } from '../../../interfaces/portalNoticias';
+import { environment } from '../../../../../environments/environment';
 @Component({
     selector: 'portal-noticias',
     standalone: true,
@@ -40,22 +40,22 @@ import { PortalNoticia } from '../../../interfaces/portalNoticias';
         <div class="grid grid-cols-12 gap-4 justify-between mt-20 md:mt-0">
                 <div class="col-span-12 lg:col-span-4 p-0 md:p-4" *ngFor="let item of data; let i = index">
                     <div class="p-4 flex flex-col border-surface-200 dark:border-surface-600 pricing-card cursor-pointer border-2 hover:border-primary duration-300 transition-all" style="border-radius: 10px">
-                    <a [href]="item.enlace" target="_blank">
-                    <img class="w-full h-56 object-cover" [src]="item.urlPortada" [alt]="item.titular" >
+                    <a [href]="item.link || item.enlace" target="_blank">
+                    <img class="w-full h-56 object-cover" [src]="item.urlPortada || item.imagenUrl || item.imagen" [alt]="item.titular" >
                                 </a>
 
                         <p-divider class="w-full bg-surface-200"></p-divider>
                         <div class="p-6">
-            <i class="pi pi-fw pi-calendar !text-2xl text-primary"></i> {{ item.fechacreacion }}
+            <i class="pi pi-fw pi-calendar !text-2xl text-primary"></i> {{ item.fecha || (item.fechacreacion | date:'dd/MM/yyyy') }}
                 <h3 class="text-xl font-semibold text-gray-900">
-                <a [href]="item.enlace" target="_blank" class="hover:text-primary focus:text-primary transition-colors">
+                <a [href]="item.link || item.enlace" target="_blank" class="hover:text-primary focus:text-primary transition-colors">
   {{ item.titular }}
 </a>
 
                 </h3>
                 <p class="text-gray-500 mt-2">{{ item.descripcion }}</p>
                 <p class="text-gray-500 mt-2"> Por:{{ item.autor }}</p>
-                <a [href]="item.link" target="_blank" class="text-primary mt-4 inline-flex items-center">Leer m&aacute;s <span class="ml-2">→</span></a>
+                <a [href]="item.link || item.enlace" target="_blank" class="text-primary mt-4 inline-flex items-center">Leer m&aacute;s <span class="ml-2">→</span></a>
             </div>
 
                     </div>
@@ -88,11 +88,34 @@ export class PortalNoticias implements OnInit{
     noticias() {
         this.router.navigate(['/noticias']);
       }
-          listar() {
 
-              this.portalService.listar(undefined, undefined).subscribe(r => {
-                this.data = r.data;
-                this.loading = false;
-              }, _=> this.loading=false);
-          }
+    listar() {
+        this.portalService.listar(undefined, undefined).subscribe(r => {
+          this.data = r.data
+            .filter(n => this.esDisponible(n))
+            .map(n => new PortalNoticia({
+              ...n,
+              titulo: n.titular ?? n.titulo,
+              detalle: n.descripcion ?? n.detalle,
+              anunciante: n.autor ?? n.anunciante,
+              link: n.enlace ?? n.link,
+              fecha: n.fechacreacion ?? n.fecha,
+              urlPortada: this.buildImageUrl(n)
+            }));
+          this.loading = false;
+        }, _ => this.loading = false);
+    }
+    private esDisponible(n: any): boolean {
+        const id = Number(n.estadoId ?? n.estado ?? n.idestado ?? n.idEstado ?? n.estado_id);
+        const desc = (n.estadoDescripcion ?? n.estado ?? '').toString().trim().toUpperCase();
+        return id === 2 || desc === 'DISPONIBLE';
+    }
+
+    private buildImageUrl(n: PortalNoticia): string {
+        const raw = n.urlPortada || (n as any).imagenUrl || n.imagen;
+        if (!raw) {
+            return 'assets/logo.png';
+        }
+        return raw.startsWith('http') ? raw : `${environment.filesUrl}/uploads/noticias/${raw}`;
+    }
 }


### PR DESCRIPTION
## Resumen
- Refactor de listados de noticias para filtrar solo registros en estado DISPONIBLE
- Normalización de campos y rutas de imagen al cargar noticias

## Pruebas
- `npm test` *(falla: TS18003 en tsconfig.spec.json)*
- `npm run build` *(falla: errores de TypeScript en material-bibliografico.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68aca9af392883299eb63151c75400ac