### PR TITLE
Corregir búsqueda y nombres en préstamos de material bibliográfico

### DIFF
--- a/Backend/login-microsoft365/src/main/java/com/miapp/model/dto/DetalleBibliotecaDTO.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/model/dto/DetalleBibliotecaDTO.java
@@ -102,6 +102,12 @@ public class DetalleBibliotecaDTO {
     /** Nombre del usuario que reservó */
     private String nombreUsuario;
 
+    /** Número de documento del usuario */
+    private String documentoUsuario;
+
+    /** Correo electrónico del usuario */
+    private String correoUsuario;
+
     /** Fecha de la reserva */
     private String fechaReserva;
 }

--- a/Backend/login-microsoft365/src/main/java/com/miapp/service/DetalleBibliotecaService.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/service/DetalleBibliotecaService.java
@@ -7,6 +7,7 @@ import com.miapp.model.dto.CambioEstadoDetalleRequest;
 import com.miapp.model.dto.DetalleBibliotecaDTO;
 import com.miapp.model.dto.ResponseDTO;
 import com.miapp.repository.DetalleBibliotecaRepository;
+import com.miapp.repository.UsuarioRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,6 +21,7 @@ public class DetalleBibliotecaService {
 
     private final DetalleBibliotecaRepository detalleBibliotecaRepository;
     private final BibliotecaMapper mapper;
+    private final UsuarioRepository usuarioRepository;
 
     @Transactional
     public ResponseDTO cambiarEstado(CambioEstadoDetalleRequest req) {
@@ -36,7 +38,20 @@ public class DetalleBibliotecaService {
     public List<DetalleBibliotecaDTO> findDetallesReservados() {
         List<DetalleBiblioteca> lista = detalleBibliotecaRepository.findByIdEstado(3L);
         return lista.stream()
-                .map(detalle -> mapper.toDetalleDto(detalle))
+                .map(detalle -> {
+                    DetalleBibliotecaDTO dto = mapper.toDetalleDto(detalle);
+                    usuarioRepository.findByLoginIgnoreCase(detalle.getCodigoUsuario())
+                            .ifPresent(u -> {
+                                String nombres = String.format("%s %s %s",
+                                        u.getApellidoPaterno() != null ? u.getApellidoPaterno() : "",
+                                        u.getApellidoMaterno() != null ? u.getApellidoMaterno() : "",
+                                        u.getNombreUsuario() != null ? u.getNombreUsuario() : "").trim();
+                                dto.setNombreUsuario(nombres);
+                                dto.setDocumentoUsuario(u.getNumDocumento() != null ? String.valueOf(u.getNumDocumento()) : null);
+                                dto.setCorreoUsuario(u.getEmail());
+                            });
+                    return dto;
+                })
                 .collect(Collectors.toList());
     }
 

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/prestamos/material-bibliografico/material-bibliografico.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/prestamos/material-bibliografico/material-bibliografico.ts
@@ -27,7 +27,12 @@ import { GrupoBiblioteca, BibliotecaResumen } from '../../../interfaces/material
 
 interface ReservaUsuario {
   codigoUsuario: string;
+  /** Apellidos y nombres del usuario */
   nombreUsuario: string;
+  /** Número de documento del usuario */
+  documentoUsuario?: string | null;
+  /** Correo electrónico del usuario */
+  correoUsuario?: string | null;
   tipoPrestamo: string | null;
   cantidad: number;
   detalles: DetalleBibliotecaDTO[];
@@ -55,8 +60,12 @@ interface ReservaUsuario {
 
                         </div>
                         <div class="flex flex-col grow basis-0 gap-2">
+                        <label for="tipo-busqueda" class="block text-sm font-medium">Buscar por</label>
+                        <p-select [(ngModel)]="campoBusqueda" [options]="opcionesBusqueda" optionLabel="label" optionValue="value" placeholder="Seleccionar" />
+                        </div>
+                        <div class="flex flex-col grow basis-0 gap-2">
                         <label for="palabra-clave" class="block text-sm font-medium">Palabra clave</label>
-                                <input [(ngModel)]="palabraClave"pInputText id="palabra-clave" type="text" placeholder="Palabra clave"/>
+                                <input [(ngModel)]="palabraClave" pInputText id="palabra-clave" type="text" placeholder="Palabra clave"/>
                         </div>
                         <div class="flex items-end">
             <button
@@ -215,6 +224,12 @@ export class PrestamoMaterialBibliografico implements OnInit {
     opcionFiltro: ClaseGeneral = new ClaseGeneral();
     palabra: any;
     palabraClave: string = "";
+    opcionesBusqueda = [
+      { label: 'Nombres', value: 'nombre' },
+      { label: 'N° Documento', value: 'documento' },
+      { label: 'Email', value: 'email' },
+    ];
+    campoBusqueda: string = 'nombre';
     expandedRows: { [key: string]: boolean } = {};
     reservadosDetalle: ReservaUsuario[] = [];
     grupos: GrupoBiblioteca[] = [];
@@ -344,11 +359,15 @@ private agruparPorBiblioteca(
 
     detalles.forEach(det => {
       const codigo = det.codigoUsuario ?? 'DESCONOCIDO';
-      const nombre = det.usuarioPrestamo ?? det.nombreUsuario ?? det.codigoUsuario ?? 'DESCONOCIDO';
+      const nombre = det.usuarioPrestamo ?? det.nombreUsuario ?? '';
+      const documento = det.documentoUsuario ?? null;
+      const correo = det.correoUsuario ?? null;
       if (!mapa.has(codigo)) {
         mapa.set(codigo, {
           codigoUsuario: codigo,
           nombreUsuario: nombre,
+          documentoUsuario: documento,
+          correoUsuario: correo,
           tipoPrestamo: det.tipoPrestamo ?? null,
           cantidad: 0,
           detalles: []
@@ -357,11 +376,15 @@ private agruparPorBiblioteca(
       const entry = mapa.get(codigo)!;
       entry.detalles.push(det);
       entry.cantidad = entry.detalles.length;
-      if (!entry.tipoPrestamo) {
-        entry.tipoPrestamo = det.tipoPrestamo ?? null;
-      }
-      if (!entry.nombreUsuario) {
+      entry.tipoPrestamo ??= det.tipoPrestamo ?? null;
+      if (!entry.nombreUsuario && nombre) {
         entry.nombreUsuario = nombre;
+      }
+      if (!entry.documentoUsuario && documento) {
+        entry.documentoUsuario = documento;
+      }
+      if (!entry.correoUsuario && correo) {
+        entry.correoUsuario = correo;
       }
     });
 
@@ -389,6 +412,7 @@ private agruparPorBiblioteca(
         this.palabraClave = "";  // Resetea el campo de búsqueda
         this.sedeFiltro = this.dataSede[0];
         this.tipoFiltro = this.dataTipo[0];
+        this.campoBusqueda = 'nombre';
         this.aplicarFiltros();
     }
 
@@ -409,15 +433,18 @@ private agruparPorBiblioteca(
     const filtrados = this.todosDetallesReservados.filter((det) => {
       const sedeOk = !sedeId || det.codigoSede === sedeId;
       const tipoOk = !tipoDesc || this.getTipoPrestamoDescripcion(det.tipoPrestamo) === tipoDesc;
-      const termOk =
-        !termino ||
-        [
-          det.usuarioPrestamo,
-          det.nombreUsuario,
-          det.codigoUsuario,
-          det.documentoUsuario,
-          det.correoUsuario,
-        ].some((v) => v?.toLowerCase().includes(termino));
+      const valorBusqueda = (() => {
+        switch (this.campoBusqueda) {
+          case 'documento':
+            return det.documentoUsuario;
+          case 'email':
+            return det.correoUsuario;
+          case 'nombre':
+          default:
+            return det.usuarioPrestamo ?? det.nombreUsuario;
+        }
+      })()?.toLowerCase() || '';
+      const termOk = !termino || valorBusqueda.includes(termino);
       return sedeOk && tipoOk && termOk;
     });
 


### PR DESCRIPTION
## Resumen
- Mapear nombre, documento y correo del usuario en los detalles de reserva.
- Consultar `UsuarioRepository` para completar datos del lector al listar reservas.

## Pruebas
- `mvn -q test` *(falló: Non-resolvable parent POM)*
- `npm test -- --watch=false --browsers=ChromeHeadless` *(falló: TS18003 No inputs were found in config file)*
- `npm run build` *(falló: TS1185 Merge conflict marker encountered)*

------
https://chatgpt.com/codex/tasks/task_e_68b7e11dd434832989a6fa400ccd4792