### PR TITLE
feat: traducir botones de confirmación

### DIFF
--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/laboratorio-computo/modal-detalle-ocurrencia.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/laboratorio-computo/modal-detalle-ocurrencia.ts
@@ -257,6 +257,8 @@ constructor(private fb: FormBuilder,private genericoService: GenericoService, pr
   confirmarCosto() {
     this.confirmationService.confirm({
       message: '¿El costo será agregado y se cargará a la cuenta del(los) usuario(s)?',
+      acceptLabel: 'SI',
+      rejectLabel: 'NO',
       accept: () => {
         this.loading = true;
 

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/mantenimientos/aceptaciones/aceptaciones.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/mantenimientos/aceptaciones/aceptaciones.ts
@@ -395,6 +395,8 @@ export class Aceptaciones implements OnInit, AfterViewInit {
 aceptarDetalle(detalle: any) {
   this.confirmationService.confirm({
     message: `¿Marcar ingreso #${detalle.numeroIngreso} como DISPONIBLE?`,
+    acceptLabel: 'SI',
+    rejectLabel: 'NO',
     accept: () => {
       this.loading = true;
       const payload = {

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/mantenimientos/material-bibliografico/modal-libro.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/mantenimientos/material-bibliografico/modal-libro.ts
@@ -1379,6 +1379,8 @@ guardarEjemplar() {
     message : '¿Estás seguro(a) de que quieres registrar?',
     header  : 'Confirmar',
     icon    : 'pi pi-exclamation-triangle',
+    acceptLabel: 'SI',
+    rejectLabel: 'NO',
     accept  : () => {
 
       const tipoAdqId = this.formDetalle.value.tipoAdquisicion;

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/mantenimientos/material-bibliografico/modal-revista.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/mantenimientos/material-bibliografico/modal-revista.ts
@@ -986,6 +986,8 @@ export class ModalRevistaComponent implements OnInit {
             message : '¿Estás seguro(a) de que quieres registrar?',
             header  : 'Confirmar',
             icon    : 'pi pi-exclamation-triangle',
+            acceptLabel: 'SI',
+            rejectLabel: 'NO',
             accept  : () => {
 
               const tipoAdqId = this.formDetalle.value.tipoAdquisicion;

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/portal/horarios.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/portal/horarios.ts
@@ -393,9 +393,11 @@ export class HorariosComponent implements OnInit {
           : 'DESCARTE';
           const decoded = this.authService.getUser();
           const usuario = decoded.sub;
-               this.confirmationService.confirm({
-                 message: `¿Cambiar estado a ${nuevoEstadoDesc}?`,
-                 accept: () => {
+              this.confirmationService.confirm({
+                message: `¿Cambiar estado a ${nuevoEstadoDesc}?`,
+                acceptLabel: 'SI',
+                rejectLabel: 'NO',
+                accept: () => {
                    this.loading = true;
                    this.portalService
                      .toggleHorario(n.id, nuevoEstadoId, usuario)

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/portal/noticias.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/portal/noticias.ts
@@ -364,11 +364,13 @@ export class Noticias implements OnInit{
     ? 'DISPONIBLE'
     : 'DESCARTE';
          this.confirmationService.confirm({
-           message: `¿Estás seguro de cambiar "${n.titular}" al estado ${nuevoEstadoDesc}?`,
-           accept: () => {
-             this.loading = true;
-             this.portalService
-               .toggleEstado(n.idnoticia!, nuevoEstadoId, usuario)
+          message: `¿Estás seguro de cambiar "${n.titular}" al estado ${nuevoEstadoDesc}?`,
+          acceptLabel: 'SI',
+          rejectLabel: 'NO',
+          accept: () => {
+            this.loading = true;
+            this.portalService
+              .toggleEstado(n.idnoticia!, nuevoEstadoId, usuario)
                .subscribe({
                  next: res => {
                    if (res.p_status === 0) {
@@ -455,6 +457,8 @@ export class Noticias implements OnInit{
 //             });
 this.confirmationService.confirm({
       message: `Eliminar "${objeto.titular}"?`,
+      acceptLabel: 'SI',
+      rejectLabel: 'NO',
       accept: () => {
         this.loading = true;
         this.portalService.delete(objeto.idnoticia!).subscribe(r=>{


### PR DESCRIPTION
## Summary
- mostrar botones SI/NO en confirmaciones de noticias, horarios, revistas, libros, aceptaciones y costos

## Testing
- `npm test` *(falla: No inputs were found in config file '/workspace/sistemabiblioteca/Frontend/sakai-ng-master/tsconfig.spec.json')*

------
https://chatgpt.com/codex/tasks/task_e_68b4c280b4dc8329bdf12b168c06f13c