### PR TITLE
fix: mostrar detalle correcto del material bibliográfico

### DIFF
--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/mantenimientos/aceptaciones/aceptaciones.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/mantenimientos/aceptaciones/aceptaciones.ts
@@ -503,7 +503,7 @@ aceptarDetalle(detalle: any) {
     }
 
   verDetalle(objeto:any){
-    this.modalDetalle.openModal();
+    this.modalDetalle.openModal(objeto);
   }
 
   irAutorizacion(detalle: any): void {

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/portal/detalle-material.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/portal/detalle-material.ts
@@ -1,67 +1,66 @@
-import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
-import { FormBuilder, FormGroup, Validators } from '@angular/forms';
-import { ConfirmationService, MenuItem, MessageService } from 'primeng/api';
+import { Component, OnInit } from '@angular/core';
+import { ConfirmationService, MessageService } from 'primeng/api';
 import { TemplateModule } from '../../template.module';
+import { environment } from '../../../../environments/environment';
 @Component({
     selector: 'app-modal-detalle-material',
     standalone: true,
-    template: ` <p-dialog [(visible)]="display" [style]="{width: '80vw'}"  header="Ficha bibliografica" [modal]="true" [closable]="true" styleClass="p-fluid">
-    <ng-template pTemplate="content">            
+    template: ` <p-dialog [(visible)]="display" [style]="{width: '80vw'}"  header="Ficha bibliográfica" [modal]="true" [closable]="true" styleClass="p-fluid">
+    <ng-template pTemplate="content">
     <div class="p-4 grid md:grid-cols-3 lg:grid-cols-12 gap-4">
     <!-- Imagen del libro -->
     <div class="col-span-12 md:col-span-4 lg:col-span-6 xl:col-span-5 flex justify-center mx-8">
-        <img src="https://biblioteca.upsjb.edu.pe/lan/Imagenes/Uploads/UPSJB_1_30112024_133774580434692598_469.jpg" 
-             alt="Portada del libro" 
+        <img [src]="getImageUrl(objeto)" [alt]="objeto?.titulo" 
              class="w-full max-w-[300px] md:max-w-[350px] lg:max-w-[300px] h-auto object-cover rounded-lg shadow-lg">
     </div>
 
     <!-- Detalles del libro -->
     <div class="col-span-12 md:col-span-9 lg:col-span-6 xl:col-span-7 space-y-3">
         <div class="text-gray-700">
-            <b class="font-semibold">Código:</b><br/>WB/925/V38
+            <b class="font-semibold">Código:</b><br/>{{objeto?.codigoLocalizacion || '-'}}
         </div><hr/>
         <div class="text-gray-700">
-            <span class="font-semibold">Título:</span><br/> FITOTERAPIA: COMPENDIO ILUSTRADO DE PLANTAS MEDICINALES
+            <span class="font-semibold">Título:</span><br/> {{objeto?.titulo || '-'}}
         </div><hr/>
         <div class="text-gray-700">
-            <span class="font-semibold">Autor:</span><br/> Vázquez López, Guillermo Jesús
+            <span class="font-semibold">Autor:</span><br/> {{objeto?.autor || '-'}}
         </div><hr/>
         <div class="text-gray-700">
-            <span class="font-semibold">Editorial:</span><br/> Mandala Ediciones
+            <span class="font-semibold">Editorial:</span><br/> {{objeto?.editorial || '-'}}
         </div><hr/>
 
         <div class="grid grid-cols-3 gap-4">
             <div class="text-gray-700">
-                <span class="font-semibold">Páginas:</span><br/> 100
+                <span class="font-semibold">Páginas:</span><br/> {{objeto?.paginas || '-'}}
             </div>
             <div class="text-gray-700">
-                <span class="font-semibold">País/Ciudad:</span><br/> España/Madrid
+                <span class="font-semibold">País/Ciudad:</span><br/> {{objeto?.paisCiudad || '-'}}
             </div>
             <div class="text-gray-700">
-                <span class="font-semibold">Año Publicación:</span><br/> 2021
+                <span class="font-semibold">Año Publicación:</span><br/> {{objeto?.anioPublicacion || '-'}}
             </div>
         </div>
 
         <div class="grid grid-cols-3 gap-4">
             <div class="text-gray-700">
-                <span class="font-semibold">ISBN:</span> 9788418672286
+                <span class="font-semibold">ISBN:</span> {{objeto?.isbn || '-'}}
             </div>
             <div class="text-gray-700">
-                <span class="font-semibold">Edición:</span> 4
+                <span class="font-semibold">Edición:</span> {{objeto?.edicion || '-'}}
             </div>
             <div class="text-gray-700">
-                <span class="font-semibold">Reimpresión:</span> 1
+                <span class="font-semibold">Reimpresión:</span> {{objeto?.reimpresion || '-'}}
             </div>
         </div>
 
-        <div class="text-gray-700"><br/> 
-            <span class="font-semibold">Temas:</span> PERÚ / HISTORIA / ÉPOCA PREHISPÁNICA / ÉPOCA COLONIAL / ÉPOCA CONTEMPORÁNEA
+        <div class="text-gray-700"><br/>
+            <span class="font-semibold">Temas:</span> {{objeto?.temas || '-'}}
         </div>
-        <div class="text-gray-700"><br/> 
-            <span class="font-semibold">Nota de Contenido:</span> La calle de los Ángeles / Toribio Alarco de Albornoz -- Las calles de Chincha / Lucas Tejada Martínez -- ¡En plena esclavitud! / María Jesús Alvarado Rivera -- ¡Amo al pueblo soberbio ...! / Abelardo Alva Maúrtua -- El problema peruano / Antonio Roy Abrill -- Duérmete novia / Luis Schwarz Zuleta -- Nocturno infinito / Carola Bermúdez de Castro -- "Chincha o Chinche" / Zoila Atúncar de Asín -- El galpón "Los come tripa" / Luis Felipe Brignole Roy...
+        <div class="text-gray-700"><br/>
+            <span class="font-semibold">Nota de Contenido:</span> {{objeto?.notaContenido || '-'}}
         </div>
-        <div class="text-gray-700"><br/> 
-            <span class="font-semibold">Nota General:</span> Círculo Cultural Chinchanidad.
+        <div class="text-gray-700"><br/>
+            <span class="font-semibold">Nota General:</span> {{objeto?.notaGeneral || '-'}}
         </div>
     </div>
 </div>
@@ -79,12 +78,34 @@ export class ModalDetalleMaterial implements OnInit {
     async ngOnInit() {
 
     }
-        openModal() {
-            this.objeto={};
+        openModal(objeto: any) {
+            this.objeto = objeto || {};
             this.display = true;
         }
-    
+
         closeModal() {
             this.display = false;
+        }
+
+        /** Devuelve la URL de la imagen almacenada si existe */
+        getImageUrl(obj: any): string | undefined {
+            if (obj?.material?.url) {
+                const p = obj.material.url as string;
+                return p.startsWith('http') ? p : `${environment.filesUrl}${p}`;
+            }
+            if (obj?.rutaImagen) {
+                const base = obj.rutaImagen.startsWith('http')
+                    ? obj.rutaImagen
+                    : `${environment.filesUrl}${obj.rutaImagen.startsWith('/') ? '' : '/'}${obj.rutaImagen}`;
+                if (obj.nombreImagen) {
+                    if (base.endsWith(obj.nombreImagen)) {
+                        return base;
+                    }
+                    const sep = base.endsWith('/') ? '' : '/';
+                    return base + sep + obj.nombreImagen;
+                }
+                return base;
+            }
+            return undefined;
         }
     }


### PR DESCRIPTION
## Resumen
- mostrar la ficha bibliográfica con los datos del material seleccionado
- pasar el objeto a la ventana de detalle y calcular la URL de la imagen

## Testing
- `npm test` *(falla: error TS18003: No inputs were found in config file)*
- `npm run build` *(falla: merge conflict markers en archivos ajenos al cambio)*

------
https://chatgpt.com/codex/tasks/task_e_68b79024bd1c83298fe065c483294f9d