### PR TITLE
fix: evitar duplicado de código en artículos

### DIFF
--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/mantenimientos/material-bibliografico/modal-otros.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/mantenimientos/material-bibliografico/modal-otros.ts
@@ -742,15 +742,12 @@ export class ModalOtrosComponent implements OnInit {
     }
     guardarEspecialidad() {
         if (this.formEspecialidad.valid) {
-<<<<<<< HEAD
             const desc = this.formEspecialidad.value.descripcion.trim().toLowerCase();
             const existe = this.especialidadLista.some(e => (e.descripcion || '').trim().toLowerCase() === desc);
             if (existe) {
                 this.messageService.add({ severity: 'warn', summary: 'Advertencia', detail: 'La especialidad ya se encuentra registrada' });
                 return;
             }
-=======
->>>>>>> c36c32b (chore: ignore build artifacts (target, *.jar))
 
             this.confirmationService.confirm({
                 message: '¿Estás seguro(a) de que quieres registrar?',

--- a/Frontend/sakai-ng-master/src/app/biblioteca/services/material-bibliografico.service.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/services/material-bibliografico.service.ts
@@ -418,11 +418,12 @@ registrarEspecialidad(especialidad: any): Observable<any> {
   private mapToOtro(b: BibliotecaDTO): Otro {
     return new Otro({
       id: b.id ?? 0,
-        tituloArticulo: b.titulo ?? '',
-        tituloRevista: b.editorialPublicacion ?? '',
-        autorPrincipal: b.autorPersonal ?? '',
-        descripcionRevista: b.tituloAnterior ?? '',
-        descripcionFisica: (b as any).descripcionFisica ?? null,
+      codigo: b.codigoLocalizacion ?? '',
+      tituloArticulo: b.titulo ?? '',
+      tituloRevista: b.editorialPublicacion ?? '',
+      autorPrincipal: b.autorPersonal ?? '',
+      descripcionRevista: b.tituloAnterior ?? '',
+      descripcionFisica: (b as any).descripcionFisica ?? null,
         cantidad: b.existencias ?? 0,
         formatoDigital: b.fladigitalizado ?? false,
         urlPublicacion: b.linkPublicacion ?? '',


### PR DESCRIPTION
## Summary
- añade mapeo del código del material al generar objetos `Otro`
- limpia conflictos y valida duplicados en el registro de especialidades

## Testing
- `npm test` *(falla: TS18003: No inputs were found in config file)*
- `npm run lint` *(falla: Missing script: "lint")*


------
https://chatgpt.com/codex/tasks/task_e_68b686559df483299ef79517688077ff