### PR TITLE
Limpiar relaciones al eliminar roles

### DIFF
--- a/Backend/login-microsoft365/src/main/java/com/miapp/controller/RolController.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/controller/RolController.java
@@ -84,6 +84,8 @@ public class RolController {
                 return ResponseEntity.status(HttpStatus.NOT_FOUND)
                         .body(Map.of("p_status", -1, "p_mensaje", "Rol no encontrado"));
             }
+            moduloRepository.removeAllModulosFromRol(id);
+            usuarioRepository.removeRolFromUsuarios(id);
             rolRepository.deleteById(id);
             return ResponseEntity.ok(Map.of("p_status", 0, "p_mensaje", "Rol eliminado correctamente"));
         } catch (Exception e) {

--- a/Backend/login-microsoft365/src/main/java/com/miapp/repository/ModuloRepository.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/repository/ModuloRepository.java
@@ -25,4 +25,9 @@ public interface ModuloRepository extends JpaRepository<Modulo, Long> {
     @Transactional
     @Query(value = "DELETE FROM ROLUSUARIO_MODULO WHERE IDROL = :idRol AND IDMODULO = :idModulo", nativeQuery = true)
     void removeModuloFromRol(@Param("idRol") Long idRol, @Param("idModulo") Long idModulo);
+
+    @Modifying
+    @Transactional
+    @Query(value = "DELETE FROM ROLUSUARIO_MODULO WHERE IDROL = :idRol", nativeQuery = true)
+    void removeAllModulosFromRol(@Param("idRol") Long idRol);
 }

--- a/Backend/login-microsoft365/src/main/java/com/miapp/repository/UsuarioRepository.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/repository/UsuarioRepository.java
@@ -3,8 +3,11 @@ package com.miapp.repository;
 import com.miapp.model.Usuario;
 import com.miapp.model.dto.VisitanteBibliotecaVirtualDTO;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 import java.util.Optional;
@@ -48,4 +51,9 @@ public interface UsuarioRepository extends JpaRepository<Usuario, Long> {
                     "WHERE COALESCE(u.loginCount,0) > 0 " +
                     "ORDER BY COALESCE(u.loginCount,0) DESC")
     List<VisitanteBibliotecaVirtualDTO> reporteVisitantesBibliotecaVirtual();
+
+    @Modifying
+    @Transactional
+    @Query(value = "DELETE FROM USUARIO_ROL WHERE IDROL = :idRol", nativeQuery = true)
+    void removeRolFromUsuarios(@Param("idRol") Long idRol);
 }


### PR DESCRIPTION
## Resumen
- Se agregan métodos en repositorios para eliminar asociaciones de módulos y usuarios por rol.
- El controlador de roles elimina las referencias antes de borrar un rol para evitar errores de integridad referencial.

## Pruebas
- `mvn -q test` *(falló: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b237494ef88329b2b44219c25f0733