### PR TITLE
Evita duplicidad de correo al actualizar usuarios

### DIFF
--- a/Frontend/sakai-ng-master/src/app/biblioteca/interfaces/usuario.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/interfaces/usuario.ts
@@ -8,6 +8,9 @@ export class Usuario {
     numDocumento?: number;
     tipoDocumento?: number;
     nombreUsuario?: string;
+    apellidoPaterno?: string;
+    apellidoMaterno?: string;
+    password?: string;
     sede?: ClaseGeneral;
     idEstado?: string;
     tipodocumento?: ClaseGeneral;
@@ -36,7 +39,10 @@ export class Usuario {
         this.tipodocumento=new ClaseGeneral();
         this.numerodocumento='';
         this.nombres='';
+        this.apellidoPaterno='';
+        this.apellidoMaterno='';
         this.email='';
+        this.password='';
         this.telefono='';
         this.celular='';
         this.direccion='';

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/usuarios/usuario-lista.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/usuarios/usuario-lista.ts
@@ -215,7 +215,7 @@ import { Usuario } from '../../interfaces/usuario';
                 <div class="flex flex-col md:flex-row gap-x-4 gap-y-2">
                     <div class="flex flex-col gap-2 w-full">
                         <label for="password">Contraseña</label>
-                        <input type="text" pInputText id="password" formControlName="password"/>
+                        <p-password id="password" formControlName="password" [toggleMask]="true" [feedback]="false" inputStyleClass="w-full"></p-password>
                         <app-input-validation [form]="form" modelo="password" ver="password"></app-input-validation>
                     </div>
                 </div>
@@ -521,14 +521,17 @@ export class UsuarioLista implements OnInit {
         );
 
       const usuarioPatch = {
-         id: this.objeto.idUsuario, // Corregido para mapear el ID real
+         id: this.objeto.idUsuario ?? this.objeto.id, // Corregido para mapear el ID real
          rol: this.objeto.rol
              ? new ClaseGeneral({ id: this.objeto.rol.idRol, descripcion: this.objeto.rol.descripcion })
              : new ClaseGeneral(),
          sede: this.objeto.sede,
          tipodocumento: documentoSeleccionado,
-         numerodocumento: this.objeto.numDocumento,
-         nombres: this.objeto.nombreUsuario,
+         numDocumento: this.objeto.numDocumento,
+         nombreUsuario: this.objeto.nombreUsuario,
+         apellidoPaterno: this.objeto.apellidoPaterno,
+         apellidoMaterno: this.objeto.apellidoMaterno,
+         password: '',
          email: this.objeto.email,
          telefono: this.objeto.telefono?.toString(),
          celular: this.objeto.celular?.toString(),
@@ -641,16 +644,19 @@ export class UsuarioLista implements OnInit {
         let rol = this.form.get('rol')?.value;
         let sede = this.form.get('sede')?.value;
         const usuarioLogeado = localStorage.getItem('upsjb_reserva') || 'desconocido';
+        const password = formValues.password ? formValues.password : this.objeto.password;
 
         console.log("ver"+rol.idRol);
+        const id = Number(this.form.get('id')?.value) || 0;
         const data = {
-            idUsuario: this.form.get('id')?.value,
+            id,
+            idUsuario: id,
             nombreUsuario: formValues.nombreUsuario,
             apellidoPaterno: formValues.apellidoPaterno,
             apellidoMaterno: formValues.apellidoMaterno,
             email: formValues.email,
             emailPersonal: formValues.emailPersonal,
-            password: formValues.password,
+            password,
             horaTrabajo: formValues.horaTrabajo,
             idSede: sede?.id,
             idTipoDocumento: tipodocumento?.idTipoDocumento,
@@ -661,7 +667,7 @@ export class UsuarioLista implements OnInit {
             usuarioCreacion: usuarioLogeado
         };
 
-       if (!data.idUsuario || data.idUsuario === 0) {
+       if (!id) {
                // Registro nuevo
                this.usuarioService.conf_event_post(data,'admin/register')
                    .subscribe(result => {


### PR DESCRIPTION
## Resumen
- Corrige el mapeo del ID en la edición de usuarios
- Usa el ID para decidir entre registro y actualización, enviando al endpoint correcto

## Pruebas
- `npm test -- --watch=false --browsers=ChromeHeadless` (falla: TS18003, no se encontraron entradas)
- `npm run build` (falla: múltiples errores de TypeScript en material-bibliografico.ts)
- `mvn -q test` (falla: Could not transfer artifact, Network is unreachable)


------
https://chatgpt.com/codex/tasks/task_e_68adf3ee0a348329a0d38b3faac58599