### PR TITLE
Validación de especialidades duplicadas

### DIFF
--- a/Backend/login-microsoft365/src/main/java/com/miapp/repository/EspecialidadRepository.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/repository/EspecialidadRepository.java
@@ -1,13 +1,15 @@
 package com.miapp.repository;
 
 import com.miapp.model.Especialidad;
-import com.miapp.model.TipoDocumento;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface EspecialidadRepository extends JpaRepository<Especialidad, Long> {
     List<Especialidad> findByActivoTrue();
+
+    Optional<Especialidad> findByDescripcionIgnoreCase(String descripcion);
 }

--- a/Backend/login-microsoft365/src/main/java/com/miapp/service/EspecialidadService.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/service/EspecialidadService.java
@@ -18,6 +18,11 @@ public class EspecialidadService {
 
     @Transactional
     public Especialidad save(Especialidad especialidad) {
+        String descripcion = especialidad.getDescripcion().trim();
+        if (especialidadRepository.findByDescripcionIgnoreCase(descripcion).isPresent()) {
+            throw new IllegalArgumentException("La especialidad ya se encuentra registrada");
+        }
+        especialidad.setDescripcion(descripcion);
         return especialidadRepository.save(especialidad);
     }
 

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/mantenimientos/material-bibliografico/modal-libro.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/mantenimientos/material-bibliografico/modal-libro.ts
@@ -1205,6 +1205,12 @@ finalizar(): void {
     }
     guardarEspecialidad() {
         if (this.formEspecialidad.valid) {
+           const desc = this.formEspecialidad.value.descripcion.trim().toLowerCase();
+           const existe = this.especialidadLista.some(e => (e.descripcion || '').trim().toLowerCase() === desc);
+           if (existe) {
+             this.messageService.add({ severity: 'warn', summary: 'Advertencia', detail: 'La especialidad ya se encuentra registrada' });
+             return;
+           }
            this.confirmationService.confirm({
              message: '¿Estás seguro de que quieres registrar esta especialidad?',
              header: 'Confirmar',

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/mantenimientos/material-bibliografico/modal-otros.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/mantenimientos/material-bibliografico/modal-otros.ts
@@ -733,6 +733,12 @@ export class ModalOtrosComponent implements OnInit {
     }
     guardarEspecialidad() {
         if (this.formEspecialidad.valid) {
+            const desc = this.formEspecialidad.value.descripcion.trim().toLowerCase();
+            const existe = this.especialidadLista.some(e => (e.descripcion || '').trim().toLowerCase() === desc);
+            if (existe) {
+                this.messageService.add({ severity: 'warn', summary: 'Advertencia', detail: 'La especialidad ya se encuentra registrada' });
+                return;
+            }
 
             this.confirmationService.confirm({
                 message: '¿Estás seguro(a) de que quieres registrar?',

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/mantenimientos/material-bibliografico/modal-revista.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/mantenimientos/material-bibliografico/modal-revista.ts
@@ -868,6 +868,12 @@ export class ModalRevistaComponent implements OnInit {
     }
     guardarEspecialidad() {
         if (this.formEspecialidad.valid) {
+            const desc = this.formEspecialidad.value.descripcion.trim().toLowerCase();
+            const existe = this.especialidadLista.some(e => (e.descripcion || '').trim().toLowerCase() === desc);
+            if (existe) {
+                this.messageService.add({ severity: 'warn', summary: 'Advertencia', detail: 'La especialidad ya se encuentra registrada' });
+                return;
+            }
 
             this.confirmationService.confirm({
                 message: '¿Estás seguro(a) de que quieres registrar?',

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/mantenimientos/material-bibliografico/modal-tesis.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/mantenimientos/material-bibliografico/modal-tesis.ts
@@ -808,6 +808,12 @@ export class ModalTesisComponent implements OnInit {
     }
     guardarEspecialidad() {
         if (this.formEspecialidad.valid) {
+            const desc = this.formEspecialidad.value.descripcion.trim().toLowerCase();
+            const existe = this.especialidadLista.some(e => (e.descripcion || '').trim().toLowerCase() === desc);
+            if (existe) {
+                this.messageService.add({ severity: 'warn', summary: 'Advertencia', detail: 'La especialidad ya se encuentra registrada' });
+                return;
+            }
 
             this.confirmationService.confirm({
                 message: '¿Estás seguro(a) de que quieres registrar?',


### PR DESCRIPTION
## Resumen
- Evita registrar especialidades repetidas en el backend.
- Muestra advertencias en los modales de mantenimiento si la especialidad ya existe.

## Pruebas
- `mvn -q test` *(falla: Non-resolvable parent POM)*
- `npm test -- --watch=false` *(falla: No inputs were found in config file)*

------
https://chatgpt.com/codex/tasks/task_e_68b0bf201ab08329b6517648d40d48a7