### PR TITLE
Quitar iconos de configuración en módulo principal

### DIFF
--- a/Frontend/sakai-ng-master/src/app/biblioteca/services/auth.service.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/services/auth.service.ts
@@ -404,6 +404,8 @@ private resetInactivityTimer(): void {
     localStorage.removeItem('currentUser');
     localStorage.removeItem(this.TOKEN_NAME);
     localStorage.removeItem(this.REFRESH_NAME);
+    // Reinicia el estado del usuario actual para evitar datos residuales tras cerrar sesión
+    this.currentUserSubject.next({} as Usuario);
     const activeAccount = this.msalService.instance.getActiveAccount();
     if (activeAccount) {
       this.msalService.logoutPopup({ mainWindowRedirectUri: '/auth/login' }).subscribe();

--- a/Frontend/sakai-ng-master/src/app/biblioteca/web/portal-landing/portalLanding.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/web/portal-landing/portalLanding.ts
@@ -13,7 +13,6 @@ import { PortalNosotros } from './components/portal-nosotros';
 import { PortalHorarios } from './components/portal-horarios';
 import { PricingWidget } from '../../../pages/landing/components/pricingwidget';
 import { TopbarWidget } from '../../../pages/landing/components/topbarwidget.component';
-import { AppFloatingConfigurator } from '../../../layout/component/app.floatingconfigurator';
 import { PortalEjemplares } from './components/portal-ejemplares';
 import { PortalNoticias } from './components/portal-noticias';
 import { PortalTopbar } from './components/portal-topbar';
@@ -25,9 +24,8 @@ import { PortalRecursosElectronicos } from './components/portal-recursos-electro
 @Component({
     selector: 'app-portal-landing',
     standalone: true,
-        imports: [ScrollTopModule,RouterModule, AppFloatingConfigurator,PortalFooter,PortalContactanos,PortalTopbar,PortalEjemplares,PortalNoticias, RippleModule, StyleClassModule, ButtonModule, DividerModule, PortalNosotros,PortalHorarios,PortalRecursosElectronicos, Portal,ScrollTopModule],
+        imports: [ScrollTopModule,RouterModule,PortalFooter,PortalContactanos,PortalTopbar,PortalEjemplares,PortalNoticias, RippleModule, StyleClassModule, ButtonModule, DividerModule, PortalNosotros,PortalHorarios,PortalRecursosElectronicos, Portal,ScrollTopModule],
     template: `
-        <app-floating-configurator />
         <div class="bg-app min-h-screen">
             <div id="home" class="landing-wrapper">
                 <portal-topbar />

--- a/Frontend/sakai-ng-master/src/app/layout/component/app.topbar.ts
+++ b/Frontend/sakai-ng-master/src/app/layout/component/app.topbar.ts
@@ -3,7 +3,6 @@ import { MenuItem } from 'primeng/api';
 import { RouterModule } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { StyleClassModule } from 'primeng/styleclass';
-import { AppConfigurator } from './app.configurator';
 import { LayoutService } from '../service/layout.service';
 
 import { OverlayPanelModule } from 'primeng/overlaypanel';
@@ -23,7 +22,7 @@ import { AuthService } from '../../biblioteca/services/auth.service';
 @Component({
     selector: 'app-topbar',
     standalone: true,
-    imports: [RouterModule, CommonModule, StyleClassModule, StyleClassModule, OverlayPanelModule, DialogModule, TableModule, ButtonModule, OverlayBadgeModule, MenuModule, AppConfigurator],
+    imports: [RouterModule, CommonModule, StyleClassModule, StyleClassModule, OverlayPanelModule, DialogModule, TableModule, ButtonModule, OverlayBadgeModule, MenuModule],
     styles: [
       `.highlight-row { animation: fadeHighlight 2s ease-in-out forwards; }
        @keyframes fadeHighlight { from { background-color: #ffe08a; } to { background-color: transparent; } }`
@@ -39,25 +38,6 @@ import { AuthService } from '../../biblioteca/services/auth.service';
         </div>
 
         <div class="layout-topbar-actions">
-            <div class="layout-config-menu">
-                <button type="button" class="layout-topbar-action" (click)="toggleDarkMode()">
-                    <i [ngClass]="{ 'pi ': true, 'pi-moon': layoutService.isDarkTheme(), 'pi-sun': !layoutService.isDarkTheme() }"></i>
-                </button>
-                <div class="relative">
-                    <button
-                        class="layout-topbar-action layout-topbar-action-highlight"
-                        pStyleClass="@next"
-                        enterFromClass="hidden"
-                        enterActiveClass="animate-scalein"
-                        leaveToClass="hidden"
-                        leaveActiveClass="animate-fadeout"
-                        [hideOnOutsideClick]="true"
-                    >
-                        <i class="pi pi-palette"></i>
-                    </button>
-                    <app-configurator />
-                </div>
-            </div>
 
                 <button class="layout-topbar-menu-button layout-topbar-action" pStyleClass="@next" enterFromClass="hidden" enterActiveClass="animate-scalein" leaveToClass="hidden" leaveActiveClass="animate-fadeout" [hideOnOutsideClick]="true">
                     <i class="pi pi-ellipsis-v"></i>
@@ -65,10 +45,6 @@ import { AuthService } from '../../biblioteca/services/auth.service';
 
             <div class="layout-topbar-menu hidden lg:block">
                 <div class="layout-topbar-menu-content">
-                    <button type="button" class="layout-topbar-action">
-                        <i class="pi pi-calendar"></i>
-                        <span>Calendar</span>
-                    </button>
 
                     <p-overlaybadge [value]="unreadCount" severity="danger">
                       <button
@@ -77,13 +53,13 @@ import { AuthService } from '../../biblioteca/services/auth.service';
                         (click)="toggleNotifications($event)"
                         [disabled]="loadingNotifications">
                         <i class="pi pi-inbox"></i>
-                        <span>Messages</span>
+                        <span>Mensajes</span>
                       </button>
                     </p-overlaybadge>
 
                     <button type="button" class="layout-topbar-action" (click)="profileMenu.toggle($event)">
                         <i class="pi pi-user"></i>
-                        <span>Profile</span>
+                        <span>{{ userEmail }}</span>
                     </button>
                     <p-menu #profileMenu [popup]="true" [model]="profileItems" appendTo="body"></p-menu>
 
@@ -188,6 +164,7 @@ export class AppTopbar implements OnInit {
     profileItems: MenuItem[] = [];
     highlightSolicitudes: number[] = [];
     highlightOcurrencias: number[] = [];
+    userEmail = '';
 
     get solicitudesNuevas(): number {
       return this.notificaciones.filter(n => !n.leida && !n.mensaje.toLowerCase().includes('ocurrencia')).length;
@@ -208,6 +185,15 @@ export class AppTopbar implements OnInit {
     ) {}
 
     ngOnInit() {
+        const user = this.authService.getUser();
+        const rawEmail =
+          this.authService.currentUserValue?.email ||
+          user?.email ||
+          user?.sub ||
+          (user?.preferred_username ?? user?.unique_name ?? user?.upn ?? '');
+        this.userEmail = (rawEmail || '')
+          .toString()
+          .replace(/@upsjb\.edu\.pe$/i, '');
         this.loadNotifications();
         this.initProfileMenu();
     }
@@ -300,19 +286,23 @@ export class AppTopbar implements OnInit {
 
   private initProfileMenu() {
     const user = this.authService.getUser();
-    const name = user?.givenname ? `${user.givenname} ${user.surname || ''}` : (user?.nombres || user?.email || '');
-    const roles = user?.roles ? (Array.isArray(user.roles) ? user.roles.join(', ') : user.roles) : (user?.role || '');
-    const items: MenuItem[] = [
-      { label: name, disabled: true }
-    ];
+    const email = this.userEmail || user?.email || user?.sub || '';
+    const name = user?.givenname
+      ? `${user.givenname} ${user.surname || ''}`
+      : (user?.nombres || email || '');
+    const roles = user?.roles
+      ? (Array.isArray(user.roles) ? user.roles.join(', ') : user.roles)
+      : (user?.role || '');
+    const items: MenuItem[] = [{ label: name, disabled: true }];
     if (roles) {
       items.push({ label: `Tipo: ${roles}`, disabled: true });
     }
     items.push({ separator: true });
-    items.push({ label: 'Cerrar sesión', icon: 'pi pi-sign-out', command: () => this.authService.logout() });
+    items.push({
+      label: 'Cerrar sesión',
+      icon: 'pi pi-sign-out',
+      command: () => this.authService.logout()
+    });
     this.profileItems = items;
   }
-    toggleDarkMode() {
-        this.layoutService.layoutConfig.update((state) => ({ ...state, darkTheme: !state.darkTheme }));
-    }
 }

--- a/Frontend/sakai-ng-master/src/app/layout/service/layout.service.ts
+++ b/Frontend/sakai-ng-master/src/app/layout/service/layout.service.ts
@@ -1,5 +1,7 @@
 import { Injectable, effect, signal, computed } from '@angular/core';
 import { Subject } from 'rxjs';
+import { $t } from '@primeng/themes';
+import Aura from '@primeng/themes/aura';
 
 export interface layoutConfig {
     preset?: string;
@@ -86,6 +88,7 @@ export class LayoutService {
         this._config.darkTheme = dark;
         this.layoutConfig.set({ ...this._config });
         this.toggleDarkMode(this._config);
+        this.applyPreset();
 
         effect(() => {
             const config = this.layoutConfig();
@@ -104,6 +107,48 @@ export class LayoutService {
 
             this.handleDarkModeTransition(config);
         });
+    }
+
+    private applyPreset(): void {
+        const color = (Aura as any).primitive.rose;
+        $t()
+            .preset(Aura)
+            .preset({
+                semantic: {
+                    primary: color,
+                    colorScheme: {
+                        light: {
+                            primary: {
+                                color: '{primary.500}',
+                                contrastColor: '#ffffff',
+                                hoverColor: '{primary.600}',
+                                activeColor: '{primary.700}'
+                            },
+                            highlight: {
+                                background: '{primary.50}',
+                                focusBackground: '{primary.100}',
+                                color: '{primary.700}',
+                                focusColor: '{primary.800}'
+                            }
+                        },
+                        dark: {
+                            primary: {
+                                color: '{primary.400}',
+                                contrastColor: '{surface.900}',
+                                hoverColor: '{primary.300}',
+                                activeColor: '{primary.200}'
+                            },
+                            highlight: {
+                                background: 'color-mix(in srgb, {primary.400}, transparent 84%)',
+                                focusBackground: 'color-mix(in srgb, {primary.400}, transparent 76%)',
+                                color: 'rgba(255,255,255,.87)',
+                                focusColor: 'rgba(255,255,255,.87)'
+                            }
+                        }
+                    }
+                }
+            })
+            .use({ useDefaultOptions: true });
     }
 
     private handleDarkModeTransition(config: layoutConfig): void {


### PR DESCRIPTION
## Resumen
- Elimina botones de modo oscuro, paleta de colores y calendario del topbar principal
- Traduce "Messages" a "Mensajes" y muestra el correo del usuario sin dominio en el botón de perfil
- Aplica por defecto la paleta "rose" del tema Aura para mantener los botones en rojo
- Restablece el usuario al cerrar sesión para mostrar correctamente el correo al iniciar con otra cuenta

## Pruebas
- `npm test` (falla: No inputs were found in config file tsconfig.spec.json)
- `npm run lint` (falla: Missing script: "lint")

------
https://chatgpt.com/codex/tasks/task_e_68b4ae69aeac83298ba6a31feeff9246