### PR TITLE
feat: agregar sección de horarios al portal

### DIFF
--- a/Frontend/sakai-ng-master/src/app/biblioteca/web/portal-landing/components/portal-horarios.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/web/portal-landing/components/portal-horarios.ts
@@ -1,0 +1,56 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MessageService } from 'primeng/api';
+import { PortalService } from '../../../services/portal.service';
+import { PortalHorario } from '../../../interfaces/portalHorario';
+
+@Component({
+    selector: 'portal-horarios',
+    standalone: true,
+    imports: [CommonModule],
+    template: `
+    <div id="portal-horarios" class="py-10">
+        <div class="py-6 px-6 lg:px-20 mt-8 mx-0 lg:mx-20">
+            <div class="text-surface-900 text-center dark:text-surface-0 font-normal mb-2 text-4xl">Horarios</div>
+            <div class="grid grid-cols-12 gap-4 justify-center">
+                <div class="col-span-12 md:col-span-12 lg:col-span-4 p-0 lg:pb-8 mt-6 lg:mt-0" *ngFor="let horario of data">
+                    <div style="height: 160px; padding: 2px; border-radius: 10px; background: linear-gradient(90deg, rgba(251, 199, 145, 0.2), rgba(246, 158, 188, 0.2)), linear-gradient(180deg, rgba(172, 180, 223, 0.2), rgba(212, 162, 221, 0.2))">
+                        <div class="p-4 bg-surface-0 dark:bg-surface-900 h-full" style="border-radius: 8px">
+                            <div class="flex items-center justify-center bg-rose-200 mb-4" style="width: 3.5rem; height: 3.5rem; border-radius: 10px">
+                                <i class="pi pi-fw pi-map-marker !text-2xl text-rose-700"></i>
+                            </div>
+                            <div class="mt-6 mb-1 text-surface-900 dark:text-surface-0 text-l font-semibold">{{ horario.sedeDescripcion }}</div>
+                            <span class="text-surface-600 dark:text-surface-200"><i class="pi pi-fw pi-clock text-primary"></i> {{ horario.descripcion }}</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    `,
+    providers: [MessageService]
+})
+export class PortalHorarios implements OnInit {
+    data: PortalHorario[] = [];
+
+    constructor(private portalService: PortalService, private messageService: MessageService) {}
+
+    ngOnInit() {
+        this.listar();
+    }
+
+    listar() {
+        this.portalService.listarHorarios().subscribe({
+            next: res => {
+                if (res.p_status === 0) {
+                    this.data = res.data;
+                } else {
+                    this.messageService.add({ severity: 'warn', detail: res.message });
+                }
+            },
+            error: () => {
+                this.messageService.add({ severity: 'error', detail: 'Error al cargar horarios' });
+            }
+        });
+    }
+}

--- a/Frontend/sakai-ng-master/src/app/biblioteca/web/portal-landing/components/portal-nosotros.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/web/portal-landing/components/portal-nosotros.ts
@@ -2,13 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { TabsModule } from 'primeng/tabs';
 import { SplitterModule } from 'primeng/splitter';
-import { FormBuilder } from '@angular/forms';
-import { Router } from '@angular/router';
-import { ConfirmationService, MessageService } from 'primeng/api';
-import { AuthService } from '../../../services/auth.service';
 import { PortalService, NosotrosDTO } from '../../../services/portal.service';
-import { InputValidation } from '../../../input-validation';
-import { TemplateModule } from '../../../template.module';
 import { CardModule } from 'primeng/card';
 import { DividerModule } from 'primeng/divider';
 import { environment } from '../../../../../../src/environments/environment';
@@ -149,59 +143,15 @@ import { environment } from '../../../../../../src/environments/environment';
 </section>
   </div>
   </div>
-</section>-->
-
-    <div class="py-10"> <div class="py-6 px-6 lg:px-20 mt-8 mx-0 lg:mx-20">
-    <div class="text-surface-900 text-center dark:text-surface-0 font-normal mb-2 text-4xl">Horarios</div>
-
-        <div class="grid grid-cols-12 gap-4 justify-center">
-
-        <div class="col-span-12 md:col-span-12 lg:col-span-4 p-0 lg:pb-8 mt-6 lg:mt-0" *ngFor="let horario of data">
-                <div style="height: 160px; padding: 2px; border-radius: 10px; background: linear-gradient(90deg, rgba(251, 199, 145, 0.2), rgba(246, 158, 188, 0.2)), linear-gradient(180deg, rgba(172, 180, 223, 0.2), rgba(212, 162, 221, 0.2))">
-                    <div class="p-4 bg-surface-0 dark:bg-surface-900 h-full" style="border-radius: 8px">
-                        <div class="flex items-center justify-center bg-rose-200 mb-4" style="width: 3.5rem; height: 3.5rem; border-radius: 10px">
-                            <i class="pi pi-fw pi-map-marker !text-2xl text-rose-700"></i>
-                        </div>
-                        <div class="mt-6 mb-1 text-surface-900 dark:text-surface-0 text-l font-semibold">{{ horario.sedeDescripcion }}</div>
-
-                        <span class="text-surface-600 dark:text-surface-200"><i class="pi pi-fw pi-clock text-primary"></i> {{ horario.descripcion }}</span>
-                    </div>
-                </div>
-            </div>
-
-        </div>
-    </div>
-    </div>`,
-    styleUrl:'portal-nosotros.component.css',
-                    providers: [MessageService, ConfirmationService]
+  </section>-->`,
+    styleUrl:'portal-nosotros.component.css'
 })
 export class PortalNosotros implements OnInit{
-    data: any[]= [];
     datos: NosotrosDTO = { eyebrow: '', title: '', imageUrl: '', body: '' };
-    constructor(private portalService: PortalService,private fb: FormBuilder,
-              private router: Router,private authService: AuthService, private confirmationService: ConfirmationService, private messageService: MessageService) { }
-              async ngOnInit() {
+    constructor(private portalService: PortalService) { }
+    ngOnInit() {
                    this.portalService.getNosotros().subscribe(dto => this.datos = dto);
-                await this.listar();
               }
-    listar() {
-
-        this.portalService.listarHorarios()
-          .subscribe({
-            next: res => {
-              if (res.p_status === 0) {
-                this.data = res.data;
-              } else {
-                this.messageService.add({ severity: 'warn', detail: res.message });
-              }
-
-            },
-            error: () => {
-              this.messageService.add({ severity: 'error', detail: 'Error al cargar horarios' });
-
-            }
-          });
-      }
 
    public getImageUrl(path: string): string {
       // El backend ya devuelve la ruta relativa del archivo

--- a/Frontend/sakai-ng-master/src/app/biblioteca/web/portal-landing/components/portal-topbar.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/web/portal-landing/components/portal-topbar.ts
@@ -56,6 +56,11 @@ import { ButtonModule } from 'primeng/button';
                     </a>
                 </li>
                 <li>
+                    <a (click)="router.navigate(['/'], { fragment: 'portal-horarios' })" pRipple class="px-0 py-4 text-surface-900 dark:text-surface-0 font-medium text-xl">
+                        <span>Horarios</span>
+                    </a>
+                </li>
+                <li>
                     <a (click)="router.navigate(['/'], { fragment: 'portal-contactanos' })" pRipple class="px-0 py-4 text-surface-900 dark:text-surface-0 font-medium text-xl">
                         <span>Cont&aacute;ctanos</span>
                     </a>

--- a/Frontend/sakai-ng-master/src/app/biblioteca/web/portal-landing/portalLanding.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/web/portal-landing/portalLanding.ts
@@ -10,6 +10,7 @@ import { FooterWidget } from '../../../pages/landing/components/footerwidget';
 import { HighlightsWidget } from '../../../pages/landing/components/highlightswidget';
 import { Portal } from './components/portal';
 import { PortalNosotros } from './components/portal-nosotros';
+import { PortalHorarios } from './components/portal-horarios';
 import { PricingWidget } from '../../../pages/landing/components/pricingwidget';
 import { TopbarWidget } from '../../../pages/landing/components/topbarwidget.component';
 import { AppFloatingConfigurator } from '../../../layout/component/app.floatingconfigurator';
@@ -24,7 +25,7 @@ import { PortalRecursosElectronicos } from './components/portal-recursos-electro
 @Component({
     selector: 'app-portal-landing',
     standalone: true,
-    imports: [ScrollTopModule,RouterModule, AppFloatingConfigurator,PortalFooter,PortalContactanos,PortalTopbar,PortalEjemplares,PortalNoticias, RippleModule, StyleClassModule, ButtonModule, DividerModule, PortalNosotros,PortalRecursosElectronicos, Portal,ScrollTopModule],
+    imports: [ScrollTopModule,RouterModule, AppFloatingConfigurator,PortalFooter,PortalContactanos,PortalTopbar,PortalEjemplares,PortalNoticias, RippleModule, StyleClassModule, ButtonModule, DividerModule, PortalNosotros,PortalHorarios,PortalRecursosElectronicos, Portal,ScrollTopModule],
     template: `
         <app-floating-configurator />
         <div class="bg-surface-0 dark:bg-surface-900">
@@ -33,6 +34,7 @@ import { PortalRecursosElectronicos } from './components/portal-recursos-electro
                 <portal />
                 <portal-ejemplares />
                 <portal-nosotros />
+                <portal-horarios />
                 <portal-recursos-electronicos />
                 <portal-noticias />
                 <portal-contactanos />

--- a/Frontend/sakai-ng-master/src/app/pages/landing/components/topbarwidget.component.ts
+++ b/Frontend/sakai-ng-master/src/app/pages/landing/components/topbarwidget.component.ts
@@ -54,6 +54,11 @@ import { ButtonModule } from 'primeng/button';
                         <span>Noticias</span>
                     </a>
                 </li>
+                <li>
+                    <a (click)="router.navigate(['/'], { fragment: 'portal-horarios' })" pRipple class="px-0 py-4 text-surface-900 dark:text-surface-0 font-medium text-xl">
+                        <span>Horarios</span>
+                    </a>
+                </li>
             </ul>
             <div class="flex border-t lg:border-t-0 border-surface py-4 lg:py-0 mt-4 lg:mt-0 gap-2">
                 <button pButton pRipple label="Iniciar sesión" routerLink="/auth/login" [rounded]="true" [text]="true"></button>


### PR DESCRIPTION
## Resumen
- crea componente independiente para la sección de horarios
- integra horarios en la página principal y limpia el componente de nosotros

## Testing
- `npm test` *(falla: TS18003 no se encontraron entradas en tsconfig.spec.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad18f41f9c8329a873fb75d50aa151