### PR TITLE
Unificar filtros "Buscar por" en módulos de biblioteca

### DIFF
--- a/Backend/login-microsoft365/src/main/java/com/miapp/service/MaterialBibliograficoService.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/service/MaterialBibliograficoService.java
@@ -220,7 +220,12 @@ public class MaterialBibliograficoService {
             } else {
                 // Para otros campos, si la propiedad es directa en MaterialBibliografico
                 spec = spec.and((root, query, cb) ->
-                        cb.like(cb.lower(root.get(opcion.toLowerCase()).as(String.class)), "%" + valor.toLowerCase() + "%")
+                        cb.like(
+                                cb.lower(
+                                        cb.function("TO_CHAR", String.class, root.get(opcion.toLowerCase()))
+                                ),
+                                "%" + valor.toLowerCase() + "%"
+                        )
                 );
             }
         }
@@ -253,8 +258,12 @@ public class MaterialBibliograficoService {
             } else {
                 // Para otros campos que sean propiedades directas en MaterialBibliografico
                 spec = spec.and((root, query, cb) ->
-                        cb.like(cb.lower(root.get(opcion.toLowerCase()).as(String.class)),
-                                "%" + valor.toLowerCase() + "%")
+                        cb.like(
+                                cb.lower(
+                                        cb.function("TO_CHAR", String.class, root.get(opcion.toLowerCase()))
+                                ),
+                                "%" + valor.toLowerCase() + "%"
+                        )
                 );
             }
         }

--- a/Backend/login-microsoft365/src/main/java/com/miapp/service/MaterialBibliograficoSpecification.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/service/MaterialBibliograficoSpecification.java
@@ -10,7 +10,15 @@ public class MaterialBibliograficoSpecification {
             if (campo == null || valor == null || valor.isEmpty()) {
                 return builder.conjunction(); // No aplica filtro
             }
-            return builder.like(builder.lower(root.get(campo.toLowerCase())), "%" + valor.toLowerCase() + "%");
+            // Algunos campos están mapeados como CLOB en la base de datos y las funciones
+            // SQL como LOWER no aceptan directamente este tipo. Se convierte el valor a
+            // cadena usando la función SQL TO_CHAR antes de aplicar LOWER y el patrón LIKE.
+            return builder.like(
+                    builder.lower(
+                            builder.function("TO_CHAR", String.class, root.get(campo.toLowerCase()))
+                    ),
+                    "%" + valor.toLowerCase() + "%"
+            );
         };
     }
 }

--- a/Backend/login-microsoft365/src/main/java/com/miapp/service/impl/BibliotecaServiceImpl.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/service/impl/BibliotecaServiceImpl.java
@@ -335,9 +335,32 @@ public class BibliotecaServiceImpl implements BibliotecaService {
                 String pattern = "%" + valor.toLowerCase() + "%";
 
                 if ("editorial".equalsIgnoreCase(opcion)) {
-                    preds.add(cb.like(cb.lower(root.get("editorialPublicacion")), pattern));
+                    preds.add(
+                            cb.like(
+                                    cb.lower(
+                                            cb.function("TO_CHAR", String.class, root.get("editorialPublicacion"))
+                                    ),
+                                    pattern
+                            )
+                    );
+                } else if ("descriptor".equalsIgnoreCase(opcion)) {
+                    preds.add(
+                            cb.like(
+                                    cb.lower(
+                                            cb.function("TO_CHAR", String.class, root.get("descriptor"))
+                                    ),
+                                    pattern
+                            )
+                    );
                 } else {
-                    preds.add(cb.like(cb.lower(root.get(opcion)), pattern));
+                    preds.add(
+                            cb.like(
+                                    cb.lower(
+                                            cb.function("TO_CHAR", String.class, root.get(opcion))
+                                    ),
+                                    pattern
+                            )
+                    );
                 }
             }
 

--- a/Frontend/sakai-ng-master/src/app/biblioteca/interfaces/clase-general.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/interfaces/clase-general.ts
@@ -1,6 +1,7 @@
 export class ClaseGeneral {
     id: number;
     descripcion: string;
+    valor?: string;
     idRol?: number;
     idTipoDocumento?: number;
     activo:boolean;
@@ -8,6 +9,7 @@ export class ClaseGeneral {
     constructor(init?: Partial<ClaseGeneral>) {
         this.id = 0;
         this.descripcion='';
+        this.valor= undefined;
         this.activo=false;
         this.estado=0;
         // Inicialización opcional si se pasa un objeto

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/mantenimientos/aceptaciones/aceptaciones.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/mantenimientos/aceptaciones/aceptaciones.ts
@@ -347,13 +347,41 @@ export class Aceptaciones implements OnInit, AfterViewInit {
       );
   }
     async listar() {
-      const sedeParam   = this.sedeFiltro?.id  ? `sedeId=${this.sedeFiltro.id}&` : '';
-      const opcionParam = this.opcionFiltro?.descripcion
-                            ? `opcion=${encodeURIComponent(this.opcionFiltro.descripcion)}&`
-                            : '';
-      const valorParam  = `valor=${encodeURIComponent(this.palabraClave.trim())}`;
-      const extra       = `soloEnProceso=true`;
-      this.baseEndpoint = `api/biblioteca/search?${sedeParam}${opcionParam}${valorParam}&${extra}`;
+      const opcion = this.opcionFiltro?.valor;
+      const valor  = this.palabraClave?.trim() || '';
+
+      if (opcion === 'codigoLocalizacion') {
+        if (valor && !/^\d+$/.test(valor)) {
+          this.messageService.add({
+            severity: 'warn',
+            summary: 'Código inválido',
+            detail: 'Ingrese solo números para buscar por código'
+          });
+          return;
+        }
+      }
+
+      if (opcion && !valor) {
+        this.messageService.add({
+          severity: 'warn',
+          summary: 'Valor requerido',
+          detail: 'Ingrese un valor para realizar la búsqueda'
+        });
+        return;
+      }
+
+      const params: string[] = [];
+      if (this.sedeFiltro?.id) {
+        params.push(`sedeId=${this.sedeFiltro.id}`);
+      }
+      if (opcion) {
+        params.push(`opcion=${encodeURIComponent(opcion)}`);
+      }
+      if (valor) {
+        params.push(`valor=${encodeURIComponent(valor)}`);
+      }
+      params.push('soloEnProceso=true');
+      this.baseEndpoint = `api/biblioteca/search?${params.join('&')}`;
       this.totalRecords = 0;
       this.data = [];
       this.first = 0;

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/mantenimientos/material-bibliografico/material-bibliografico.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/mantenimientos/material-bibliografico/material-bibliografico.ts
@@ -255,6 +255,16 @@ export class MaterialBibliografico {
           { field: 'anioPublicacion', header: 'Año' }
         ];
         break;
+      case 4: // Artículo
+        this.columns = [
+          { field: 'codigoLocalizacion', header: 'Codigo' },
+          { field: 'titulo', header: 'Título' },
+          { field: 'autorPersonal', header: 'Autor' },
+          { field: 'editorialPublicacion', header: 'Revista' },
+          { field: 'numeroPaginas', header: 'Páginas' },
+          { field: 'anioPublicacion', header: 'Año' }
+        ];
+        break;
       default: // Otros
         this.columns = [
           { field: 'codigoLocalizacion', header: 'Codigo' },
@@ -512,144 +522,96 @@ onSaved(): void {
     }
 
   }
-//   async listar() {
-//     this.loading = true;
-//     this.data = [];
-//
-//     if(this.tipoRecursoFiltro.tipo.id==1){//Libro
-//       this.lista_libros();
-//     }else if(this.tipoRecursoFiltro.tipo.id==2){//Revista
-//       this.lista_revistas();
-//     }else{
-//       this.lista_otro();
-//     }
-//     this.loading = false;
-//   }
-
 async listar() {
   this.loading = true;
   this.data = [];
   this.setColumns();
-  // Si se ingresa palabra clave o se ha seleccionado una opción de búsqueda distinta a "TODOS"
-  if (this.palabraClave && this.palabraClave.trim() !== ""||
-  (this.opcionFiltro && this.opcionFiltro.descripcion && this.opcionFiltro.descripcion.toLowerCase() !== "todos")) {
 
-    // Construir los parámetros de búsqueda
-    const tipoParam = this.tipoRecursoFiltro?.tipo?.id ? `tipoMaterial=${this.tipoRecursoFiltro.tipo.id}&` : "";
-    const opcionParam = this.opcionFiltro?.descripcion ? `opcion=${this.opcionFiltro.descripcion}&` : "";
-    const valorParam = `valor=${encodeURIComponent(this.palabraClave.trim())}`;
-    const extraParam = `soloEnProceso=false`;
-    const endpoint = `api/biblioteca/search?${tipoParam}${opcionParam}${valorParam}&${extraParam}`;
+  const opcion = this.opcionFiltro?.valor;
+  const valor  = this.palabraClave?.trim() || '';
 
-    this.materialBibliograficoService.search_get(endpoint)
-      .subscribe(
-        (result: any) => {
-          // Supongamos que el endpoint devuelve directamente un array
-          console.log(result);
-          // Normalizamos la respuesta para trabajar siempre con un arreglo
-          const lista: any[] = Array.isArray(result?.data?.content)
-            ? result.data.content
-            : Array.isArray(result?.content)
-            ? result.content
-            : Array.isArray(result?.data)
-            ? result.data
-            : Array.isArray(result)
-            ? result
-            : [];
-          this.data = lista.filter((b: any) => Number(b.estadoId) === 2);
-          this.loading = false;
-        },
-        (error: HttpErrorResponse) => {
-          console.error("Error en búsqueda:", error);
-          this.loading = false;
-        }
-      );
-
+  if (opcion === 'codigoLocalizacion') {
+    if (valor && !/^\d+$/.test(valor)) {
+      this.messageService.add({
+        severity: 'warn',
+        summary: 'Código inválido',
+        detail: 'Ingrese solo números para buscar por código'
+      });
+      this.loading = false;
+      return;
+    }
   }
 
-  else {
-    // Si no se ingresó palabra clave, se filtra según el tipo de material.
-    if (this.tipoRecursoFiltro?.tipo?.id === 1) { // Libro
-      this.lista_libros();
-    } else if (this.tipoRecursoFiltro?.tipo?.id === 2) { // Revista
-      this.lista_revistas();
-    } else {
-      this.lista_otro();
+  if (opcion && !valor) {
+    this.messageService.add({
+      severity: 'warn',
+      summary: 'Valor requerido',
+      detail: 'Ingrese un valor para realizar la búsqueda'
+    });
+    this.loading = false;
+    return;
+  }
+
+  if (valor || opcion) {
+    const params: string[] = [];
+    if (this.tipoRecursoFiltro?.tipo?.id) {
+      params.push(`tipoMaterial=${this.tipoRecursoFiltro.tipo.id}`);
     }
+    if (opcion) {
+      params.push(`opcion=${opcion}`);
+    }
+    if (valor) {
+      params.push(`valor=${encodeURIComponent(valor)}`);
+    }
+    params.push('soloEnProceso=false');
+    const endpoint = `api/biblioteca/search?${params.join('&')}`;
+
+    this.materialBibliograficoService.search_get(endpoint).subscribe(
+      (result: any) => {
+        const lista: any[] = Array.isArray(result?.data?.content)
+          ? result.data.content
+          : Array.isArray(result?.content)
+          ? result.content
+          : Array.isArray(result?.data)
+          ? result.data
+          : Array.isArray(result)
+          ? result
+          : [];
+        this.data = lista.filter((b: any) => Number(b.estadoId) === 2);
+        this.loading = false;
+      },
+      (error: HttpErrorResponse) => {
+        console.error('Error en búsqueda:', error);
+        this.loading = false;
+      }
+    );
+  } else {
+    this.listarPorTipoMaterial(this.tipoRecursoFiltro?.tipo?.id);
   }
 }
 
-
-  lista_libros() {
-    this.materialBibliograficoService
-      .api_libros_lista('api/material-bibliografico/libros')
-      .subscribe(
-        (result: any) => {
-          const lista: any[] = Array.isArray(result?.data?.content)
-            ? result.data.content
-            : Array.isArray(result?.content)
-            ? result.content
-            : Array.isArray(result?.data)
-            ? result.data
-            : Array.isArray(result)
-            ? result
-            : [];
-          this.data = lista.filter((b: any) => Number(b.estadoId) === 2);
-          this.loading = false;
-        },
-        (error: HttpErrorResponse) => {
-          this.loading = false;
-        }
-      );
+  private listarPorTipoMaterial(tipo?: number) {
+    const base = 'api/biblioteca/search?soloEnProceso=false';
+    const endpoint = tipo ? `${base}&tipoMaterial=${tipo}` : base;
+    this.materialBibliograficoService.search_get(endpoint).subscribe(
+      (result: any) => {
+        const lista: any[] = Array.isArray(result?.data?.content)
+          ? result.data.content
+          : Array.isArray(result?.content)
+          ? result.content
+          : Array.isArray(result?.data)
+          ? result.data
+          : Array.isArray(result)
+          ? result
+          : [];
+        this.data = lista.filter((b: any) => Number(b.estadoId) === 2);
+        this.loading = false;
+      },
+      () => (this.loading = false)
+    );
   }
 
-  lista_revistas() {
-    this.materialBibliograficoService
-      .api_revistas_lista('api/material-bibliografico/revistas')
-      .subscribe(
-        (result: any) => {
-          const lista: any[] = Array.isArray(result?.data?.content)
-            ? result.data.content
-            : Array.isArray(result?.content)
-            ? result.content
-            : Array.isArray(result?.data)
-            ? result.data
-            : Array.isArray(result)
-            ? result
-            : [];
-          this.data = lista.filter((b: any) => Number(b.estadoId) === 2);
-          this.loading = false;
-        },
-        (error: HttpErrorResponse) => {
-          this.loading = false;
-        }
-      );
-  }
-
-  lista_otro() {
-    this.materialBibliograficoService
-      .api_otros_lista(this.modulo + '/lista')
-      .subscribe(
-        (result: any) => {
-          const lista: any[] = Array.isArray(result?.data?.content)
-            ? result.data.content
-            : Array.isArray(result?.content)
-            ? result.content
-            : Array.isArray(result?.data)
-            ? result.data
-            : Array.isArray(result)
-            ? result
-            : [];
-          this.data = lista.filter((b: any) => Number(b.estadoId) === 2);
-          this.loading = false;
-        },
-        (error: HttpErrorResponse) => {
-          this.loading = false;
-        }
-      );
-  }
-
-
+  
 
   cambiarEstadoRegistro(objeto: Ejemplar) {
     let estado = "";

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/portal/catalogo-enlinea.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/portal/catalogo-enlinea.ts
@@ -420,9 +420,30 @@ export class CatalogoEnLineaComponent {
         this.detallesPorBiblioteca = {};
     }
     listar() {
-        // Construye los parámetros de búsqueda según los filtros seleccionados
+        const opcion = this.opcionFiltro?.valor;
+        const valor  = this.palabraClave?.trim() || '';
+
+        if (opcion === 'codigoLocalizacion') {
+            if (valor && !/^\d+$/.test(valor)) {
+                this.messageService.add({
+                    severity: 'warn',
+                    summary: 'Código inválido',
+                    detail: 'Ingrese solo números para buscar por código'
+                });
+                return;
+            }
+        }
+
+        if (opcion && !valor) {
+            this.messageService.add({
+                severity: 'warn',
+                summary: 'Valor requerido',
+                detail: 'Ingrese un valor para realizar la búsqueda'
+            });
+            return;
+        }
+
         const params = new URLSearchParams();
-        const valor = this.palabraClave?.trim();
         if (valor) {
             params.set('valor', valor);
         }
@@ -432,13 +453,12 @@ export class CatalogoEnLineaComponent {
         if (this.coleccionFiltro?.id) {
             params.set('tipoMaterial', String(this.coleccionFiltro.id));
         }
-        if (this.opcionFiltro?.descripcion) {
-            params.set('opcion', this.opcionFiltro.descripcion);
+        if (opcion) {
+            params.set('opcion', opcion);
         }
 
         const url = params.toString() ? `api/biblioteca/catalogo?${params}` : 'api/biblioteca/catalogo';
 
-        // Recupera solo las cabeceras disponibles
         this.loading = true;
         this.materialBibliograficoService.api_libros_lista(url).subscribe({
             next: (result: any) => {

--- a/Frontend/sakai-ng-master/src/app/biblioteca/web/catalogo/catalogo-lista.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/web/catalogo/catalogo-lista.ts
@@ -275,14 +275,37 @@ export class CatalogoLista implements OnInit {
     }
 
 listar() {
+  const valor  = this.palabraClave?.trim() || '';
+  const opcion = this.opcionFiltro.valor || undefined;
+
+  if (opcion === 'codigoLocalizacion') {
+    if (valor && !/^\d+$/.test(valor)) {
+      this.messageService.add({
+        severity: 'warn',
+        summary: 'Código inválido',
+        detail: 'Ingrese solo números para buscar por código'
+      });
+      return;
+    }
+  }
+
+  if (opcion && !valor) {
+    this.messageService.add({
+      severity: 'warn',
+      summary: 'Valor requerido',
+      detail: 'Ingrese un valor para realizar la búsqueda'
+    });
+    return;
+  }
+
   this.loading = true;
   this.data = [];
   this.materialBibliograficoService
     .catalogo(
-      this.palabraClave,
+      valor,
       this.sedeFiltro.id,
       this.tipoRecursoFiltro.id,
-      this.opcionFiltro.descripcion
+      opcion
     )
     .subscribe(
       list => {

--- a/Frontend/sakai-ng-master/src/assets/demo/biblioteca/opcionFiltroBiblioteca.json
+++ b/Frontend/sakai-ng-master/src/assets/demo/biblioteca/opcionFiltroBiblioteca.json
@@ -1,13 +1,10 @@
 {
     "status":"0",
     "data": [ 
-        {"id":0,"descripcion": "Cualquier campo", "activo": true}, 
-        {"id":1,"descripcion": "Tema", "activo": true}, 
-        {"id":2,"descripcion": "Codigo", "activo": true}, 
-        {"id":3,"descripcion": "Nombre", "activo": true},
-        {"id":4,"descripcion": "Descripcion", "activo": true}, 
-        {"id":5,"descripcion": "Autor", "activo": true}, 
-        {"id":6,"descripcion": "Genero", "activo": true}, 
-        {"id":7,"descripcion": "Editorial", "activo": true}
+        {"id":0,"descripcion": "Todos", "valor": "", "activo": true},
+        {"id":1,"descripcion": "Tema", "valor": "descriptor", "activo": true},
+        {"id":2,"descripcion": "Autor", "valor": "autorPersonal", "activo": true},
+        {"id":3,"descripcion": "Título", "valor": "titulo", "activo": true},
+        {"id":4,"descripcion": "Código", "valor": "codigoLocalizacion", "activo": true}
     ]
 }

--- a/Frontend/sakai-ng-master/src/assets/demo/biblioteca/tipos-recurso.json
+++ b/Frontend/sakai-ng-master/src/assets/demo/biblioteca/tipos-recurso.json
@@ -4,6 +4,6 @@
         {"id":1,"tipo":{"id":1,"descripcion": "Material", "activo": true},"descripcion": "Libro", "activo": true}, 
         {"id":2,"tipo":{"id":1,"descripcion": "Material", "activo": true},"descripcion": "Revista", "activo": true}, 
         {"id":3,"tipo":{"id":1,"descripcion": "Material", "activo": true},"descripcion": "Tesis", "activo": true},  
-        {"id":4,"tipo":{"id":1,"descripcion": "Material", "activo": true},"descripcion": "Articulos", "activo": true}
+        {"id":4,"tipo":{"id":1,"descripcion": "Material", "activo": true},"descripcion": "Artículo", "activo": true}
     ]
 }


### PR DESCRIPTION
## Resumen
- Limita la búsqueda por *Tema* únicamente al campo `descriptor`
- Conserva la unificación de filtros en la capa de servicio

## Testing
- `npm test` *(falla: error TS18003: No inputs were found in config file '/workspace/sistemabiblioteca/Frontend/sakai-ng-master/tsconfig.spec.json')*
- `mvn -q test` *(falla: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.3)*

------
https://chatgpt.com/codex/tasks/task_e_68b537f1045083299c58a01d305df0a9