### PR TITLE
Filtrar horarios por sede en portal

### DIFF
--- a/Backend/login-microsoft365/src/main/java/com/miapp/controller/HorarioController.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/controller/HorarioController.java
@@ -20,8 +20,8 @@
         private final HorarioRepository repo;
 
         @GetMapping("/listar")
-        public ResponseDTO<List<HorarioDTO>> listar() {
-            List<HorarioDTO> list = srv.listar();   // <— aquí toma el List<HorarioDTO>
+        public ResponseDTO<List<HorarioDTO>> listar(@RequestParam(value = "sedeId", required = false) Long sedeId) {
+            List<HorarioDTO> list = srv.listar(sedeId);
             return new ResponseDTO<>(0, "OK", list);
         }
 

--- a/Backend/login-microsoft365/src/main/java/com/miapp/repository/HorarioRepository.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/repository/HorarioRepository.java
@@ -9,5 +9,6 @@ import java.util.List;
 public interface HorarioRepository extends JpaRepository<Horario, Long> {
     // para filtrar si algún día lo necesitas
     List<Horario> findByFechaCreacionBetween(LocalDateTime start, LocalDateTime end);
+    List<Horario> findBySedeId(Long sedeId);
 }
 

--- a/Backend/login-microsoft365/src/main/java/com/miapp/service/HorarioService.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/service/HorarioService.java
@@ -23,8 +23,11 @@ public class HorarioService {
     private final SedeRepository sedeRepo;
     private final EstadoRepository estadoRepo;
 
-    public List<HorarioDTO> listar() {
-        return repo.findAll()
+    public List<HorarioDTO> listar(Long sedeId) {
+        List<Horario> horarios = (sedeId != null && sedeId > 0)
+                ? repo.findBySedeId(sedeId)
+                : repo.findAll();
+        return horarios
                 .stream()
                 .map(this::toDto)
                 .collect(Collectors.toList());

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/portal/horarios.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/portal/horarios.ts
@@ -216,7 +216,9 @@ export class HorariosComponent implements OnInit {
         if (res.status === 0) {
           const sedes = (res.data as Sedes[]).filter(s => s.id !== 0);
           this.dataSede = sedes;
-          this.dataSedesFiltro = sedes;
+          const todas = new Sedes({ id: 0, descripcion: 'Todas las sedes' });
+          this.dataSedesFiltro = [todas, ...sedes];
+          this.sedeFiltro = todas;
         }
       }
         formValidar(){
@@ -360,7 +362,8 @@ export class HorariosComponent implements OnInit {
   }
       listar() {
         this.loading = true;
-        this.portalService.listarHorarios()
+        const sedeId = this.sedeFiltro?.id;
+        this.portalService.listarHorarios(sedeId && sedeId > 0 ? sedeId : undefined)
           .subscribe({
             next: res => {
               if (res.p_status === 0) {

--- a/Frontend/sakai-ng-master/src/app/biblioteca/services/portal.service.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/services/portal.service.ts
@@ -139,9 +139,10 @@ export class PortalService {
         );
       }
 
-listarHorarios(): Observable<{ p_status: number; message: string; data: PortalHorario[] }> {
+listarHorarios(sedeId?: number): Observable<{ p_status: number; message: string; data: PortalHorario[] }> {
+  const params = sedeId && sedeId > 0 ? `?sedeId=${sedeId}` : '';
   return this.http.get<{ p_status: number; message: string; data: PortalHorario[] }>(
-    `${this.apiUrl}/api/horarios/listar`,
+    `${this.apiUrl}/api/horarios/listar${params}`,
     { headers: this.authHeaders() }
   );
 }


### PR DESCRIPTION
## Resumen
- Permitir que el backend reciba un `sedeId` opcional para listar horarios filtrados por sede
- Ajustar el servicio Angular para enviar el parámetro de sede
- Usar la sede seleccionada en el componente de horarios al obtener la lista
- Añadir opción **Todas las sedes** para mostrar todos los horarios cuando no se aplica filtro

## Pruebas
- `npm test -- --watch=false --browsers=ChromeHeadless` *(falla: No inputs were found in config file 'tsconfig.spec.json')*
- `mvn -q test` *(falla: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f843e88483298d3946d396a3aa88