### PR TITLE
feat: permitir cambiar de cuenta Microsoft

### DIFF
--- a/Frontend/sakai-ng-master/src/app/biblioteca/services/auth.service.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/services/auth.service.ts
@@ -320,8 +320,12 @@ private resetInactivityTimer(): void {
     localStorage.removeItem('currentUser');
     localStorage.removeItem(this.TOKEN_NAME);
     localStorage.removeItem(this.REFRESH_NAME);
-    // Redirige a la página de login o principal según tu flujo
-    this.router.navigate(['/']);
+    const activeAccount = this.msalService.instance.getActiveAccount();
+    if (activeAccount) {
+      this.msalService.logoutPopup({ mainWindowRedirectUri: '/auth/login' }).subscribe();
+    } else {
+      this.router.navigate(['/auth/login']);
+    }
     return;
   }
 

--- a/Frontend/sakai-ng-master/src/app/pages/auth/login.ts
+++ b/Frontend/sakai-ng-master/src/app/pages/auth/login.ts
@@ -32,7 +32,10 @@ export interface LoginCredentials {
                         <div class="text-center mb-8">
                             <img src="assets/logo.png" alt="Logo" class="mb-8 w-30 shrink-0 mx-auto" />
                             <span class="text-muted-color font-medium mb-4">Inicia sesión para continuar</span>
-                            <p-button label="Iniciar sesión con Microsoft365" styleClass="w-full mt-4" (click)="loginWithMicrosoft()"></p-button>
+                            <div class="flex flex-col sm:flex-row gap-2 w-full mt-4">
+                                <p-button label="Iniciar sesión con Microsoft365" styleClass="w-full flex-1" (click)="loginWithMicrosoft()"></p-button>
+                                <p-button label="Cambiar de cuenta" icon="pi pi-sign-out" severity="secondary" styleClass="w-full flex-1" (click)="logout()" [disabled]="loading"></p-button>
+                            </div>
                              <div class="flex items-center my-4">
                                <!-- Línea izquierda -->
                                <div class="flex-grow border-t border-gray-300"></div>
@@ -83,6 +86,16 @@ export class Login implements OnInit {
      loginWithMicrosoft() {
         this.authService.loginMicrosoft();
      }
+
+    loading: boolean = false;
+
+    logout(): void {
+        this.loading = true;
+        this.msalService.logoutPopup({ mainWindowRedirectUri: '/auth/login' }).subscribe({
+            next: () => (this.loading = false),
+            error: () => (this.loading = false)
+        });
+    }
 
     ngOnInit(): void {
         const remembered = localStorage.getItem('rememberedEmail');


### PR DESCRIPTION
## Resumen
- agrega un botón para cerrar sesión de Microsoft y escoger otra cuenta en la pantalla de login
- cierra la sesión de Microsoft al cerrar sesión del sistema
- organiza los botones de Microsoft para una mejor presentación en la pantalla de acceso

## Testing
- `npm test -- --watch=false` *(falla: error TS18003 no inputs were found)*

------
https://chatgpt.com/codex/tasks/task_e_68af638e4f98832993fd753ea3b6e94b