### PR TITLE
feat: cargar roles disponibles en el login

### DIFF
--- a/Backend/login-microsoft365/src/main/java/com/miapp/config/SecurityConfig.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/config/SecurityConfig.java
@@ -34,13 +34,8 @@ public class SecurityConfig {
             .csrf(csrf -> csrf.disable())
             .authorizeHttpRequests(auth -> auth
                     .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll() // Permite OPTIONS en todas las rutas
-<<<<<<< HEAD
-                    .requestMatchers("/auth/login-microsoft",
-                            "/auth/login",
-=======
                     .requestMatchers(HttpMethod.POST, "/auth/login", "/auth/login-microsoft").permitAll()
                     .requestMatchers(
->>>>>>> c36c32b (chore: ignore build artifacts (target, *.jar))
                             "/auth/forgot-password",
                             "/reset-password",
                             "/reset-password/**",
@@ -49,6 +44,7 @@ public class SecurityConfig {
                             "/auth/lista-activo",
                             "/auth/actualizar",
                             "/auth/permisosRolPorUsuario/**",
+                            "/auth/permisosRolPorUsuarioEmail/**",
                             "/auth/agregar-rol",
                             "/auth/quitar-rol",
                             "/auth/roles/**",

--- a/Backend/login-microsoft365/src/main/java/com/miapp/controller/AuthController.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/controller/AuthController.java
@@ -292,6 +292,22 @@ public class AuthController {
         }
     }
 
+    @GetMapping("/permisosRolPorUsuarioEmail/{email}")
+    public ResponseEntity<?> getPermisosRolPorUsuarioEmail(@PathVariable String email) {
+        try {
+            Optional<Usuario> usuarioOpt = usuarioService.buscarPorEmail(email.toUpperCase());
+            if (usuarioOpt.isPresent()) {
+                List<Rol> rolesAsignados = List.copyOf(usuarioOpt.get().getRoles());
+                return ResponseEntity.ok(Map.of("status", "0", "data", rolesAsignados));
+            } else {
+                return ResponseEntity.ok(Map.of("status", "0", "data", Collections.emptyList()));
+            }
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(Map.of("status", "-1", "message", e.getMessage()));
+        }
+    }
+
     @PostMapping("/agregar-rol")
     public ResponseEntity<?> agregarRol(@RequestBody Map<String, Object> payload) {
         try {

--- a/Frontend/sakai-ng-master/src/app/biblioteca/services/auth.service.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/services/auth.service.ts
@@ -1,23 +1,14 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
-<<<<<<< HEAD
 import { BehaviorSubject, Observable, of, forkJoin } from 'rxjs';
-=======
-import { BehaviorSubject, Observable, of } from 'rxjs';
->>>>>>> c36c32b (chore: ignore build artifacts (target, *.jar))
-import { map, tap } from 'rxjs/operators';
-import { JwtHelperService } from "@auth0/angular-jwt";
+import { map, tap, catchError } from 'rxjs/operators';
+import { JwtHelperService } from '@auth0/angular-jwt';
 import { Router } from '@angular/router';
 import * as _ from 'lodash';
 import { environment } from '../../../environments/environment';
 import { Authentication, LoginRequest, LoginResponse } from '../interfaces/Authentication';
 import { Usuario } from '../interfaces/usuario';
-<<<<<<< HEAD
 import { Modulo } from '../interfaces/modulo';
-=======
->>>>>>> c36c32b (chore: ignore build artifacts (target, *.jar))
-
-import { catchError } from 'rxjs/operators';
 import { MsalService } from '@azure/msal-angular';
 import { AuthenticationResult } from '@azure/msal-browser';
 
@@ -30,11 +21,6 @@ interface ResponseDTO<T> {
 
 const httpOptions = {
   headers: new HttpHeaders({
-<<<<<<< HEAD
-=======
-    'Access-Control-Allow-Origin': '*',
-    'Access-Control-Allow-Methods': 'GET,POST,OPTIONS,DELETE,PUT',
->>>>>>> c36c32b (chore: ignore build artifacts (target, *.jar))
     'Content-Type': 'application/json'
   }),
   withCredentials: true
@@ -116,7 +102,6 @@ export class AuthService {
 //     return of({ success: false });
 //   }
 
-<<<<<<< HEAD
   setAuthentication(token: string) {
     localStorage.setItem(this.TOKEN_NAME, token);
     const decoded = this.helper.decodeToken(token);
@@ -174,32 +159,6 @@ export class AuthService {
       if (Number.isFinite(id)) return id;
     }
     return 0;
-=======
-  setAuthentication(token:string){
-    localStorage.setItem(this.TOKEN_NAME, token);
-      const decoded = this.helper.decodeToken(token);
-
-      const isExpired = this.helper.isTokenExpired(token);
-
-      if (isExpired) {
-        this.logout();
-      } else {
-        const roles = Array.isArray(decoded.role) ? decoded.role : [decoded.role];
-        // Si ya no tienes 'user' y 'idrol', usa directamente 'sub' y 'role'
-       const user: Usuario = {
-         id: 0, // Asigna un valor predeterminado o el valor real si está disponible
-         email: decoded.sub,
-         roles: roles
-       };// O guarda más datos si tienes
-
-
-        localStorage.setItem("currentUser", JSON.stringify(user));
-        localStorage.setItem("role", JSON.stringify(roles));
-        // Emite el usuario incluyendo los roles
-        this.currentUserSubject.next({ ...user, roles });
-        this.scheduleAutoLogout();
-      }
->>>>>>> c36c32b (chore: ignore build artifacts (target, *.jar))
   }
   getToken(): string {
     return localStorage.getItem(this.TOKEN_NAME) || '';
@@ -216,7 +175,6 @@ export class AuthService {
     return decoded;
   }
 
-<<<<<<< HEAD
   /**
    * Obtiene el identificador numérico del usuario autenticado a partir del token o del almacenamiento local.
    */
@@ -232,12 +190,6 @@ export class AuthService {
     const modules = localStorage.getItem('modules');
     return modules ? JSON.parse(modules) : [];
   }
-=======
-  getRoles(): string[] {
-       const role = localStorage.getItem("role");
-       return role ? JSON.parse(role) : [];
-    }
->>>>>>> c36c32b (chore: ignore build artifacts (target, *.jar))
 
   idAuthenticated():boolean{
     const token = this.getToken();
@@ -274,7 +226,6 @@ export class AuthService {
 // }
 
 loginMicrosoft() {
-<<<<<<< HEAD
     // Limpia la cuenta activa para evitar reutilizar sesiones previas
     this.msalService.instance.setActiveAccount(null);
     this.msalService.loginPopup({ prompt: 'select_account', scopes: ['user.read'] }).subscribe({
@@ -313,47 +264,6 @@ loginMicrosoft() {
               alert(this.obtenerMensajeError(error));
             },
           });
-=======
-    this.msalService.loginPopup().subscribe({
-      next: (result: AuthenticationResult) => {
-        console.log('Inicio de sesión exitoso', result);
-        // Establece la cuenta activa y continua con la obtención del token
-        this.msalService.instance.setActiveAccount(result.account);
-        this.msalService.acquireTokenSilent({
-            scopes: ['user.read'],
-          }).pipe(
-            catchError(error => {
-              // Si el token silencioso falla, intenta obtener el token con un popup
-              return this.msalService.acquireTokenPopup({
-                scopes: ['user.read'],
-              });
-            })
-          ).subscribe({
-          next: (tokenResponse) => {
-            console.log('Token de Microsoft:', tokenResponse.accessToken);
-            this.http.post<LoginResponse>(`${this.apiUrl}/login-microsoft`, { token: tokenResponse.accessToken })
-              .subscribe({
-                next: (backendResponse) => {
-                  if (backendResponse.token) {
-                    this.setAuthentication(backendResponse.token);
-                    this.currentUserSubject.next(this.getUser());
-                    this.openPendingResource();
-                    this.router.navigate(['/main']);
-                  }
-                },
-                error: (error) => {
-                  console.error('Error en autenticación con backend:', error);
-                  // Cierra el popup (MSAL lo debería cerrar automáticamente) y muestra tu alerta
-                  alert(this.obtenerMensajeError(error));
-                }
-              });
-          },
-          error: (error) => {
-            console.error('Error obteniendo el token de Microsoft:', error);
-            alert(this.obtenerMensajeError(error));
-          },
-        });
->>>>>>> c36c32b (chore: ignore build artifacts (target, *.jar))
       },
       error: (error) => {
         console.error('Error en la autenticación con Microsoft:', error);
@@ -362,7 +272,6 @@ loginMicrosoft() {
     });
   }
 
-<<<<<<< HEAD
   // Método para personalizar el mensaje de error
   private obtenerMensajeError(error: any): string {
     const errorMessage =
@@ -372,18 +281,9 @@ loginMicrosoft() {
     }
     return `Error de autenticación: ${errorMessage}`;
   }
-=======
- // Método para personalizar el mensaje de error
-     private obtenerMensajeError(error: any): string {
-       if (error.error && error.error.indexOf('AADSTS50020') !== -1) {
-         return 'Usuario no registrado en el tenant. Por favor, utiliza una cuenta válida o contacta a tu administrador.';
-       }
-       return `Error de autenticación: ${error.message || error}`;
-     }
->>>>>>> c36c32b (chore: ignore build artifacts (target, *.jar))
 
   // Login manual: envía las credenciales y espera una respuesta con mensaje y token.
-  loginManual(credentials: { email: string; password: string }): Observable<any> {
+  loginManual(credentials: { email: string; password: string; role?: string }): Observable<any> {
       const headers = new HttpHeaders({ 'Content-Type': 'application/json' });
       return this.http.post<LoginResponse>(`${this.apiUrl}/login`, credentials, { headers, withCredentials: true })
         .pipe(
@@ -428,6 +328,20 @@ loginMicrosoft() {
       );
   }
 
+  getRolesByEmail(email: string): Observable<{ label: string; value: string }[]> {
+    const normalized = email?.trim().toUpperCase();
+    if (!normalized) {
+      return of([]);
+    }
+    const encoded = encodeURIComponent(normalized);
+    return this.http
+      .get<{ status: string; data: any[] }>(`${this.apiUrl}/permisosRolPorUsuarioEmail/${encoded}`)
+      .pipe(
+        map(res => res.data.map(r => ({ label: r.descripcion, value: r.descripcion }))),
+        catchError(() => of([]))
+      );
+  }
+
 // Registro manual: envía los datos del usuario
 register(userData: any): Observable<any> {
     return this.http.post<any>(`${this.apiUrl}/register`, userData);
@@ -462,17 +376,12 @@ private resetInactivityTimer(): void {
     localStorage.removeItem('currentUser');
     localStorage.removeItem(this.TOKEN_NAME);
     localStorage.removeItem(this.REFRESH_NAME);
-<<<<<<< HEAD
     const activeAccount = this.msalService.instance.getActiveAccount();
     if (activeAccount) {
       this.msalService.logoutPopup({ mainWindowRedirectUri: '/auth/login' }).subscribe();
     } else {
       this.router.navigate(['/auth/login']);
     }
-=======
-    // Redirige a la página de login o principal según tu flujo
-    this.router.navigate(['/']);
->>>>>>> c36c32b (chore: ignore build artifacts (target, *.jar))
     return;
   }
 

--- a/Frontend/sakai-ng-master/src/app/pages/auth/login.ts
+++ b/Frontend/sakai-ng-master/src/app/pages/auth/login.ts
@@ -1,153 +1,170 @@
 import { Component, OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { RouterModule } from '@angular/router';
+import { Router, RouterModule } from '@angular/router';
 import { ButtonModule } from 'primeng/button';
 import { CheckboxModule } from 'primeng/checkbox';
 import { InputTextModule } from 'primeng/inputtext';
 import { PasswordModule } from 'primeng/password';
+import { DropdownModule } from 'primeng/dropdown';
 import { RippleModule } from 'primeng/ripple';
 import { AppFloatingConfigurator } from '../../layout/component/app.floatingconfigurator';
 import { AuthService } from '../../biblioteca/services/auth.service';
-<<<<<<< HEAD
-
-import { Router } from '@angular/router';
-=======
-import { LoginRequest, LoginResponse } from '../../biblioteca/interfaces/Authentication';
-
-import { Router } from '@angular/router';
-import { MsalService } from '@azure/msal-angular';
-import { InteractionType, AuthenticationResult } from '@azure/msal-browser';
->>>>>>> c36c32b (chore: ignore build artifacts (target, *.jar))
 
 export interface LoginCredentials {
   email: string;
   password: string;
+  role: string;
 }
 
 @Component({
-    selector: 'app-login',
-    standalone: true,
-    imports: [ButtonModule, CheckboxModule, InputTextModule, PasswordModule, FormsModule, RouterModule, RippleModule, AppFloatingConfigurator],
-    template: `
-        <app-floating-configurator />
-        <div class="bg-surface-50 dark:bg-surface-950 flex items-center justify-center min-h-screen min-w-[100vw] overflow-hidden">
-            <div class="flex flex-col items-center justify-center">
-                <div style="border-radius: 56px; padding: 0.3rem; background: linear-gradient(180deg, var(--primary-color) 10%, rgba(33, 150, 243, 0) 30%)">
-                    <div class="w-full bg-surface-0 dark:bg-surface-900 py-20 px-8 sm:px-20" style="border-radius: 53px">
-                        <div class="text-center mb-8">
-                            <img src="assets/logo.png" alt="Logo" class="mb-8 w-30 shrink-0 mx-auto" />
-                            <span class="text-muted-color font-medium mb-4">Inicia sesión para continuar</span>
-<<<<<<< HEAD
-                            <div class="flex flex-col sm:flex-row gap-2 w-full mt-4">
-                                <p-button label="Iniciar sesión con Microsoft365" styleClass="w-full flex-1" (click)="loginWithMicrosoft()"></p-button>
-                            </div>
-=======
-                            <p-button label="Iniciar sesión con Microsoft365" styleClass="w-full mt-4" (click)="loginWithMicrosoft()"></p-button>
->>>>>>> c36c32b (chore: ignore build artifacts (target, *.jar))
-                             <div class="flex items-center my-4">
-                               <!-- Línea izquierda -->
-                               <div class="flex-grow border-t border-gray-300"></div>
-
-                               <!-- Texto "o" -->
-                               <span class="mx-4 text-gray-500">O</span>
-
-                               <!-- Línea derecha -->
-                               <div class="flex-grow border-t border-gray-300"></div>
-                             </div>
-                        </div>
-
-                        <div>
-
-
-                            <label for="email1" class="block text-surface-900 dark:text-surface-0 text-xl font-medium mb-2">Correo electrónico</label>
-                            <input pInputText id="email" type="text" placeholder="Email address" class="w-full md:w-[30rem] mb-4" [(ngModel)]="credentials.email" name="email" />
-
-                            <label for="password1" class="block text-surface-900 dark:text-surface-0 font-medium text-xl mb-2">Contraseña</label>
-                            <p-password id="password1" [(ngModel)]="credentials.password" placeholder="Contraseña" [toggleMask]="true" styleClass="mb-4" [fluid]="true" [feedback]="false"></p-password>
-
-
-                            <div class="flex items-center justify-between mt-2 mb-8 gap-8">
-                                <div class="flex items-center">
-                                    <p-checkbox [(ngModel)]="checked" id="rememberme1" binary class="mr-2"></p-checkbox>
-                                    <label for="rememberme1">Recordarme</label>
-                                </div>
-                                <span class="font-medium no-underline ml-2 text-right cursor-pointer text-primary" (click)="onForgotPassword()">¿Olvidaste tu contraseña?</span>
-                            </div>
-                            <p-button label="Iniciar sesión" styleClass="w-full" (click)="onLogin()"></p-button>
-                        </div>
-                    </div>
-                </div>
+  selector: 'app-login',
+  standalone: true,
+  imports: [
+    ButtonModule,
+    CheckboxModule,
+    InputTextModule,
+    PasswordModule,
+    DropdownModule,
+    FormsModule,
+    RouterModule,
+    RippleModule,
+    AppFloatingConfigurator
+  ],
+  template: `
+    <app-floating-configurator />
+    <div class="bg-surface-50 dark:bg-surface-950 flex items-center justify-center min-h-screen min-w-[100vw] overflow-hidden">
+      <div class="flex flex-col items-center justify-center">
+        <div style="border-radius: 56px; padding: 0.3rem; background: linear-gradient(180deg, var(--primary-color) 10%, rgba(33, 150, 243, 0) 30%)">
+          <div class="w-full bg-surface-0 dark:bg-surface-900 py-20 px-8 sm:px-20" style="border-radius: 53px">
+            <div class="text-center mb-8">
+              <img src="assets/logo.png" alt="Logo" class="mb-8 w-30 shrink-0 mx-auto" />
+              <span class="text-muted-color font-medium mb-4">Inicia sesión para continuar</span>
+              <div class="flex flex-col sm:flex-row gap-2 w-full mt-4">
+                <p-button label="Iniciar sesión con Microsoft365" styleClass="w-full flex-1" (click)="loginWithMicrosoft()"></p-button>
+              </div>
+              <div class="flex items-center my-4">
+                <div class="flex-grow border-t border-gray-300"></div>
+                <span class="mx-4 text-gray-500">O</span>
+                <div class="flex-grow border-t border-gray-300"></div>
+              </div>
             </div>
+            <div>
+              <label for="email" class="block text-surface-900 dark:text-surface-0 text-xl font-medium mb-2">Correo electrónico</label>
+              <input pInputText id="email" type="text" placeholder="Email address" class="w-full md:w-[30rem] mb-4" [(ngModel)]="credentials.email" name="email" (ngModelChange)="onEmailChange()" />
+
+              <label for="password" class="block text-surface-900 dark:text-surface-0 font-medium text-xl mb-2">Contraseña</label>
+              <p-password id="password" [(ngModel)]="credentials.password" placeholder="Contraseña" [toggleMask]="true" styleClass="mb-4" [fluid]="true" [feedback]="false"></p-password>
+
+              <label for="role" class="block text-surface-900 dark:text-surface-0 font-medium text-xl mb-2">Tipo de usuario</label>
+              <p-dropdown id="role" [options]="userRoles" optionLabel="label" optionValue="value" [(ngModel)]="credentials.role" placeholder="Seleccione un rol" class="w-full md:w-[30rem] mb-4" [disabled]="roleDisabled"></p-dropdown>
+
+              <div class="flex items-center justify-between mt-2 mb-8 gap-8">
+                <div class="flex items-center">
+                  <p-checkbox [(ngModel)]="checked" id="rememberme1" binary class="mr-2"></p-checkbox>
+                  <label for="rememberme1">Recordarme</label>
+                </div>
+                <span class="font-medium no-underline ml-2 text-right cursor-pointer text-primary" (click)="onForgotPassword()">¿Olvidaste tu contraseña?</span>
+              </div>
+              <p-button label="Iniciar sesión" styleClass="w-full" (click)="onLogin()"></p-button>
+            </div>
+          </div>
         </div>
-    `
+      </div>
+    </div>
+  `
 })
 export class Login implements OnInit {
-    email: string = '';
+  checked = false;
+  userRoles: { label: string; value: string }[] = [];
+  roleDisabled = true;
+  credentials: LoginCredentials = { email: '', password: '', role: '' };
 
-    password: string = '';
+  constructor(private authService: AuthService, private router: Router) {}
 
-    checked: boolean = false;
-    credentials: LoginCredentials = { email: '', password: '' };
+  loginWithMicrosoft() {
+    this.authService.loginMicrosoft();
+  }
 
-<<<<<<< HEAD
-    constructor(private authService: AuthService, private router: Router) {}
-=======
-    constructor(private msalService: MsalService, private authService: AuthService, private router: Router) {}
->>>>>>> c36c32b (chore: ignore build artifacts (target, *.jar))
-
-     loginWithMicrosoft() {
-        this.authService.loginMicrosoft();
-     }
-
-    ngOnInit(): void {
-        const remembered = localStorage.getItem('rememberedEmail');
-        if (remembered) {
-            this.credentials.email = remembered;
-            this.checked = true;
-        }
+  ngOnInit(): void {
+    const remembered = localStorage.getItem('rememberedEmail');
+    if (remembered) {
+      this.credentials.email = remembered;
+      this.checked = true;
+      this.loadUserRoles();
     }
+  }
 
-    onLogin(): void {
-        if (this.credentials.email && this.credentials.password) {
-            this.authService.loginManual(this.credentials).subscribe({
-                next: (response) => {
-                    this.authService.setAuthentication(response.token);
-                    this.authService.openPendingResource();
-                    if (this.checked) {
-                        localStorage.setItem('rememberedEmail', this.credentials.email);
-                    } else {
-                        localStorage.removeItem('rememberedEmail');
-                    }
-                    this.router.navigate(['/main']);
-                },
-                error: (err) => {
-                    alert('Credenciales incorrectas');
-                    console.error('Error en login manual:', err);
-                }
-            });
+  onEmailChange(): void {
+    this.loadUserRoles();
+  }
+
+  private loadUserRoles(): void {
+    if (!this.credentials.email) {
+      this.userRoles = [];
+      this.credentials.role = '';
+      this.roleDisabled = true;
+      return;
+    }
+    this.authService.getRolesByEmail(this.credentials.email).subscribe({
+      next: (roles) => {
+        this.userRoles = roles;
+        if (roles.length === 1) {
+          this.credentials.role = roles[0].value;
+          this.roleDisabled = true;
         } else {
-            alert('Por favor ingresa email y contraseña');
+          this.credentials.role = '';
+          this.roleDisabled = false;
         }
-    }
+      },
+      error: () => {
+        this.userRoles = [];
+        this.credentials.role = '';
+        this.roleDisabled = true;
+      }
+    });
+  }
 
-    onForgotPassword(): void {
-        if (!this.credentials.email) {
-            alert('Ingresa tu email para recuperar la contraseña');
-            return;
+  onLogin(): void {
+    if (this.credentials.email && this.credentials.password && this.credentials.role) {
+      this.authService.loginManual(this.credentials).subscribe({
+        next: (response) => {
+          this.authService.setAuthentication(response.token);
+          this.authService.openPendingResource();
+          if (this.checked) {
+            localStorage.setItem('rememberedEmail', this.credentials.email);
+          } else {
+            localStorage.removeItem('rememberedEmail');
+          }
+          this.router.navigate(['/main']);
+        },
+        error: (err) => {
+          alert('Credenciales incorrectas');
+          console.error('Error en login manual:', err);
         }
-        this.authService.forgotPassword(this.credentials.email).subscribe({
-            next: (res) => {
-                if (res.token) {
-                    this.router.navigate(['/auth/reset-password'], { queryParams: { token: res.token } });
-                } else {
-                    alert(res.message || 'No se pudo generar el token');
-                }
-            },
-            error: (err) => {
-                const msg = err.error?.message || 'Error al solicitar recuperación de contraseña';
-                alert(msg);
-            }
-        });
+      });
+    } else {
+      alert('Por favor ingresa email, contraseña y tipo de usuario');
     }
+  }
 
+  onForgotPassword(): void {
+    if (!this.credentials.email) {
+      alert('Ingresa tu email para recuperar la contraseña');
+      return;
+    }
+    this.authService.forgotPassword(this.credentials.email).subscribe({
+      next: (res) => {
+        if (res.token) {
+          this.router.navigate(['/auth/reset-password'], { queryParams: { token: res.token } });
+        } else {
+          alert(res.message || 'No se pudo generar el token');
+        }
+      },
+      error: (err) => {
+        const msg = err.error?.message || 'Error al solicitar recuperación de contraseña';
+        alert(msg);
+      }
+    });
+  }
 }
+


### PR DESCRIPTION
## Summary
- agregar endpoint `/auth/permisosRolPorUsuarioEmail/{email}` para devolver roles asignados a un correo
- mantener la selección de roles en el login consumiendo este servicio
- permitir el acceso público a `/auth/permisosRolPorUsuarioEmail/**` en la configuración de seguridad

## Testing
- `npm test` *(falla: error TS18003: No inputs were found in config file 'tsconfig.spec.json')*
- `mvn -q test` *(falla: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_68b40bd432608329b65cd91a074ac957