### PR TITLE
Ordenar noticias por fecha descendente

### DIFF
--- a/Backend/login-microsoft365/src/main/java/com/miapp/repository/NoticiaRepository.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/repository/NoticiaRepository.java
@@ -10,5 +10,5 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 public interface NoticiaRepository extends JpaRepository<Noticia,Long> {
-    List<Noticia> findByFechacreacionBetween(LocalDateTime start, LocalDateTime end);
+    List<Noticia> findByFechacreacionBetweenOrderByFechacreacionDesc(LocalDateTime start, LocalDateTime end);
 }

--- a/Backend/login-microsoft365/src/main/java/com/miapp/service/NoticiaService.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/service/NoticiaService.java
@@ -21,7 +21,7 @@ public class NoticiaService {
     private final EstadoRepository estadoRepo;
 
     public List<NoticiaDTO> listarPorFecha(LocalDateTime start, LocalDateTime end) {
-        return repo.findByFechacreacionBetween(start, end).stream()
+        return repo.findByFechacreacionBetweenOrderByFechacreacionDesc(start, end).stream()
                 .map(this::toDto)
                 .collect(Collectors.toList());
     }


### PR DESCRIPTION
## Resumen
- Ordena las noticias por fecha de creación descendente desde el repositorio.
- Ajusta el servicio de noticias para usar la nueva consulta ordenada.

## Testing
- `mvn -q test` *(falla: Network is unreachable y no se pudo resolver spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b64a6a7c8329870a73aa6fe034f9