### PR TITLE
fix: evitar recorte de etiquetas en detalle de ejemplares

### DIFF
--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/mantenimientos/material-bibliografico/modal-libro.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/mantenimientos/material-bibliografico/modal-libro.ts
@@ -387,7 +387,7 @@ import { Output, EventEmitter } from '@angular/core';
                   </ng-template>
                 </p-dialog>
                 <p-dialog [(visible)]="displayEjemplar" [style]="{width: '75%'}" header="Detalle" [modal]="true" [closable]="true"
-                  styleClass="p-fluid">
+                  styleClass="p-fluid" [contentStyle]="{overflow: 'visible'}">
                   <ng-template pTemplate="content">
                     <form [formGroup]="formDetalle">
                       <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-3 gap-4">
@@ -457,6 +457,7 @@ import { Output, EventEmitter } from '@angular/core';
                 </p-dialog>
                 <p-confirmDialog [style]="{width: '450px'}"></p-confirmDialog>
                 <p-toast></p-toast>`,
+    styles: [`:host ::ng-deep label{white-space:normal !important;overflow:visible !important;text-overflow:initial !important;}`],
     imports: [TemplateModule, InputValidation],
     providers: [MessageService, ConfirmationService]
 })

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/mantenimientos/material-bibliografico/modal-otros.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/mantenimientos/material-bibliografico/modal-otros.ts
@@ -254,7 +254,7 @@ import { AuthService } from '../../../services/auth.service';
                 <button pButton pRipple type="button" icon="pi pi-check" (click)="finalizar()" [disabled]="formOtro.invalid  || formPortada.invalid || loading" label="Guardar" class="p-button-success"></button>
             </ng-template>
 </p-dialog>
-<p-dialog [(visible)]="displayEjemplar" [style]="{width: '75%'}"  header="Registro" [modal]="true" [closable]="true" styleClass="p-fluid">
+<p-dialog [(visible)]="displayEjemplar" [style]="{width: '75%'}"  header="Registro" [modal]="true" [closable]="true" styleClass="p-fluid" [contentStyle]="{overflow: 'visible'}">
 <ng-template pTemplate="content">
     <form [formGroup]="formDetalle">
     <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-3 gap-4">
@@ -299,6 +299,7 @@ import { AuthService } from '../../../services/auth.service';
 </p-dialog>
   <p-confirmDialog [style]="{width: '450px'}"></p-confirmDialog>
             <p-toast></p-toast>`,
+    styles: [`:host ::ng-deep label{white-space:normal !important;overflow:visible !important;text-overflow:initial !important;}`],
     imports: [TemplateModule, InputValidation],
     providers: [MessageService, ConfirmationService]
 })

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/mantenimientos/material-bibliografico/modal-revista.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/mantenimientos/material-bibliografico/modal-revista.ts
@@ -316,7 +316,7 @@ import { AuthService } from '../../../services/auth.service';
                 <button pButton pRipple type="button" icon="pi pi-check" (click)="finalizar()" [disabled]="formRevista.invalid  || formPortada.invalid || loading" label="Guardar" class="p-button-success"></button>
             </ng-template>
 </p-dialog>
-<p-dialog [(visible)]="displayEjemplar" [style]="{width: '75%'}"  header="Detalle" [modal]="true" [closable]="true" styleClass="p-fluid">
+<p-dialog [(visible)]="displayEjemplar" [style]="{width: '75%'}"  header="Detalle" [modal]="true" [closable]="true" styleClass="p-fluid" [contentStyle]="{overflow: 'visible'}">
 <ng-template pTemplate="content">
     <form [formGroup]="formDetalle">
     <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-3 gap-4">
@@ -382,6 +382,7 @@ import { AuthService } from '../../../services/auth.service';
 </p-dialog>
   <p-confirmDialog [style]="{width: '450px'}"></p-confirmDialog>
             <p-toast></p-toast>`,
+    styles: [`:host ::ng-deep label{white-space:normal !important;overflow:visible !important;text-overflow:initial !important;}`],
     imports: [TemplateModule, InputValidation],
     providers: [MessageService, ConfirmationService]
 })

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/mantenimientos/material-bibliografico/modal-tesis.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/mantenimientos/material-bibliografico/modal-tesis.ts
@@ -296,7 +296,7 @@ import { AuthService } from '../../../services/auth.service';
                 <button pButton pRipple type="button" icon="pi pi-check" (click)="finalizar()" [disabled]="formOtro.invalid  || formPortada.invalid || loading" label="Guardar" class="p-button-success"></button>
             </ng-template>
 </p-dialog>
-<p-dialog [(visible)]="displayEjemplar" [style]="{width: '75%'}"  header="Detalle" [modal]="true" [closable]="true" styleClass="p-fluid">
+<p-dialog [(visible)]="displayEjemplar" [style]="{width: '75%'}"  header="Detalle" [modal]="true" [closable]="true" styleClass="p-fluid" [contentStyle]="{overflow: 'visible'}">
 <ng-template pTemplate="content">
     <form [formGroup]="formDetalle">
     <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-3 gap-4">
@@ -345,6 +345,7 @@ import { AuthService } from '../../../services/auth.service';
 </p-dialog>
   <p-confirmDialog [style]="{width: '450px'}"></p-confirmDialog>
             <p-toast></p-toast>`,
+    styles: [`:host ::ng-deep label{white-space:normal !important;overflow:visible !important;text-overflow:initial !important;}`],
     imports: [TemplateModule, InputValidation],
     providers: [MessageService, ConfirmationService]
 })


### PR DESCRIPTION
## Summary
- permite overflow visible en el diálogo `displayEjemplar` de libros, tesis, revistas y otros para que las etiquetas se muestren completas

## Testing
- `npm test` *(falla: error TS18003, no se encontraron entradas en tsconfig.spec.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4c6fa0ccc832982d46d99805718bb