### PR TITLE
Filtrar horarios disponibles, evitar duplicados y mostrar carga del catálogo

### DIFF
--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/portal/horarios.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/portal/horarios.ts
@@ -239,6 +239,7 @@ export class HorariosComponent implements OnInit {
           this.filter.nativeElement.value = '';
       }
       editarRegistro(objeto:PortalHorario){
+         this.objeto = objeto;
          this.form.patchValue({
              id:          objeto.id,
              sedeId:      objeto.sedeId,
@@ -247,6 +248,7 @@ export class HorariosComponent implements OnInit {
         this.objetoDialog = true;
       }
       nuevoRegistro(){
+        this.objeto = new PortalHorario();
         this.formValidar();
         this.objetoDialog = true;
       }
@@ -287,49 +289,61 @@ export class HorariosComponent implements OnInit {
       guardar() {
         if (this.form.invalid) return;
 
-          const decoded = this.authService.getUser();
-          const usuario = decoded.sub;    // "admin@gmail.com"
+        const sedeId = this.form.get('sedeId')!.value;
+        const id = this.form.get('id')!.value;
 
-          const dto: PortalHorario = {
-            id:                   this.form.get('id')!.value,
-            descripcion:          this.form.get('descripcion')!.value,
-            estadoId:              2,
-            sedeId:               this.form.get('sedeId')!.value,
-            usuarioCreacion:      usuario,
-            usuarioModificacion:  usuario
-          };
+        // Validar que no exista otro horario para la misma sede
+        const existe = this.data.some(h => h.sedeId === sedeId && h.id !== id);
+        if (existe) {
+          this.messageService.add({ severity: 'warn', summary: 'Aviso', detail: 'Ya existe un horario para este local/filial' });
+          return;
+        }
+
+        const decoded = this.authService.getUser();
+        const usuario = decoded.sub; // "admin@gmail.com"
+
+        // Mantener el estado actual al actualizar; por defecto, DISPONIBLE (2)
+        const estadoActual = this.objeto.estadoId ?? 2;
+
+        const dto: PortalHorario = {
+          id: this.form.get('id')!.value,
+          descripcion: this.form.get('descripcion')!.value,
+          estadoId: estadoActual,
+          sedeId: sedeId,
+          usuarioCreacion: usuario,
+          usuarioModificacion: usuario
+        };
 
         // 3) Llamas al servicio
         this.loading = true;
-        this.portalService.saveHorario(dto)
-          .subscribe({
-            next: res => {
-              this.loading = false;
-              if (res.p_status === 0) {
-                this.messageService.add({
-                  severity: 'success',
-                  summary:  '¡Listo!',
-                  detail:   dto.id ? 'Horario actualizado' : 'Horario creado'
-                });
-                this.objetoDialog = false;
-                this.listar();
-              } else {
-                this.messageService.add({
-                  severity: 'error',
-                  summary:  'Error',
-                  detail:   'No se pudo procesar.'
-                });
-              }
-            },
-            error: () => {
-              this.loading = false;
+        this.portalService.saveHorario(dto).subscribe({
+          next: res => {
+            this.loading = false;
+            if (res.p_status === 0) {
+              this.messageService.add({
+                severity: 'success',
+                summary: '¡Listo!',
+                detail: dto.id ? 'Horario actualizado' : 'Horario creado'
+              });
+              this.objetoDialog = false;
+              this.listar();
+            } else {
               this.messageService.add({
                 severity: 'error',
-                summary:  'Error',
-                detail:   'Error de comunicación con el servidor.'
+                summary: 'Error',
+                detail: 'No se pudo procesar.'
               });
             }
-          });
+          },
+          error: () => {
+            this.loading = false;
+            this.messageService.add({
+              severity: 'error',
+              summary: 'Error',
+              detail: 'Error de comunicación con el servidor.'
+            });
+          }
+        });
       }
 
 

--- a/Frontend/sakai-ng-master/src/app/biblioteca/web/catalogo/catalogo-lista.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/web/catalogo/catalogo-lista.ts
@@ -1,22 +1,18 @@
 import { ChangeDetectorRef, Component, ElementRef, OnInit, ViewChild } from '@angular/core';
 import { ClaseGeneral } from '../../interfaces/clase-general';
 import { TemplateModule } from '../../template.module';
-import { MessageService, ConfirmationService, MenuItem } from 'primeng/api';
+import { MessageService, MenuItem } from 'primeng/api';
 import { GenericoService } from '../../services/generico.service';
-import { ReservasService } from '../../services/reservas.service';
-import { FormBuilder } from '@angular/forms';
-import { UsuarioService } from '../../services/usuarios.service';
 import { Table } from 'primeng/table';
 import { Menu } from 'primeng/menu';
-import { HttpErrorResponse } from '@angular/common/http';
-import { PortalService } from '../../services/portal.service';
-import { Material } from '../../interfaces/material-bibliografico/material';
 import { TipoRecurso } from '../../interfaces/tipo-recurso';
 import { MaterialBibliograficoService } from '../../services/material-bibliografico.service';
-import { Router } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { PortalDetalleEjemplar } from '../portal-landing/components/portal-detalle-ejemplar';
 import { PortalDisponibleEjemplar } from '../portal-landing/components/portal-disponible-ejemplar';
 import { BibliotecaDTO } from '../../interfaces/material-bibliografico/biblioteca.model';
+import { ProgressSpinnerModule } from 'primeng/progressspinner';
+import { environment } from '../../../../environments/environment';
 
 @Component({
     selector: 'catalogo-lista',
@@ -94,9 +90,12 @@ import { BibliotecaDTO } from '../../interfaces/material-bibliografico/bibliotec
 
     </ng-template>
     </p-toolbar>
-            <p-table #dt1 [value]="data" dataKey="id" [rows]="10" [showCurrentPageReport]="true"
+    <div *ngIf="loading" class="flex justify-center py-4">
+        <p-progressSpinner></p-progressSpinner>
+    </div>
+            <p-table *ngIf="!loading" #dt1 [value]="data" dataKey="id" [rows]="10" [showCurrentPageReport]="true"
                     currentPageReportTemplate="Mostrando {first} a {last} de {totalRecords} registros"
-                    [rowsPerPageOptions]="[10, 25, 50]" [loading]="loading" [rowHover]="true"
+                    [rowsPerPageOptions]="[10, 25, 50]" [rowHover]="true"
                     styleClass="p-datatable-gridlines" [paginator]="true"
                     [globalFilterFields]="['codigo','titulo','editorial.autorPersonal','editorial.autorSecundario','editorial.anio']"
                     responsiveLayout="scroll">
@@ -144,8 +143,8 @@ import { BibliotecaDTO } from '../../interfaces/material-bibliografico/bibliotec
                             </td>
                             <td class="text-center">
                             <div class="flex flex-wrap justify-center gap-2">
-                                <p-button outlined icon="pi pi-search-plus" pTooltip="Más información" tooltipPosition="bottom" (click)="masInformacion()"/>
-                                <p-button icon="pi pi-map-marker" pTooltip="Disponibilidad" tooltipPosition="bottom" (click)="disponible()"/>
+                                <p-button outlined icon="pi pi-search-plus" pTooltip="Más información" tooltipPosition="bottom" (click)="masInformacion(objeto)"/>
+                                <p-button icon="pi pi-map-marker" pTooltip="Disponibilidad" tooltipPosition="bottom" (click)="disponible(objeto)"/>
                                 <!--<p-button icon="pi pi-calendar" pTooltip="Reservar" tooltipPosition="bottom" (click)="reservar()"/>-->
                             </div>
 
@@ -159,11 +158,6 @@ import { BibliotecaDTO } from '../../interfaces/material-bibliografico/bibliotec
                             <td colspan="11">No se encontraron registros.</td>
                         </tr>
                     </ng-template>
-                    <ng-template pTemplate="loadingbody">
-                        <tr>
-                            <td colspan="11">Cargando datos. Espere por favor.</td>
-                        </tr>
-                    </ng-template>
                 </p-table>
             </div>
 
@@ -171,8 +165,8 @@ import { BibliotecaDTO } from '../../interfaces/material-bibliografico/bibliotec
         <portal-detalle-ejemplar [objeto]="objeto" [displayDialog]="displayDialog"/>
         <portal-disponible-ejemplar [objeto]="objeto" [displayDialog]="displayDisponibleDialog"/>
     `,
-    imports: [TemplateModule, TemplateModule, PortalDetalleEjemplar,PortalDisponibleEjemplar],
-    providers: [MessageService, ConfirmationService]
+    imports: [TemplateModule, PortalDetalleEjemplar, PortalDisponibleEjemplar, ProgressSpinnerModule],
+    providers: [MessageService]
 })
 export class CatalogoLista implements OnInit {
     modulo: string = "catalogo";
@@ -195,9 +189,14 @@ export class CatalogoLista implements OnInit {
     objeto:any;
     palabraClave: string = '';
 
-    constructor( private router: Router,private materialBibliograficoService: MaterialBibliograficoService, private portalService: PortalService, private reservasService: ReservasService, private genericoService: GenericoService,
-
-        usuariooService: UsuarioService, private fb: FormBuilder, private messageService: MessageService, private confirmationService: ConfirmationService,private cd: ChangeDetectorRef) { }
+    constructor(
+        private router: Router,
+        private route: ActivatedRoute,
+        private materialBibliograficoService: MaterialBibliograficoService,
+        private genericoService: GenericoService,
+        private messageService: MessageService,
+        private cd: ChangeDetectorRef
+    ) {}
     async ngOnInit() {
         // this.user = this.authService.getUser();
 
@@ -209,6 +208,7 @@ export class CatalogoLista implements OnInit {
         await this.listarTiposRecurso();
         await this.listaFiltros();
         await this.ListaSede();
+        this.palabraClave = this.route.snapshot.queryParamMap.get('valor') ?? '';
         await this.listar();
     }
 
@@ -229,29 +229,24 @@ export class CatalogoLista implements OnInit {
     }
 
     listaFiltros() {
-        this.loading = true;
-        this.data = [];
-        this.materialBibliograficoService.filtros(this.modulo + '/lista')
+        this.materialBibliograficoService
+            .filtros(this.modulo + '/lista')
             .subscribe(
                 (result: any) => {
-                    this.loading = false;
                     if (result.status == "0") {
                         this.filtros = result.data;
                         this.opcionFiltro = this.filtros[0];
                     }
                 }
-                , (error: HttpErrorResponse) => {
-                    this.loading = false;
-                }
             );
     }
+
     async listarTiposRecurso() {
-        this.loading = true;
         this.dataTipoRecursoFiltro = [];
-        this.genericoService.tiporecurso_get(this.modulo + '/lista')
+        this.genericoService
+            .tiporecurso_get(this.modulo + '/lista')
             .subscribe(
                 (result: any) => {
-                    this.loading = false;
                     if (result.status == "0") {
                         let recursosFiltrados = result.data.filter((recurso: { tipo: { id: any; }; }) => recurso.tipo.id === 1);
 
@@ -260,13 +255,12 @@ export class CatalogoLista implements OnInit {
                         this.tipoRecursoFiltro = this.dataTipoRecursoFiltro[0];
                     }
                 }
-                , (error: HttpErrorResponse) => {
-                    this.loading = false;
-                }
             );
     }
+
 listar() {
   this.loading = true;
+  this.data = [];
   this.materialBibliograficoService
     .catalogo(
       this.palabraClave,
@@ -274,10 +268,37 @@ listar() {
       this.tipoRecursoFiltro.id,
       this.opcionFiltro.descripcion
     )
-    .subscribe(list => {
-      this.data = list;      // ahora son BibliotecaDTO[]
-      this.loading = false;
-    }, () => this.loading = false);
+    .subscribe(
+      list => {
+        this.data = list.map(b => ({
+          ...b,
+          urlPortada: this.getImageUrl(b)
+        }));
+        this.loading = false;
+      },
+      () => (this.loading = false)
+    );
+}
+
+getImageUrl(obj: BibliotecaDTO): string | undefined {
+  if ((obj as any).material?.url) {
+    const p = (obj as any).material.url as string;
+    return p.startsWith('http') ? p : `${environment.filesUrl}${p}`;
+  }
+  if (obj.rutaImagen) {
+    const base = obj.rutaImagen.startsWith('http')
+      ? obj.rutaImagen
+      : `${environment.filesUrl}${obj.rutaImagen.startsWith('/') ? '' : '/'}${obj.rutaImagen}`;
+    if (obj.nombreImagen) {
+      if (base.endsWith(obj.nombreImagen)) {
+        return base;
+      }
+      const sep = base.endsWith('/') ? '' : '/';
+      return base + sep + obj.nombreImagen;
+    }
+    return base;
+  }
+  return undefined;
 }
 
     onGlobalFilter(table: Table, event: Event) {
@@ -297,24 +318,23 @@ listar() {
     reservar(){
         this.router.navigate(['/reservar']);
     }
-    masInformacion(){
-      this.objeto={
-          codigo:''
-      }
+    masInformacion(obj: BibliotecaDTO){
+      this.objeto = obj;
       this.displayDialog = false;
       this.cd.detectChanges();
       setTimeout(() => {
           this.displayDialog = true;
-          this.cd.detectChanges(); // Vuelve a detectar cambios para mostrar el diálogo
+          this.cd.detectChanges();
       }, 50);
 
     }
-    disponible(){
+    disponible(obj: BibliotecaDTO){
+        this.objeto = obj;
         this.displayDisponibleDialog = false;
         this.cd.detectChanges();
         setTimeout(() => {
             this.displayDisponibleDialog = true;
-            this.cd.detectChanges(); // Vuelve a detectar cambios para mostrar el diálogo
+            this.cd.detectChanges();
         }, 50);
     }
 }

--- a/Frontend/sakai-ng-master/src/app/biblioteca/web/portal-landing/components/portal-horarios.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/web/portal-landing/components/portal-horarios.ts
@@ -43,7 +43,8 @@ export class PortalHorarios implements OnInit {
         this.portalService.listarHorarios().subscribe({
             next: res => {
                 if (res.p_status === 0) {
-                    this.data = res.data;
+                    // Solo mostrar los horarios disponibles (estadoId === 2)
+                    this.data = res.data.filter(h => h.estadoId === 2);
                 } else {
                     this.messageService.add({ severity: 'warn', detail: res.message });
                 }


### PR DESCRIPTION
## Resumen
- Elimina la carga duplicada del catálogo mostrando la tabla solo tras finalizar la búsqueda.
- Mantiene un único `ProgressSpinner` centrado mientras se obtienen los resultados.

## Pruebas
- `npm test` *(falla: error TS18003, no se encontraron entradas en tsconfig.spec.json)*
- `mvn -q test` *(falla: MissingProjectException: no hay POM en el directorio)*

------
https://chatgpt.com/codex/tasks/task_e_68ad35cc20048329a76e88bd5ea4e6e8