### PR TITLE
Evalúa rol seleccionado al iniciar sesión

### DIFF
--- a/Backend/login-microsoft365/src/main/java/com/miapp/controller/AuthController.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/controller/AuthController.java
@@ -131,17 +131,21 @@ public class AuthController {
         return ResponseEntity.ok(new LoginResponse("Login exitoso", jwt, refresh.getToken()));
     }
 
-    @PostMapping("/login")
+        @PostMapping("/login")
     public ResponseEntity<?> loginManual(@RequestBody LoginRequest loginRequest) {
         String emailUpper = loginRequest.getEmail().toUpperCase();
         Optional<Usuario> usuarioOpt = usuarioService.validarCredenciales(emailUpper, loginRequest.getPassword());
         if (usuarioOpt.isPresent()) {
             Usuario usuario = usuarioOpt.get();
-            String rolDescripcion = usuario.getRoles().isEmpty()
-                    ? "Sin Rol"
-                    : usuario.getRoles().iterator().next().getDescripcion();
+            String requestedRole = loginRequest.getRole();
+            boolean hasRole = usuario.getRoles().stream()
+                    .anyMatch(r -> r.getDescripcion().equalsIgnoreCase(requestedRole));
+            if (!hasRole) {
+                return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                        .body(Map.of("message", "Rol no autorizado"));
+            }
             usuarioService.incrementarContadorLogins(usuario.getLogin());
-            String jwt = jwtUtil.generateToken(usuario.getEmail(), rolDescripcion);
+            String jwt = jwtUtil.generateToken(usuario.getEmail(), requestedRole);
             RefreshToken refresh = refreshTokenService.createRefreshToken(usuario);
             System.out.println(jwt);
             return ResponseEntity.ok(new LoginResponse("Login exitoso", jwt, refresh.getToken()));
@@ -150,7 +154,6 @@ public class AuthController {
                     .body("Credenciales incorrectas");
         }
     }
-
     @PostMapping("/forgot-password")
     public ResponseEntity<Map<String, String>> forgotPassword(@RequestBody Map<String, String> request) {
         String email = request.get("email").toUpperCase();

--- a/Backend/login-microsoft365/src/main/java/com/miapp/model/LoginRequest.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/model/LoginRequest.java
@@ -6,4 +6,5 @@ import lombok.Data;
 public class LoginRequest {
     private String email;
     private String password;
+    private String role;
 }

--- a/Frontend/sakai-ng-master/src/app/biblioteca/interfaces/Authentication.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/interfaces/Authentication.ts
@@ -9,6 +9,7 @@ export interface Authentication {
 export interface LoginRequest {
   email: string;
   password: string;
+  role: string;
 }
 
 export interface LoginResponse {

--- a/Frontend/sakai-ng-master/src/app/biblioteca/services/auth.service.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/services/auth.service.ts
@@ -283,7 +283,7 @@ loginMicrosoft() {
   }
 
   // Login manual: envía las credenciales y espera una respuesta con mensaje y token.
-  loginManual(credentials: { email: string; password: string; role?: string }): Observable<any> {
+  loginManual(credentials: LoginRequest): Observable<LoginResponse> {
       const headers = new HttpHeaders({ 'Content-Type': 'application/json' });
       return this.http.post<LoginResponse>(`${this.apiUrl}/login`, credentials, { headers, withCredentials: true })
         .pipe(


### PR DESCRIPTION
## Resumen
- Agrega campo `role` al DTO de `LoginRequest`.
- Valida que el usuario tenga el rol seleccionado y genera el token con ese rol.
- Actualiza interfaces y servicio de autenticación en el frontend para enviar y tipar el rol.

## Testing
- `mvn -q test` *(falló: Network is unreachable al resolver dependencias Maven)*
- `npm test` *(falló: TS18003 No inputs were found in config file)*

------
https://chatgpt.com/codex/tasks/task_e_68b484f9c19c8329b7169b07593efcb5