### PR TITLE
feat: permitir registrar roles

### DIFF
--- a/Backend/login-microsoft365/src/main/java/com/miapp/controller/RolController.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/controller/RolController.java
@@ -4,9 +4,7 @@ import com.miapp.model.Rol;
 import com.miapp.repository.RolRepository;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.Map;
@@ -31,6 +29,30 @@ public class RolController {
             // En caso de error se retorna un mensaje y status "-1"
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                     .body(Map.of("status", "-1", "message", "Error al cargar roles: " + e.getMessage()));
+        }
+    }
+
+    @PostMapping("/registrar")
+    public ResponseEntity<?> registrarRol(@RequestBody Map<String, Object> payload) {
+        try {
+            Long id = payload.get("id") != null ? Long.valueOf(payload.get("id").toString()) : 0L;
+            String descripcion = payload.get("descripcion").toString();
+
+            // Evita duplicados cuando se registra un nuevo rol
+            if (id == 0 && rolRepository.findByDescripcion(descripcion).isPresent()) {
+                return ResponseEntity.ok(
+                        Map.of("p_status", -1, "p_mensaje", "La descripción del rol ya existe"));
+            }
+
+            Rol rol = (id > 0) ? rolRepository.findById(id).orElse(new Rol()) : new Rol();
+            rol.setDescripcion(descripcion);
+            Rol guardado = rolRepository.save(rol);
+
+            return ResponseEntity.ok(
+                    Map.of("p_status", 0, "p_mensaje", "Rol registrado correctamente", "data", guardado));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(Map.of("p_status", -1, "p_mensaje", e.getMessage()));
         }
     }
 }

--- a/Backend/login-microsoft365/src/main/java/com/miapp/model/Rol.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/model/Rol.java
@@ -11,7 +11,8 @@ import lombok.NoArgsConstructor;
 public class Rol {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "rol_seq")
+    @SequenceGenerator(name = "rol_seq", sequenceName = "ROLUSUARIO_SEQ", allocationSize = 1)
     @Column(name = "IDROL")
     private Long idRol;
 


### PR DESCRIPTION
## Summary
- habilitar endpoint POST `/auth/roles/registrar` para crear o actualizar roles
- generar identificadores de rol mediante secuencia para Oracle

## Testing
- `mvn -q test` *(falló: Network is unreachable al resolver dependencias)*

------
https://chatgpt.com/codex/tasks/task_e_68b0ef0bf974832994afef5050e77953