### PR TITLE
feat: añadir regularización de préstamos

### DIFF
--- a/Frontend/sakai-ng-master/src/app/biblioteca/interfaces/usuario.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/interfaces/usuario.ts
@@ -33,6 +33,8 @@ export class Usuario {
     codigo?: string;
     foto?: string;
     registrado?:number;
+    tipoUsuario?: string;
+    tipoUsuarioCodigo?: string;
     constructor(init?: Partial<Usuario>) {
         this.id = 0;
         this.rol=new ClaseGeneral();
@@ -58,6 +60,8 @@ export class Usuario {
         this.codigo='';
         this.foto='';
         this.registrado=0;
+        this.tipoUsuario='';
+        this.tipoUsuarioCodigo='';
         // Inicialización opcional si se pasa un objeto
         Object.assign(this, init);
     }

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/prestamos/material-bibliografico/material-bibliografico.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/prestamos/material-bibliografico/material-bibliografico.ts
@@ -157,6 +157,7 @@ interface ReservaUsuario {
                 <th>N.I</th>
                 <th>Fecha de reserva</th>
                 <th>Prestar</th>
+                <th>Regularizar</th>
                 <th>Cancelar</th>
             </tr>
         </ng-template>
@@ -169,6 +170,9 @@ interface ReservaUsuario {
                 <td>
                    <p-button icon="pi pi-check" rounded outlined (click)="prestar(bib)"pTooltip="Prestar" tooltipPosition="bottom"/>
 
+                </td>
+                <td>
+                <p-button icon="pi pi-refresh" rounded outlined (click)="regularizarPrestamo(bib)" pTooltip="Regularizar" tooltipPosition="bottom"/>
                 </td>
                 <td>
                 <p-button icon="pi pi-times" rounded outlined (click)="cancelar(bib)"pTooltip="Cancelar" tooltipPosition="bottom"/>
@@ -661,8 +665,8 @@ private agruparPorBiblioteca(
     // Si quisieras limpiar algo al colapsar, aquí va
   }
 
-  regularizarPrestamo() {
-    this.modalRegularizar.openModal();
+  regularizarPrestamo(detalle: DetalleBibliotecaDTO) {
+    this.modalRegularizar.openModal(detalle);
   }
 
 }

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/prestamos/material-bibliografico/modal-regularizar.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/prestamos/material-bibliografico/modal-regularizar.ts
@@ -1,9 +1,9 @@
-import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
-import { ConfirmationService, MenuItem, MessageService } from 'primeng/api';
+import { ConfirmationService, MessageService } from 'primeng/api';
 import { HttpErrorResponse } from '@angular/common/http';
-import { Table } from 'primeng/table';
-import { Menu } from 'primeng/menu';
+import { DetalleBibliotecaDTO } from '../../../interfaces/material-bibliografico/DetalleBibliotecaDTO';
+import { Usuario } from '../../../interfaces/usuario';
 import { InputValidation } from '../../../input-validation';
 import { GenericoService } from '../../../services/generico.service';
 import { MaterialBibliograficoService } from '../../../services/material-bibliografico.service';
@@ -21,7 +21,7 @@ import { TemplateModule } from '../../../template.module';
                             <p-tabpanels>
                                 <p-tabpanel value="0">
                                 <form [formGroup]="form">
-    
+    <h3 class="text-base font-semibold">Datos del usuario</h3>
     <div class="flex flex-col md:flex-row gap-x-4 gap-y-2">
                       <div class="flex flex-col gap-2 w-full">
                       <label for="tipoUsuario">Tipo de usuario</label>
@@ -32,9 +32,11 @@ import { TemplateModule } from '../../../template.module';
                       <div class="col-span-2 flex items-center gap-2">
                       <div class="col-span-2 flex items-center gap-2">
     <p-radiobutton id="option1" name="tipoBuscar" value="1" formControlName="tipoBuscar" />
-    <label for="option1">Código</label>
+    <label for="option1">N&deg; Documento</label>
     <p-radiobutton id="option2" name="tipoBuscar" value="2" formControlName="tipoBuscar" />
     <label for="option2">Apellidos y nombres</label>
+    <p-radiobutton id="option3" name="tipoBuscar" value="3" formControlName="tipoBuscar" />
+    <label for="option3">Email</label>
   </div>
                       </div>
 </div>
@@ -42,18 +44,18 @@ import { TemplateModule } from '../../../template.module';
                       <label for="especialidad">Buscar</label>
                       <div class="flex items-center gap-x-2">
                       <input pInputText id="palabra-clave" type="text" formControlName="palabraBuscar" class="w-full" />
-                      <button 
-      pButton 
-      type="button" 
-      class="p-button-rounded bg-red-500 text-white" 
-      icon="pi pi-search" 
-      (click)="buscar()" 
-      [disabled]="form.get('palabraBuscar')?.invalid"   
+                      <button
+      pButton
+      type="button"
+      class="p-button-rounded bg-red-500 text-white"
+      icon="pi pi-search"
+      (click)="buscar()"
+      [disabled]="form.get('palabraBuscar')?.invalid"
       pTooltip="Buscar">
     </button>
                       </div>
-                      
-                                
+
+
 </div>
     </div>
     <div class="flex flex-col md:flex-row gap-x-4 gap-y-2">
@@ -62,7 +64,8 @@ import { TemplateModule } from '../../../template.module';
     <p-select appendTo="body" id="usuario" formControlName="usuario" [options]="usuariosLista" optionLabel="descripcion" placeholder="Seleccionar" class="w-full"></p-select>
     <app-input-validation [form]="form" modelo="usuario" ver="usuario"></app-input-validation>
 </div>
-</div>
+    </div>
+    <h3 class="mt-4 text-base font-semibold">Detalle de pr&eacute;stamo</h3>
 <div class="flex flex-col md:flex-row gap-x-4 gap-y-2">
                       <div class="flex flex-col gap-2 w-full">
                       <label for="numeroIngreso">N&uacute;mero de ingreso</label>
@@ -79,7 +82,7 @@ import { TemplateModule } from '../../../template.module';
 <div class="flex flex-col md:flex-row gap-x-4 gap-y-2">
                       <div class="flex flex-col gap-2 w-full">
                       <label for="usuario">Fecha de prestamo</label>
-                      <p-datepicker 
+                      <p-datepicker
       appendTo="body"
       formControlName="fechaPrestamo"
       [ngClass]="'w-full'"
@@ -98,7 +101,7 @@ import { TemplateModule } from '../../../template.module';
 
 <div class="flex flex-col gap-2 w-full">
                       <label for="fechaDevolucion">Fecha de devoluci&oacute;n</label>
-                      <p-datepicker 
+                      <p-datepicker
       appendTo="body"
       formControlName="fechaDevolucion"
       [ngClass]="'w-full'"
@@ -120,7 +123,7 @@ import { TemplateModule } from '../../../template.module';
                                 </p-tabpanel>
                                 <p-tabpanel value="1">
                                 <form [formGroup]="formOtroUsuario">
-    
+    <h3 class="text-base font-semibold">Datos del usuario</h3>
     <div class="flex flex-col md:flex-row gap-x-4 gap-y-2">
                       <div class="flex flex-col gap-2 w-full">
                       <label for="tipoUsuario">Tipo de usuario</label>
@@ -135,18 +138,18 @@ import { TemplateModule } from '../../../template.module';
                       <label for="nummeroDocumento">Numero Documento</label>
                       <div class="flex items-center gap-x-2">
                       <input pInputText id="nummeroDocumento" type="text" formControlName="nummeroDocumento" class="w-full" />
-                      <button 
-      pButton 
-      type="button" 
-      class="p-button-rounded bg-red-500 text-white" 
-      icon="pi pi-search" 
-      (click)="buscar()" 
-      [disabled]="formOtroUsuario.get('nummeroDocumento')?.invalid"  
+                      <button
+      pButton
+      type="button"
+      class="p-button-rounded bg-red-500 text-white"
+      icon="pi pi-search"
+      (click)="buscar()"
+      [disabled]="formOtroUsuario.get('nummeroDocumento')?.invalid"
       pTooltip="Buscar">
     </button>
                       </div>
-                      
-                                
+
+
 </div>
     </div>
     <div class="flex flex-col md:flex-row gap-x-4 gap-y-2">
@@ -155,7 +158,8 @@ import { TemplateModule } from '../../../template.module';
                       <input pInputText id="nombreCompleto" type="text" formControlName="nombreCompleto" />
     <app-input-validation [form]="formOtroUsuario" modelo="nombreCompleto" ver="Nombre Completo"></app-input-validation>
 </div>
-</div>
+    </div>
+    <h3 class="mt-4 text-base font-semibold">Detalle de pr&eacute;stamo</h3>
 <div class="flex flex-col md:flex-row gap-x-4 gap-y-2">
                       <div class="flex flex-col gap-2 w-full">
                       <label for="numeroIngreso">N&uacute;mero de ingreso</label>
@@ -172,7 +176,7 @@ import { TemplateModule } from '../../../template.module';
 <div class="flex flex-col md:flex-row gap-x-4 gap-y-2">
                       <div class="flex flex-col gap-2 w-full">
                       <label for="usuario">Fecha de prestamo</label>
-                      <p-datepicker 
+                      <p-datepicker
       appendTo="body"
       formControlName="fechaPrestamo"
       [ngClass]="'w-full'"
@@ -190,17 +194,17 @@ import { TemplateModule } from '../../../template.module';
 </div>
 </div>
 <div class="flex flex-col md:flex-row gap-x-4 gap-y-2">
-   
+
     <div class="flex items-center space-x-3 py-2">
                             <p-checkbox id="checkDevolver" name="option" value="1" formControlName="devolver"/>
                             <label for="checkDevolver" class="ml-2">¿Desea devolver?</label>
                         </div>
-</div> 
+</div>
 <div class="flex flex-col md:flex-row gap-x-4 gap-y-2" *ngIf="formOtroUsuario.get('devolver')?.value.length>0">
 
 <div class="flex flex-col gap-2 w-full">
                       <label for="fechaDevolucion">Fecha de devoluci&oacute;n</label>
-                      <p-datepicker 
+                      <p-datepicker
       appendTo="body"
       formControlName="fechaDevolucion"
       [ngClass]="'w-full'"
@@ -238,13 +242,13 @@ export class ModalRegularizarComponent implements OnInit {
     form: FormGroup = new FormGroup({});
     formOtroUsuario: FormGroup = new FormGroup({});
     display: boolean = false;
-    items!: MenuItem[];
     uploadedFiles: any[] = [];
     tipoUsuarioLista: any[] = [];
     tipoDocumentoLista: any[] = [];
     usuariosLista: any[] = [];
     tipoMaterialLista: any[] = [];
     usuariosPRLista: any[] = [];
+    usuariosTodos: Usuario[] = [];
     objeto: any = null;
     radioValue: any = null;
     palabraClave: string = "";
@@ -263,6 +267,7 @@ export class ModalRegularizarComponent implements OnInit {
             usuarioPrestamo: ['', [Validators.required]],
             usuarioRecepcion: ['', [Validators.required]]
         });
+        this.form.get('tipoUsuario')?.valueChanges.subscribe(() => this.filtrarUsuarios());
         this.formOtroUsuario = this.fb.group({
             
             tipoUsuario: ['', [Validators.required]],
@@ -281,6 +286,7 @@ export class ModalRegularizarComponent implements OnInit {
     async ngOnInit() {
 
         await this.listarTiposDocumento();
+        await this.listarTiposUsuario();
     }
     
   async listarTiposDocumento() {
@@ -300,8 +306,46 @@ export class ModalRegularizarComponent implements OnInit {
         }
       );
   }
-    openModal() {
-        this.objeto = {};
+
+  async listarTiposUsuario() {
+    this.genericoService.roles_get('roles/lista-roles').subscribe({
+      next: (result: any) => {
+        if (result.status === '0') {
+          this.tipoUsuarioLista = result.data.map((rol: any) => ({
+            id: rol.idRol ?? rol.id ?? rol.codigo,
+            descripcion: rol.descripcion
+          }));
+        } else {
+          this.tipoUsuarioLista = [];
+        }
+      },
+      error: () => {
+        this.tipoUsuarioLista = [];
+      }
+    });
+  }
+    openModal(detalle: DetalleBibliotecaDTO) {
+        this.objeto = detalle;
+        if (detalle) {
+            const fechaPrestamo = detalle.fechaReserva ? new Date(detalle.fechaReserva) : null;
+            const fechaDevolucion = fechaPrestamo
+                ? new Date(fechaPrestamo.getTime() + 7 * 24 * 60 * 60 * 1000)
+                : null;
+            if (detalle.tipoMaterial) {
+                this.tipoMaterialLista = [detalle.tipoMaterial];
+            }
+            if (detalle.usuarioPrestamo) {
+                this.usuariosPRLista = [{ descripcion: detalle.usuarioPrestamo }];
+            }
+            this.form.patchValue({
+                numeroIngreso: detalle.numeroIngreso ?? '',
+                tipoMaterial: detalle.tipoMaterial ?? null,
+                fechaPrestamo,
+                fechaDevolucion,
+                usuarioPrestamo: detalle.usuarioPrestamo ? { descripcion: detalle.usuarioPrestamo } : null
+            });
+        }
+        this.cargarUsuarios(detalle?.codigoUsuario ?? '');
         this.display = true;
     }
 
@@ -312,6 +356,66 @@ export class ModalRegularizarComponent implements OnInit {
         this.loading = false;
         this.display = false;
     }
-    buscar() { }
+    buscar() {
+        this.filtrarUsuarios();
+    }
+
+    private cargarUsuarios(codigoSeleccionado: string) {
+        this.loading = true;
+        this.materialBibliograficoService.listarUsuarios().subscribe({
+            next: (usuarios: Usuario[]) => {
+                this.loading = false;
+                this.usuariosTodos = usuarios;
+                let tipoInicial = this.tipoUsuarioLista[0];
+                if (codigoSeleccionado) {
+                    const uSel = usuarios.find(
+                        u => u.codigo === codigoSeleccionado || u.login === codigoSeleccionado
+                    );
+                    if (uSel) {
+                        tipoInicial = this.tipoUsuarioLista.find(t => t.descripcion === uSel.tipoUsuario) || tipoInicial;
+                    }
+                }
+                if (tipoInicial) {
+                    this.form.get('tipoUsuario')?.setValue(tipoInicial);
+                    this.filtrarUsuarios(codigoSeleccionado);
+                }
+            },
+            error: () => {
+                this.loading = false;
+            }
+        });
+    }
+
+    private filtrarUsuarios(codigoSeleccionado: string = '') {
+        const tipoId = String(this.form.get('tipoUsuario')?.value?.id ?? '');
+        const termino = (this.form.get('palabraBuscar')?.value || '').toLowerCase();
+        const tipoBuscar = this.form.get('tipoBuscar')?.value;
+        let lista = this.usuariosTodos.filter(u => String(u.tipoUsuarioCodigo ?? '') === tipoId);
+        if (termino) {
+            lista = lista.filter(u => {
+                const documento = (u.numeroDocumento || u.numerodocumento || u.login || '').toLowerCase();
+                const nombre = `${u.nombres ?? ''} ${u.apellidoPaterno ?? ''} ${u.apellidoMaterno ?? ''}`.toLowerCase();
+                const correo = (u.email || '').toLowerCase();
+                switch (tipoBuscar) {
+                    case 1: return documento.includes(termino);
+                    case 2: return nombre.includes(termino);
+                    case 3: return correo.includes(termino);
+                    default: return false;
+                }
+            });
+        }
+        this.usuariosLista = lista.map(u => ({
+            descripcion: `${u.nombres ?? ''} ${u.apellidoPaterno ?? ''} ${u.apellidoMaterno ?? ''}`.trim() || u.email || u.login || u.codigo,
+            codigoUsuario: u.codigo ?? u.login ?? ''
+        }));
+        if (codigoSeleccionado) {
+            const u = this.usuariosLista.find(us => us.codigoUsuario === codigoSeleccionado);
+            if (u) {
+                this.form.get('usuario')?.setValue(u);
+            }
+        } else {
+            this.form.get('usuario')?.setValue(null);
+        }
+    }
 
 }

--- a/Frontend/sakai-ng-master/src/app/biblioteca/services/material-bibliografico.service.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/services/material-bibliografico.service.ts
@@ -563,7 +563,38 @@ crearOcurrencia(dto: OcurrenciaDTO): Observable<OcurrenciaDTO> {
           `${this.apiUrl}/api/prestamos/usuarios`,
           { headers: this.headers, params }
         )
-        .pipe(map(resp => resp.data));
+        .pipe(
+          map(resp => {
+            const tipoMap: Record<string, string> = {
+              '1': 'Administrador',
+              '2': 'Ejecutivo',
+              '3': 'Usuario',
+              '4': 'Otro'
+            };
+            return resp.data.map(u => {
+              const rawObj = (u as any).tipoUsuario ?? (u as any).rol;
+              let codigo: string;
+              let descRaw: any;
+              if (rawObj && typeof rawObj === 'object') {
+                codigo = String(
+                  rawObj.idRol ?? rawObj.id ?? rawObj.codigo ??
+                  (u as any).tipo ?? (u as any).tipoUsuarioCodigo ?? ''
+                );
+                descRaw = rawObj.descripcion ?? rawObj.nombre ?? rawObj;
+              } else {
+                codigo = String(
+                  rawObj ?? (u as any).tipo ?? (u as any).tipoUsuarioCodigo ?? ''
+                );
+                descRaw = rawObj;
+              }
+              return {
+                ...u,
+                tipoUsuario: tipoMap[codigo] ?? String(descRaw ?? ''),
+                tipoUsuarioCodigo: codigo
+              } as Usuario;
+            });
+          })
+        );
     }
 
     /** Lista equipos; si pasas `search` filtra por id, nombre o ip */


### PR DESCRIPTION
## Summary
- agregar columna y botón de regularización en cada ejemplar prestado
- precargar y permitir búsqueda de usuarios en el modal de regularización
- eliminar uso innecesario de MenuItem que impedía la compilación
- separar en el modal las secciones de datos del usuario y detalle de préstamo
- filtrar lista de usuarios según el tipo seleccionado en la regularización
- usar `tipoUsuario` en lugar de `tipo` y añadir el campo al modelo `Usuario`
- mapear `tipo` a `tipoUsuario` al listar usuarios para poblar los combos de tipos
- asegurar que los tipos de usuario se conviertan a cadena y no se descarten valores como 0
- mapear la descripción del tipo de usuario cuando el backend devuelve un objeto
- obtener el catálogo de roles desde el backend y usarlo para poblar el combo de tipos de usuario
- corregir el endpoint para listar roles a `roles/lista-roles` evitando respuestas 403
- filtrar usuarios por tipo incluso cuando el backend devuelve códigos primitivos
- considerar propiedades `rol` e `idRol` al mapear usuarios para poblar combos dependientes

## Testing
- `npm run build` (falla: TS1185 merge conflict markers en roles-lista.ts, app.menu.ts, etc.)
- `npm test -- --watch=false --browsers=ChromeHeadless` (falla: TS18003 No inputs were found en tsconfig.spec.json)


------
https://chatgpt.com/codex/tasks/task_e_68b8b8c19efc8329aeb494b2f342903f