### PR TITLE
fix: handle JWT expiration

### DIFF
--- a/Backend/login-microsoft365/src/main/java/com/miapp/config/JwtAuthenticationFilter.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/config/JwtAuthenticationFilter.java
@@ -5,36 +5,33 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-<<<<<<< HEAD
-=======
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
->>>>>>> c36c32b (chore: ignore build artifacts (target, *.jar))
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.web.filter.OncePerRequestFilter;
+
 import java.io.IOException;
 import java.util.List;
 
+/**
+ * Filtro de autenticación JWT. Valida el token antes de procesar cada petición
+ * y, si es correcto, registra la autenticación en el contexto de seguridad.
+ */
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
-<<<<<<< HEAD
-=======
     private static final List<String> EXCLUDED_PATHS = List.of(
             "/auth/login",
             "/auth/login-microsoft"
     );
 
->>>>>>> c36c32b (chore: ignore build artifacts (target, *.jar))
-    private final JwtUtil jwtUtil; // tu clase para manejar JWT
+    private final JwtUtil jwtUtil;
 
     public JwtAuthenticationFilter(JwtUtil jwtUtil) {
         this.jwtUtil = jwtUtil;
     }
 
     @Override
-<<<<<<< HEAD
-=======
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
         String path = request.getRequestURI();
         String context = request.getContextPath();
@@ -45,30 +42,22 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     }
 
     @Override
->>>>>>> c36c32b (chore: ignore build artifacts (target, *.jar))
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
         String header = request.getHeader("Authorization");
         if (header != null && header.startsWith("Bearer ")) {
             String token = header.substring(7);
-<<<<<<< HEAD
             if (jwtUtil.validateToken(token)) {
                 String username = jwtUtil.getUsernameFromToken(token);
-                // Aquí puedes obtener roles y construir la autenticación
-                UsernamePasswordAuthenticationToken authentication =
-                        new UsernamePasswordAuthenticationToken(username, null, List.of());
-=======
-            String role = jwtUtil.getRoleFromToken(token);
-            if (jwtUtil.validateToken(token)) {
-                String username = jwtUtil.getUsernameFromToken(token);
+                String role = jwtUtil.getRoleFromToken(token);
                 List<GrantedAuthority> authorities =
                         List.of(new SimpleGrantedAuthority("ROLE_" + role));
                 UsernamePasswordAuthenticationToken authentication =
-                        new UsernamePasswordAuthenticationToken(username, null, authorities);                // Aquí puedes obtener roles y construir la autenticación
->>>>>>> c36c32b (chore: ignore build artifacts (target, *.jar))
+                        new UsernamePasswordAuthenticationToken(username, null, authorities);
                 SecurityContextHolder.getContext().setAuthentication(authentication);
             }
         }
         filterChain.doFilter(request, response);
     }
 }
+

--- a/Backend/login-microsoft365/src/main/java/com/miapp/util/JwtUtil.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/util/JwtUtil.java
@@ -4,12 +4,16 @@ import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import java.util.Date;
 
 @Component
 public class JwtUtil {
+
+    private static final Logger log = LoggerFactory.getLogger(JwtUtil.class);
 
     @Value("${jwt.secret}")
     private String secret;
@@ -57,8 +61,8 @@ public class JwtUtil {
                     .parseClaimsJws(token);
             return true;
         } catch (JwtException e) {
-            // El token es inválido
-            System.out.println("Token inválido: " + e.getMessage());
+            // El token es inválido o expirado
+            log.warn("Token inválido: {}", e.getMessage());
             return false;
         }
     }
@@ -72,8 +76,6 @@ public class JwtUtil {
                 .getSubject();
     }
 
-<<<<<<< HEAD
-=======
     public String getRoleFromToken(String token) {
         return Jwts.parserBuilder()
                 .setSigningKey(Keys.hmacShaKeyFor(secret.getBytes()))
@@ -82,8 +84,6 @@ public class JwtUtil {
                 .getBody()
                 .get("role", String.class);
     }
-
->>>>>>> c36c32b (chore: ignore build artifacts (target, *.jar))
     public long getRefreshExpirationMs() {
         return refreshExpirationMs;
     }


### PR DESCRIPTION
## Summary
- resolve leftover merge conflicts and add role extraction utility
- validate JWT before parsing claims in filter to avoid ExpiredJwtException
- log invalid tokens with SLF4J instead of printing to console

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b3dd40b82c832991657d3db072bc9b