### PR TITLE
fix: cargar detalle completo de material en aceptaciones

### DIFF
--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/mantenimientos/aceptaciones/aceptaciones.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/mantenimientos/aceptaciones/aceptaciones.ts
@@ -502,8 +502,49 @@ aceptarDetalle(detalle: any) {
       this.modal.openModal(item);
     }
 
-  verDetalle(objeto:any){
-    this.modalDetalle.openModal(objeto);
+  verDetalle(objeto: any) {
+    if (!objeto?.id) {
+      this.modalDetalle.openModal(objeto);
+      return;
+    }
+
+    this.loading = true;
+    this.materialBibliograficoService.get(objeto.id).subscribe({
+      next: (res: any) => {
+        const detalle = {
+          ...res,
+          codigoLocalizacion: res?.codigoLocalizacion || res?.codigo,
+          autor:
+            res?.autorPersonal ||
+            res?.autorSecundario ||
+            res?.autorInstitucional ||
+            '',
+          editorial:
+            res?.editorialPublicacion || res?.editorial?.descripcion || '',
+          paginas: res?.numeroPaginas,
+          paisCiudad: [res?.pais?.descripcion, res?.ciudad?.descripcion]
+            .filter(Boolean)
+            .join(' / '),
+          anioPublicacion: res?.anioPublicacion,
+          isbn: res?.isbn,
+          edicion: res?.edicion,
+          reimpresion: res?.reimpresion,
+          temas: res?.descriptor,
+          notaContenido: res?.notaContenido,
+          notaGeneral: res?.notaGeneral,
+        };
+        this.modalDetalle.openModal(detalle);
+        this.loading = false;
+      },
+      error: () => {
+        this.loading = false;
+        this.messageService.add({
+          severity: 'error',
+          summary: 'Error',
+          detail: 'No se pudo obtener la ficha bibliográfica',
+        });
+      },
+    });
   }
 
   irAutorizacion(detalle: any): void {


### PR DESCRIPTION
## Summary
- cargar desde el servicio la ficha completa del material antes de mostrar el detalle

## Testing
- `npm test` *(falla: No inputs were found in config file '/workspace/sistemabiblioteca/Frontend/sakai-ng-master/tsconfig.spec.json')*


------
https://chatgpt.com/codex/tasks/task_e_68b7aee6d55c8329b2613262c1b19eab