### PR TITLE
Corrige actualización de datos de usuario

### DIFF
--- a/Backend/login-microsoft365/src/main/java/com/miapp/controller/AuthController.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/controller/AuthController.java
@@ -208,8 +208,8 @@ public class AuthController {
             Usuario nuevoUsuario = usuarioService.registrarUsuario(usuario);
             return ResponseEntity.ok(Map.of("p_status", 0, "p_mensaje", "Usuario registrado exitosamente por el administrador", "data", nuevoUsuario));
         } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                    .body(Map.of("p_status", -1, "p_mensaje", e.getMessage()));
+            // Se retorna 200 para que el frontend pueda manejar el mensaje de validación
+            return ResponseEntity.ok(Map.of("p_status", -1, "p_mensaje", e.getMessage()));
         }
     }
 
@@ -264,11 +264,11 @@ public class AuthController {
                     )
             );
         } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                    .body(Map.of(
-                            "p_status", -1,
-                            "p_mensaje", e.getMessage()
-                    ));
+            // Se retorna 200 para permitir que el frontend muestre el mensaje de error
+            return ResponseEntity.ok(Map.of(
+                    "p_status", -1,
+                    "p_mensaje", e.getMessage()
+            ));
         }
     }
 

--- a/Backend/login-microsoft365/src/main/java/com/miapp/service/UsuarioService.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/service/UsuarioService.java
@@ -202,12 +202,21 @@ public class UsuarioService {
 
         // Actualizar los campos simples
         usuarioExistente.setNombreUsuario(usuario.getNombreUsuario());
+        usuarioExistente.setApellidoPaterno(usuario.getApellidoPaterno());
+        usuarioExistente.setApellidoMaterno(usuario.getApellidoMaterno());
         usuarioExistente.setEmail(usuario.getEmail());
         if (usuario.getPassword() != null && !usuario.getPassword().isBlank()) {
             usuarioExistente.setPassword(passwordEncoder.encode(usuario.getPassword()));
         }
         usuarioExistente.setTelefono(usuario.getTelefono());
+        usuarioExistente.setCell(usuario.getCell());
         usuarioExistente.setDireccion(usuario.getDireccion());
+        usuarioExistente.setNumDocumento(usuario.getNumDocumento());
+        if (usuario.getTipodocumento() != null && usuario.getTipodocumento().getIdTipoDocumento() != null) {
+            TipoDocumento tipo = tipoDocumentoRepository.findById(usuario.getTipodocumento().getIdTipoDocumento())
+                    .orElseThrow(() -> new RuntimeException("Tipo de documento no encontrado"));
+            usuarioExistente.setTipodocumento(tipo);
+        }
         // Se omite la actualización de roles aquí, pues se maneja en endpoints específicos
 
         return usuarioRepository.save(usuarioExistente);

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/usuarios/usuario-lista.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/usuarios/usuario-lista.ts
@@ -11,6 +11,7 @@ import { Menu } from 'primeng/menu';
 import { Message } from 'primeng/message';
 import { UsuarioService } from '../../services/usuarios.service';
 import { Usuario } from '../../interfaces/usuario';
+import { firstValueFrom } from 'rxjs';
 
 @Component({
     selector: 'app-usuario-lista',
@@ -366,20 +367,20 @@ export class UsuarioLista implements OnInit {
         }
     }
 
-    async tipodocumentos() {
-        this.usuarioService.conf_event_get('lista-activo').subscribe(
-            (result: any) => {
-                if (result.status == '0') {
-                    this.dataTipoDocumento = result.data;
-                    console.log('Tipos de documento:', this.dataTipoDocumento);
-                }
-                this.loading = false;
-            },
-            (error: HttpErrorResponse) => {
-                console.log(error);
-                this.loading = false;
+    async tipodocumentos(): Promise<void> {
+        try {
+            const result: any = await firstValueFrom(
+                this.usuarioService.conf_event_get('lista-activo')
+            );
+            if (result.status === '0') {
+                this.dataTipoDocumento = result.data;
+                console.log('Tipos de documento:', this.dataTipoDocumento);
             }
-        );
+        } catch (error) {
+            console.log(error);
+        } finally {
+            this.loading = false;
+        }
     }
     async formValidar() {
         let dataObjeto = this.objeto ? JSON.parse(JSON.stringify(this.objeto)) : {};
@@ -420,7 +421,12 @@ export class UsuarioLista implements OnInit {
                               return false;
                           }
                         : () => true;
-                this.data = registros.filter((obj: any) => filtroRol(obj));
+                this.data = registros
+                    .filter((obj: any) => filtroRol(obj))
+                    .map((obj: any) => ({
+                        ...obj,
+                        celular: obj.celular ?? obj.CELL ?? obj.cell
+                    }));
             },
             (_error: HttpErrorResponse) => {
                 this.loading = false;
@@ -471,7 +477,13 @@ export class UsuarioLista implements OnInit {
         this.objeto = JSON.parse(JSON.stringify(objeto));
         console.log('Objeto a editar:', this.objeto);
 
-        const documentoSeleccionado = this.dataTipoDocumento.find((item) => item.idTipoDocumento === this.objeto.tipodocumento?.idTipoDocumento);
+        const idTipoDoc =
+            this.objeto.tipodocumento?.idTipoDocumento ??
+            this.objeto.idtipodocumento;
+
+        const documentoSeleccionado = this.dataTipoDocumento.find(
+            (item) => item.idTipoDocumento === Number(idTipoDoc)
+        );
 
         const usuarioPatch = {
             id: this.objeto.idUsuario ?? this.objeto.id, // Corregido para mapear el ID real
@@ -613,9 +625,12 @@ export class UsuarioLista implements OnInit {
             password,
             horaTrabajo: formValues.horaTrabajo,
             idSede: sede?.id,
-            idTipoDocumento: tipodocumento?.idTipoDocumento,
+            tipodocumento: tipodocumento
+                ? { idTipoDocumento: tipodocumento.idTipoDocumento }
+                : null,
             numDocumento: formValues.numDocumento,
             telefono: formValues.telefono,
+            CELL: formValues.celular,
             direccion: formValues.direccion,
             roles: [{ idRol: rol.idRol }],
             usuarioCreacion: usuarioLogeado


### PR DESCRIPTION
## Resumen
- Retorna respuestas HTTP 200 con mensajes de validación cuando el correo o el número de documento ya están registrados
- Recupera y asigna el tipo de documento correcto al actualizar usuarios
- Envía el objeto `tipodocumento` desde el formulario para que se guarde la selección

## Testing
- `mvn -q test` *(falla: MissingProjectException)*
- `mvn -q test -f Backend/login-microsoft365/pom.xml` *(falla: Non-resolvable parent POM; Network is unreachable)*
- `npm test --prefix Frontend/sakai-ng-master` *(falla: TS18003 No inputs were found in config file)*
- `npm run build --prefix Frontend/sakai-ng-master`


------
https://chatgpt.com/codex/tasks/task_e_68b0cd6535e883298a6c1d9c81069a9c