### PR TITLE
fix: corrige mensajes de carga en material bibliográfico

### DIFF
--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/mantenimientos/material-bibliografico/material-bibliografico.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/mantenimientos/material-bibliografico/material-bibliografico.ts
@@ -195,13 +195,10 @@ export class MaterialBibliografico {
   @ViewChild('menu') menu!: Menu;
   @ViewChild('filter') filter!: ElementRef;
   items!: MenuItem[];
-  dataTipo: ClaseGeneral[] = [];
   dataTipoRecurso: TipoRecurso[] = [];
   dataSede: Sedes[] = [];
   dataSedesFiltro: Sedes[] = [];
   sedeFiltro: Sedes = new Sedes();
-  dataTipoFiltro: ClaseGeneral[] = [];
-  tipoFiltro: ClaseGeneral = new ClaseGeneral();
   dataTipoRecursoFiltro: TipoRecurso[] = [];
   tipoRecursoFiltro: TipoRecurso = new TipoRecurso();
   filtros: ClaseGeneral[] = [];
@@ -246,7 +243,6 @@ export class MaterialBibliografico {
     }
     await this.listarTiposRecurso();
     await this.listaFiltros();
-    await this.ListaTipo();
 //     await this.ListaSede();
     await this.listar();
     this.formValidar();
@@ -393,22 +389,6 @@ onSaved(): void {
   }
 
 
-  async ListaTipo() {
-    try {
-      const result: any = await this.genericoService.tipo_get('conf/tipo-lista').toPromise();
-      if (result.status === "0") {
-        this.dataTipo = result.data;
-        let tipos = [{ id: 0, descripcion: 'TODAS LOS TIPOS', activo: true, estado: 1 }, ...this.dataTipo];
-
-        this.dataTipoFiltro = tipos;
-        this.tipoFiltro = this.dataTipoFiltro[0];
-      }
-    } catch (error) {
-      console.log(error);
-      this.messageService.add({ severity: 'error', summary: 'Error', detail: 'Ocurrió un error. No se pudo cargar roles' });
-    }
-
-  }
   async listarTiposRecurso() {
     this.loading = true;
     this.dataTipoRecurso = [];
@@ -442,7 +422,7 @@ onSaved(): void {
       }
     } catch (error) {
       console.log(error);
-      this.messageService.add({ severity: 'error', summary: 'Error', detail: 'Ocurrió un error. No se pudo cargar roles' });
+      this.messageService.add({ severity: 'error', summary: 'Error', detail: 'Ocurrió un error. No se pudieron cargar las sedes' });
     }
 
   }


### PR DESCRIPTION
## Resumen
- Ajusta mensajes de error para tipos y sedes en material bibliográfico
- Elimina método `ListaTipo` y variables asociadas, evitando consultas innecesarias

## Testing
- `npm test -- --watch=false` (falla: No inputs were found in config file tsconfig.spec.json)


------
https://chatgpt.com/codex/tasks/task_e_68ae209294748329b3f5dff4a8b26b1b