### PR TITLE
fix: cargar combos de búsqueda en catálogo

### DIFF
--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/portal/catalogo-enlinea.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/portal/catalogo-enlinea.ts
@@ -396,6 +396,42 @@ export class CatalogoEnLineaComponent {
 
     user: any;
 
+    /** Carga la lista de sedes disponibles */
+    private async cargarSedes() {
+        try {
+            const res: any = await this.genericoService
+                .sedes_get('api/equipos/sedes')
+                .toPromise();
+            const rawList: any[] = Array.isArray(res?.data) ? res.data : Array.isArray(res) ? res : [];
+            this.dataSede = rawList.map(s => new Sedes(s));
+            this.sedeFiltro = this.dataSede[0] ?? new Sedes();
+        } catch (err) {
+            this.messageService.add({ severity: 'error', detail: 'Error al cargar sedes' });
+        }
+    }
+
+    /** Carga los tipos de material bibliográfico */
+    private async cargarColecciones() {
+        try {
+            const res: any = await this.materialBibliograficoService
+                .lista_tipo_material('catalogos/tipomaterial/activos')
+                .toPromise();
+            const rawList: any[] = Array.isArray(res?.data) ? res.data : Array.isArray(res) ? res : [];
+            this.dataColeccion = rawList.map(
+                t =>
+                    new ClaseGeneral({
+                        id: t.id ?? t.tipo?.id,
+                        descripcion: t.descripcion ?? t.tipo?.descripcion,
+                        activo: t.activo ?? true,
+                        estado: 1,
+                    }),
+            );
+            this.coleccionFiltro = this.dataColeccion[0] ?? new ClaseGeneral();
+        } catch (err) {
+            this.messageService.add({ severity: 'error', detail: 'Error al cargar colecciones' });
+        }
+    }
+
     private parseTime(t: string) {
         const [h, m] = t.split(':').map(n => parseInt(n, 10));
         return { h, m };
@@ -431,22 +467,6 @@ export class CatalogoEnLineaComponent {
         return undefined;
     }
 
-<<<<<<< HEAD
-=======
-    private isDisponibleAhora(det: any): boolean {
-        if (!det.horaInicio || !det.horaFin) {
-            return true;
-        }
-        const now = new Date();
-        const start = this.parseTimeAtDate(det.horaInicio, now);
-        const end = this.parseTimeAtDate(det.horaFin, now);
-        if (end <= start) {
-            return now >= start || now <= end;
-        }
-        return now >= start && now <= end;
-    }
-
->>>>>>> c36c32b (chore: ignore build artifacts (target, *.jar))
     constructor(
         private materialBibliograficoService: MaterialBibliograficoService,
         private genericoService: GenericoService,
@@ -456,13 +476,13 @@ export class CatalogoEnLineaComponent {
     ) { }
 
     async ngOnInit() {
-         this.user = this.authService.getUser();
+        this.user = this.authService.getUser();
+        await Promise.all([this.cargarSedes(), this.cargarColecciones()]);
         this.listar();
         this.detallesPorBiblioteca = {};
     }
     listar() {
         // Recupera solo las cabeceras disponibles
-<<<<<<< HEAD
         this.loading = true;
         this.materialBibliograficoService
             .api_libros_lista('api/biblioteca/catalogo?estadoId=2')
@@ -471,21 +491,6 @@ export class CatalogoEnLineaComponent {
                     const cabeceras = (Array.isArray(result) ? result : result?.data || []).filter(
                         (b: any) =>
                             b.estadoId === 2 || b.estado?.descripcion === 'DISPONIBLE'
-=======
-        this.materialBibliograficoService
-            .api_libros_lista('api/biblioteca/disponibles')
-            .subscribe({
-                next: (result: any) => {
-                    if (result.status !== '0') {
-                        this.loading = false;
-                        return;
-                    }
-
-                    const cabeceras = result.data.filter(
-                        (b: any) =>
-                            (b.estadoId === 2 || b.estado?.descripcion === 'DISPONIBLE') &&
-                            this.isDisponibleAhora(b)
->>>>>>> c36c32b (chore: ignore build artifacts (target, *.jar))
                     );
 
                     if (cabeceras.length === 0) {
@@ -502,12 +507,7 @@ export class CatalogoEnLineaComponent {
                                     cab: b,
                                     detalles: det.filter(
                                         d =>
-<<<<<<< HEAD
                                             d.idEstado === 2 || d.estado?.descripcion === 'DISPONIBLE'
-=======
-                                            (d.idEstado === 2 || d.estado?.descripcion === 'DISPONIBLE') &&
-                                            this.isDisponibleAhora(d)
->>>>>>> c36c32b (chore: ignore build artifacts (target, *.jar))
                                     )
                                 }))
                             )
@@ -563,13 +563,7 @@ export class CatalogoEnLineaComponent {
             .subscribe({
                 next: (lista: any[]) => {
                     this.detallesPorBiblioteca[row.id] = lista.filter(
-<<<<<<< HEAD
                         d => d.idEstado === 2 || d.estado?.descripcion === 'DISPONIBLE'
-=======
-                        d =>
-                            (d.idEstado === 2 || d.estado?.descripcion === 'DISPONIBLE') &&
-                            this.isDisponibleAhora(d)
->>>>>>> c36c32b (chore: ignore build artifacts (target, *.jar))
                     );
                 },
                 error: () => {

--- a/Frontend/sakai-ng-master/src/app/biblioteca/services/generico.service.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/services/generico.service.ts
@@ -60,22 +60,19 @@ export class GenericoService {
     );
   }
 
-<<<<<<< HEAD
-  /** Obtiene el catálogo completo de módulos disponibles en el sistema */
-  modulos_get(): Observable<any> {
-    return this.http.get<any[]>(
-      `${this.apiUrl}/conf/lista-modulos`,
-      { headers: this.authHeaders() }
-    );
-  }
-
-=======
->>>>>>> c36c32b (chore: ignore build artifacts (target, *.jar))
-  sedes_get(modulo: any):Observable<any>{
-    return this.http.get<any[]>(`${this.apiUrl}/${modulo}`
-    ,{ headers: new HttpHeaders().set('Authorization',`Bearer ${this.authService.getToken()}`)}
-    );
-//     return this.http.get<any[]>('assets/demo/biblioteca/sedes.json');
+    /** Obtiene el catálogo completo de módulos disponibles en el sistema */
+    modulos_get(): Observable<any> {
+      return this.http.get<any[]>(
+        `${this.apiUrl}/conf/lista-modulos`,
+        { headers: this.authHeaders() }
+      );
+    }
+    sedes_get(modulo: any):Observable<any>{
+    const token = this.authService.getToken();
+    const options = token
+      ? { headers: new HttpHeaders().set('Authorization', `Bearer ${token}`) }
+      : {};
+    return this.http.get<any[]>(`${this.apiUrl}/${modulo}`, options);
   }
 
   tipodocumento_get(modulo: any): Observable<any> {

--- a/Frontend/sakai-ng-master/src/app/biblioteca/services/material-bibliografico.service.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/services/material-bibliografico.service.ts
@@ -97,9 +97,11 @@ api_libros_lista(modulo: any): Observable<any> {
     return this.http.get<any[]>('assets/demo/biblioteca/material-bibliografico/ejemplar.json');
   }
   lista_tipo_material(modulo: any):Observable<any>{
-    return this.http.get<any[]>(`${this.apiUrl}/api/${modulo}`
-            ,{ headers: new HttpHeaders().set('Authorization',`Bearer ${this.authService.getToken()}`)}
-            );
+    const token = this.authService.getToken();
+    const options = token
+      ? { headers: new HttpHeaders().set('Authorization', `Bearer ${token}`) }
+      : {};
+    return this.http.get<any[]>(`${this.apiUrl}/api/${modulo}`, options);
   }
   lista_tipo_adquisicion(modulo: any):Observable<any>{
     return this.http.get<any[]>(`${this.apiUrl}/api/${modulo}`


### PR DESCRIPTION
## Summary
- solicitar sedes desde `api/equipos/sedes` para poblar el combo Local
- depurar conflictos de merge en el listado de materiales

## Testing
- `npm test` *(falla: error TS18003: No inputs were found in config file '/workspace/sistemabiblioteca/Frontend/sakai-ng-master/tsconfig.spec.json')*


------
https://chatgpt.com/codex/tasks/task_e_68b3f38b4b688329ae2f0f1a0f8f6bc5