### PR TITLE
Filtrar equipos por discapacidad al cambiar checkbox

### DIFF
--- a/Backend/login-microsoft365/src/main/java/com/miapp/controller/EquipoController.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/controller/EquipoController.java
@@ -69,14 +69,14 @@ public class EquipoController {
     }
 
     @GetMapping("/list")
-    public ResponseEntity<?> listarEquipos() {
-        List<Equipo> lista = equipoService.listarEquipos();
+    public ResponseEntity<?> listarEquipos(@RequestParam(required = false) Boolean discapacidad) {
+        List<Equipo> lista = equipoService.listarEquipos(discapacidad);
         return ResponseEntity.ok(Map.of("status", 0, "data", lista));
     }
 
     @GetMapping("/filter")
-    public ResponseEntity<?> filtrarPorSede(@RequestParam Long sedeId) {
-        List<Equipo> lista = equipoService.filtrarPorSedeExcluyendoEnProceso(sedeId);
+    public ResponseEntity<?> filtrarPorSede(@RequestParam Long sedeId, @RequestParam(required = false) Boolean discapacidad) {
+        List<Equipo> lista = equipoService.filtrarPorSedeExcluyendoEnProceso(sedeId, discapacidad);
         return ResponseEntity.ok(Map.of("status", 0, "data", lista));
     }
 
@@ -120,8 +120,8 @@ public class EquipoController {
 
     // Endpoint que lista equipos sin el estado "EN PROCESO"
     @GetMapping("/listWithoutEnProceso")
-    public ResponseEntity<?> listWithoutEnProceso() {
-        List<Equipo> lista = equipoService.listWithoutEnProceso();
+    public ResponseEntity<?> listWithoutEnProceso(@RequestParam(required = false) Boolean discapacidad) {
+        List<Equipo> lista = equipoService.listWithoutEnProceso(discapacidad);
         return ResponseEntity.ok(Map.of("status", 0, "data", lista));
     }
 

--- a/Backend/login-microsoft365/src/main/java/com/miapp/repository/EquipoRepository.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/repository/EquipoRepository.java
@@ -13,14 +13,23 @@ public interface EquipoRepository extends JpaRepository<Equipo, Long> {
     // Filtrar equipos por id de sede
     List<Equipo> findBySede_Id(Long id);
     List<Equipo> findBySede_IdAndEstado_DescripcionNotIgnoreCase(Long sedeId, String descripcion);
+    List<Equipo> findBySede_IdAndEstado_DescripcionNotIgnoreCaseAndEquipoDiscapacidad(Long sedeId, String descripcion, Boolean equipoDiscapacidad);
     // Retorna los equipos cuyo estado sea exactamente "EN PROCESO"
     List<Equipo> findByEstado_DescripcionIgnoreCase(String descripcion);
 
     // Retorna los equipos cuyo estado no sea "EN PROCESO"
     List<Equipo> findByEstado_DescripcionNotIgnoreCase(String descripcion);
+    List<Equipo> findByEstado_DescripcionNotIgnoreCaseAndEquipoDiscapacidad(String descripcion, Boolean equipoDiscapacidad);
+    @Query("SELECT e FROM Equipo e WHERE UPPER(e.estado.descripcion) <> UPPER(:descripcion) " +
+            "AND (e.equipoDiscapacidad = false OR e.equipoDiscapacidad IS NULL)")
+    List<Equipo> findByEstadoDescripcionNotIgnoreCaseAndEquipoDiscapacidadFalseOrNull(@Param("descripcion") String descripcion);
 
     // Retorna equipos de una sede que tengan el estado "EN PROCESO" (ignora mayúsculas/minúsculas)
     List<Equipo> findBySede_IdAndEstado_DescripcionIgnoreCase(Long sedeId, String descripcion);
+    @Query("SELECT e FROM Equipo e WHERE e.sede.id = :sedeId AND UPPER(e.estado.descripcion) <> UPPER(:descripcion) " +
+            "AND (e.equipoDiscapacidad = false OR e.equipoDiscapacidad IS NULL)")
+    List<Equipo> findBySedeIdAndEstadoDescripcionNotIgnoreCaseAndEquipoDiscapacidadFalseOrNull(@Param("sedeId") Long sedeId,
+                                                                                                @Param("descripcion") String descripcion);
 
     @Query("select e from Equipo e where " +
             "str(e.idEquipo) like %:q% or " +

--- a/Backend/login-microsoft365/src/main/java/com/miapp/service/EquipoService.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/service/EquipoService.java
@@ -50,9 +50,9 @@ public class EquipoService {
         equipoRepository.deleteById(id);
     }
 
-    // Listado completo
-    public List<Equipo> listarEquipos() {
-        return equipoRepository.findAll();
+    // Listado completo excluyendo equipos "EN PROCESO" con opción a filtrar por discapacidad
+    public List<Equipo> listarEquipos(Boolean discapacidad) {
+        return listWithoutEnProceso(discapacidad);
     }
 
     // Filtrado por sede
@@ -78,7 +78,13 @@ public class EquipoService {
         return equipoRepository.findById(id);
     }
 
-    public List<Equipo> filtrarPorSedeExcluyendoEnProceso(Long idSede) {
+    public List<Equipo> filtrarPorSedeExcluyendoEnProceso(Long idSede, Boolean discapacidad) {
+        if (Boolean.TRUE.equals(discapacidad)) {
+            return equipoRepository.findBySede_IdAndEstado_DescripcionNotIgnoreCaseAndEquipoDiscapacidad(idSede, "EN PROCESO", true);
+        }
+        if (Boolean.FALSE.equals(discapacidad)) {
+            return equipoRepository.findBySedeIdAndEstadoDescripcionNotIgnoreCaseAndEquipoDiscapacidadFalseOrNull(idSede, "EN PROCESO");
+        }
         return equipoRepository.findBySede_IdAndEstado_DescripcionNotIgnoreCase(idSede, "EN PROCESO");
     }
 
@@ -87,8 +93,14 @@ public class EquipoService {
         return equipoRepository.findByEstado_DescripcionIgnoreCase("EN PROCESO");
     }
 
-    // Lista los equipos cuyo estado NO sea "EN PROCESO"
-    public List<Equipo> listWithoutEnProceso() {
+    // Lista los equipos cuyo estado NO sea "EN PROCESO", con opción a filtrar por discapacidad
+    public List<Equipo> listWithoutEnProceso(Boolean discapacidad) {
+        if (Boolean.TRUE.equals(discapacidad)) {
+            return equipoRepository.findByEstado_DescripcionNotIgnoreCaseAndEquipoDiscapacidad("EN PROCESO", true);
+        }
+        if (Boolean.FALSE.equals(discapacidad)) {
+            return equipoRepository.findByEstadoDescripcionNotIgnoreCaseAndEquipoDiscapacidadFalseOrNull("EN PROCESO");
+        }
         return equipoRepository.findByEstado_DescripcionNotIgnoreCase("EN PROCESO");
     }
 

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/mantenimientos/biblioteca-virtual/biblioteca-vritual.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/mantenimientos/biblioteca-virtual/biblioteca-vritual.ts
@@ -43,7 +43,7 @@ import { Estado } from '../../../interfaces/biblioteca-virtual/estado';
 
                         <label for="discapacidad" class="block text-sm font-medium">&nbsp;</label>
                         <div class="col-span-2 flex items-center gap-2">
-                        <p-checkbox id="checkDiscapacidad" name="option"  [(ngModel)]="discapacidadFiltro" [binary]="true"></p-checkbox>
+                        <p-checkbox id="checkDiscapacidad" name="option" [(ngModel)]="discapacidadFiltro" [binary]="true" (onChange)="filtrarPorSede()"></p-checkbox>
                         <label for="checkDiscapacidad" class="text-sm">¿Equipos con discapacidad?</label>
       </div>
                 </div>
@@ -255,7 +255,7 @@ export class BibliotecaVirtual implements OnInit {
     }
     await this.cargarEstados();
     await this.ListaSede();
-    await this.listar();
+    this.filtrarPorSede();
     this.formValidar();
   }
 
@@ -500,7 +500,7 @@ private mapToEquipo(obj: any): Equipo {
         if (result.p_status == 0) {
           this.objetoDialog = false;
           this.messageService.add({ severity: 'success', summary: 'Satisfactorio', detail: 'Registro guardado.' });
-          this.listar();
+          this.filtrarPorSede();
         } else {
           this.messageService.add({ severity: 'error', summary: 'Error', detail: 'No se puedo realizar el proceso.' });
         }
@@ -529,25 +529,6 @@ private mapToEquipo(obj: any): Equipo {
     }
 
   }
-  async listar() {
-    this.loading = true;
-    this.data = [];
-
-    this.bibliotecaVirtualService.listarEquipos()
-      .subscribe(
-        (result: any) => {
-          this.loading = false;
-          if (result.status == "0") {
-            this.data = result.data;
-          }
-        }
-        , (error: HttpErrorResponse) => {
-          this.loading = false;
-        }
-      );
-
-    this.loading = false;
-  }
   cambiarEstadoRegistro(objeto: Ejemplar) {
     let estado = "";
     if (objeto.activo) {
@@ -569,7 +550,7 @@ private mapToEquipo(obj: any): Equipo {
             if (result.p_status == 0) {
               this.objetoDialog = false;
               this.messageService.add({ severity: 'success', summary: 'Satisfactorio', detail: 'Estado de registro satisfactorio.' });
-              this.listar();
+              this.filtrarPorSede();
             } else {
               this.messageService.add({ severity: 'error', summary: 'Error', detail: 'No se puedo realizar el proceso.' });
             }
@@ -587,23 +568,27 @@ private mapToEquipo(obj: any): Equipo {
     this.menu.toggle(event);
   }
 
-    // Filtrar equipos por sede
+    // Filtrar equipos por sede o por discapacidad cuando se elige "todas las sedes"
     filtrarPorSede() {
-      if (this.sedeFiltro && this.sedeFiltro.id) {
-    this.bibliotecaVirtualService.filtrarPorSede(this.sedeFiltro.id).subscribe(
-            (result: any) => {
-              this.loading = false;
-              if (result.status == "0") {
-                this.data = result.data;
-              }
-            }
-            , (error: HttpErrorResponse) => {
-              this.loading = false;
-            }
-          );
-      } else {
-        this.listar();
-      }
+      this.loading = true;
+      const sedeId = this.sedeFiltro?.id ?? 0;
+      const discapacidad = this.discapacidadFiltro;
+
+      const obs = sedeId === 0
+        ? this.bibliotecaVirtualService.listarEquipos(discapacidad)
+        : this.bibliotecaVirtualService.filtrarPorSede(sedeId, discapacidad);
+
+      obs.subscribe(
+        (result: any) => {
+          this.loading = false;
+          if (result.status == "0") {
+            this.data = result.data;
+          }
+        },
+        (error: HttpErrorResponse) => {
+          this.loading = false;
+        }
+      );
     }
 
 

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/mantenimientos/biblioteca-virtual/form-equipo.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/mantenimientos/biblioteca-virtual/form-equipo.ts
@@ -274,11 +274,23 @@ export class FormEquipo implements OnInit, OnChanges {
             maxHoras: equipo.maxHoras ?? null
         });
     }
-    /** Convierte un string "HH:mm" a un objeto Date (solo para p-calendar timeOnly) */
-    private stringToDate(hhmm: string): Date {
-        const parts = hhmm.split(':');
+    /** Convierte un valor de hora a objeto Date (soporta "HH:mm", "HH:mm:ss" o número) */
+    private stringToDate(time: string | number): Date | null {
+        if (time === null || time === undefined) {
+            return null;
+        }
         const d = new Date();
-        d.setHours(+parts[0], +parts[1], 0, 0);
+        if (typeof time === 'number') {
+            d.setHours(time, 0, 0, 0);
+            return d;
+        }
+        const parts = time.split(':');
+        const hours = parseInt(parts[0], 10);
+        const minutes = parts.length > 1 ? parseInt(parts[1], 10) : 0;
+        if (isNaN(hours) || isNaN(minutes)) {
+            return null;
+        }
+        d.setHours(hours, minutes, 0, 0);
         return d;
     }
 }

--- a/Frontend/sakai-ng-master/src/app/biblioteca/services/biblioteca-virtual.service.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/services/biblioteca-virtual.service.ts
@@ -43,16 +43,24 @@ export class BibliotecaVirtualService {
     return this.http.post<any>(`${this.apisUrl}/delete-bulk`, ids);
   }
 
-    listarEquipos(): Observable<any> {
-      return this.http.get<any>(`${this.apisUrl}/listWithoutEnProceso`);
+    listarEquipos(discapacidad?: boolean): Observable<any> {
+      let params = new HttpParams();
+      if (discapacidad !== undefined) {
+        params = params.set('discapacidad', discapacidad);
+      }
+      return this.http.get<any>(`${this.apisUrl}/list`, { params });
     }
 
     listarEquiposEnProceso(): Observable<any> {
       return this.http.get<any>(`${this.apisUrl}/listEnProceso`);
     }
 
-    filtrarPorSede(sedeId: number): Observable<any> {
-      return this.http.get<any>(`${this.apisUrl}/filter?sedeId=${sedeId}`);
+    filtrarPorSede(sedeId: number, discapacidad?: boolean): Observable<any> {
+      let params = new HttpParams().set('sedeId', sedeId);
+      if (discapacidad !== undefined) {
+        params = params.set('discapacidad', discapacidad);
+      }
+      return this.http.get<any>(`${this.apisUrl}/filter`, { params });
     }
     filtrarPorSedeEnProcesp(sedeId: number): Observable<any> {
       return this.http.get<any>(`${this.apisUrl}/filter/onlyEnProceso?sedeId=${sedeId}`);


### PR DESCRIPTION
## Resumen
- Invocar el filtro de equipos al cargar el módulo para incluir el parámetro de discapacidad desde la primera consulta
- Simplificar la carga inicial eliminando el método `listar` y reutilizando `filtrarPorSede` tanto para sede específica como para todas

## Testing
- `mvn -q test -f Backend/login-microsoft365/pom.xml` *(falla: Non-resolvable parent POM, Network is unreachable)*
- `npm test --prefix Frontend/sakai-ng-master -- --watch=false` *(falla: error TS18003: No inputs were found en tsconfig.spec.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7cab359cc83298108e4b5e2fb5de5