### PR TITLE
feat: autocompletar nombre de usuario por documento

### DIFF
--- a/Frontend/sakai-ng-master/src/app/biblioteca/configuracion/tipo-documento/tipo-documento.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/configuracion/tipo-documento/tipo-documento.ts
@@ -24,7 +24,7 @@ export class TipoDocumento {
     loading: boolean = true;
     constructor(private genericoService: GenericoService) { }
     ngOnInit() {
-      this.genericoService.tipodocumento_get(this.modulo+'/lista')
+      this.genericoService.tipodocumento_get('lista-activo')
       .subscribe(
         (result: any) => {
           this.loading=false;

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/prestamos/biblioteca-virtual/modal-regularizar.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/prestamos/biblioteca-virtual/modal-regularizar.ts
@@ -288,7 +288,7 @@ export class ModalRegularizarComponent implements OnInit {
   async listarTiposDocumento() {
     this.loading = true;
     this.tipoDocumentoLista = [];
-    this.genericoService.tipodocumento_get('')
+    this.genericoService.tipodocumento_get('lista-activo')
       .subscribe(
         (result: any) => {
           this.loading = false;

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/prestamos/material-bibliografico/modal-regularizar.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/prestamos/material-bibliografico/modal-regularizar.ts
@@ -131,7 +131,7 @@ import { TemplateModule } from '../../../template.module';
     <app-input-validation [form]="formOtroUsuario" modelo="tipoUsuario" ver="Tipo Usuario"></app-input-validation>
 </div><div class="flex flex-col gap-2 w-full">
                       <label for="tipoDocumento">Tipo de documento</label>
-    <p-select appendTo="body" id="tipoDocumento" formControlName="tipoDocumento" [options]="tipoDocumentoLista" optionLabel="descripcion" placeholder="Seleccionar" class="w-full"></p-select>
+    <p-select appendTo="body" id="tipoDocumento" formControlName="tipoDocumento" [options]="tipoDocumentoLista" optionLabel="descripcion" optionValue="codigo" placeholder="Seleccionar" class="w-full"></p-select>
     <app-input-validation [form]="formOtroUsuario" modelo="tipoDocumento" ver="Tipo Documento"></app-input-validation>
 </div>
 <div class="flex flex-col gap-2 w-full">
@@ -306,17 +306,22 @@ export class ModalRegularizarComponent implements OnInit {
   async listarTiposDocumento() {
     this.loading = true;
     this.tipoDocumentoLista = [];
-    this.genericoService.tipodocumento_get('')
+    this.genericoService.tipodocumento_get('lista-activo')
       .subscribe(
         (result: any) => {
           this.loading = false;
           if (result.status == "0") {
             this.tipoDocumentoLista = result.data;
-            this.formOtroUsuario.get('tipoDocumento')?.setValue(this.tipoDocumentoLista[0]);
+            this.formOtroUsuario.get('tipoDocumento')?.setValue(this.tipoDocumentoLista[0]?.codigo);
           }
         }
         , (error: HttpErrorResponse) => {
           this.loading = false;
+          this.messageService.add({
+            severity: 'error',
+            summary: 'Error',
+            detail: 'No se pudo obtener los tipos de documento'
+          });
         }
       );
   }
@@ -396,7 +401,36 @@ export class ModalRegularizarComponent implements OnInit {
         });
     }
     buscar() {
-        this.filtrarUsuarios();
+        if (this.activeTab === '0') {
+            this.filtrarUsuarios();
+        } else {
+            this.buscarPorDocumento();
+        }
+    }
+
+    private buscarPorDocumento() {
+        const tipo = this.formOtroUsuario.get('tipoDocumento')?.value;
+        const numero = (this.formOtroUsuario.get('nummeroDocumento')?.value || '').trim();
+        if (!tipo || !numero) {
+            return;
+        }
+        this.loading = true;
+        this.genericoService.consultarDocumento(tipo, numero).subscribe({
+            next: (resp: any) => {
+                this.loading = false;
+                const data = resp?.SJB_CONSULTA_DNI_RESP;
+                if (data && data.CodigoRespuesta === 1) {
+                    const nombre = data.NombreCompleto || `${data.Nombres || ''} ${data.ApellidoPaterno || ''} ${data.ApellidoMaterno || ''}`.trim();
+                    this.formOtroUsuario.get('nombreCompleto')?.setValue(nombre);
+                } else {
+                    this.formOtroUsuario.get('nombreCompleto')?.setValue('');
+                }
+            },
+            error: () => {
+                this.loading = false;
+                this.formOtroUsuario.get('nombreCompleto')?.setValue('');
+            }
+        });
     }
 
     private cargarUsuarios(codigoSeleccionado: string) {

--- a/Frontend/sakai-ng-master/src/app/biblioteca/services/generico.service.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/services/generico.service.ts
@@ -74,10 +74,21 @@ export class GenericoService {
     return this.http.get<any[]>(`${this.apiUrl}/${modulo}`, options);
   }
 
-  tipodocumento_get(modulo: any): Observable<any> {
-    return this.http.get<any[]>(`${this.apiUrl}/${modulo}`,
-      { headers: this.authHeaders() }
-    );
+  tipodocumento_get(modulo: string): Observable<any> {
+    const token = this.authService.getToken();
+    const options = token
+      ? { headers: new HttpHeaders().set('Authorization', `Bearer ${token}`) }
+      : {};
+    return this.http.get<any[]>(`${this.apiUrl}/${modulo}`, options);
+  }
+
+  consultarDocumento(tipo: string, numero: string): Observable<any> {
+    const token = this.authService.getToken();
+    const options = token
+      ? { headers: new HttpHeaders().set('Authorization', `Bearer ${token}`) }
+      : {};
+    const url = `${this.apiUrl}/api/documento/consultar/${tipo}/${numero}`;
+    return this.http.get<any>(url, options);
   }
 
   tipo_get(modulo: any): Observable<any> {


### PR DESCRIPTION
## Summary
- usa el endpoint `lista-activo` para obtener los tipos de documento existentes
- autocompleta el nombre del usuario al consultar por tipo y número de documento
- maneja la carga de tipos de documento sin token para evitar 403
- consulta de documento redirigida al backend para evitar CORS y usar el código seleccionado
- corrige la ruta de tipos de documento en el servicio genérico para evitar errores en el combo

## Testing
- `npm test --silent -- --watch=false` *(falla: TS18003 No inputs were found)*
- `npm run build` *(sin salida, posible limitación del entorno)*

------
https://chatgpt.com/codex/tasks/task_e_68b9b42bc8d88329a48fe6106be27422