### PR TITLE
Fix: remover opción 'todas las sedes' en horarios

### DIFF
--- a/Frontend/sakai-ng-master/src/app/biblioteca/interfaces/portalHorario.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/interfaces/portalHorario.ts
@@ -2,13 +2,13 @@ import { Sedes } from "./sedes";
 
 export class PortalHorario {
     id: number;
-    sede?:Sedes | null;
+    sede?: Sedes;
     descripcion: string;
     activo?:boolean;
     estado?: boolean;
     estadoId?:  number;
     estadoDescripcion?: string;
-    sedeId?: number;
+    sedeId: number;
     sedeDescripcion?: string;
     usuarioCreacion?: string;
     usuarioModificacion?: string;
@@ -16,9 +16,10 @@ export class PortalHorario {
     fechaModificacion?: string;
     constructor(init?: Partial<PortalHorario>) {
         this.id = 0;
-        this.sede=null;
-        this.descripcion='';
-        this.activo=false;
+        this.sede = new Sedes();
+        this.descripcion = '';
+        this.activo = false;
+        this.sedeId = 0;
         // Inicialización opcional si se pasa un objeto
         Object.assign(this, init);
     }

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/portal/horarios.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/portal/horarios.ts
@@ -214,11 +214,9 @@ export class HorariosComponent implements OnInit {
     private async ListaSede() {
         const res: any = await this.genericoService.sedes_get('api/equipos/sedes').toPromise();
         if (res.status === 0) {
-          // agrego “Todas” al inicio si quieres
-          this.dataSede = [
-            { id: 0, descripcion: 'TODAS LAS SEDES', activo: true, estado: 1 },
-            ...res.data
-          ];
+          const sedes = (res.data as Sedes[]).filter(s => s.id !== 0);
+          this.dataSede = sedes;
+          this.dataSedesFiltro = sedes;
         }
       }
         formValidar(){
@@ -243,7 +241,7 @@ export class HorariosComponent implements OnInit {
       editarRegistro(objeto:PortalHorario){
          this.form.patchValue({
              id:          objeto.id,
-             sedeId:      objeto.sedeId ?? null,      // <— aquí “cae” el select
+             sedeId:      objeto.sedeId,
              descripcion: objeto.descripcion
            });
         this.objetoDialog = true;


### PR DESCRIPTION
## Resumen
- filtrar la sede con id 0 al cargar los combos de horarios
- hacer obligatorio el `sedeId` en `PortalHorario`

## Pruebas
- `npm test --silent` *(falla: TS18003 no encontró archivos de prueba)*
- `npm run build --silent` *(falla: errores de TypeScript en módulos no relacionados)*

------
https://chatgpt.com/codex/tasks/task_e_68ad229d96908329829b1c9d576c3c8b