### PR TITLE
feat: permitir regularización manual de préstamos

### DIFF
--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/prestamos/material-bibliografico/material-bibliografico.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/prestamos/material-bibliografico/material-bibliografico.ts
@@ -104,7 +104,7 @@ interface ReservaUsuario {
                        <div class="flex items-center justify-between">
                <div class="flex gap-2">
                    <p-button [outlined]="true" icon="pi pi-filter-slash" label="Limpiar" (click)="clear(dt1)" />
-                   <p-button icon="pi pi-refresh" label="Regularizar" (click)="regularizarSeleccionado()" [disabled]="!detalleSeleccionado" />
+                   <p-button icon="pi pi-refresh" label="Regularizar" (click)="regularizarPrestamo()" />
                </div>
 
                <p-iconfield>
@@ -620,12 +620,6 @@ private agruparPorBiblioteca(
     });
   }
 
-  regularizarSeleccionado() {
-    if (this.detalleSeleccionado) {
-      this.regularizarPrestamo(this.detalleSeleccionado);
-    }
-  }
-
     cancelar(detalle: DetalleBibliotecaDTO) {
       this.confirmationService.confirm({
         message: '¿Estás seguro(a) de cancelar la reserva del ejemplar?',
@@ -674,7 +668,7 @@ private agruparPorBiblioteca(
     // Si quisieras limpiar algo al colapsar, aquí va
   }
 
-  regularizarPrestamo(detalle: DetalleBibliotecaDTO) {
+  regularizarPrestamo(detalle: DetalleBibliotecaDTO | null = null) {
     this.modalRegularizar.openModal(detalle);
   }
 

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/prestamos/material-bibliografico/modal-regularizar.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/prestamos/material-bibliografico/modal-regularizar.ts
@@ -344,8 +344,10 @@ export class ModalRegularizarComponent implements OnInit {
       }
     });
   }
-    openModal(detalle: DetalleBibliotecaDTO) {
+    openModal(detalle: DetalleBibliotecaDTO | null = null) {
         this.objeto = detalle;
+        this.form.reset({ tipoBuscar: 1 });
+        this.formOtroUsuario.reset({ devolver: false });
         if (detalle) {
             const fechaPrestamo = detalle.fechaReserva ? new Date(detalle.fechaReserva) : null;
             const fechaDevolucion = fechaPrestamo


### PR DESCRIPTION
## Summary
- Habilitar la regularización manual sin selección previa
- Inicializar formularios al abrir el modal de regularización

## Testing
- `npm test` (falla: No inputs were found in config file)

------
https://chatgpt.com/codex/tasks/task_e_68bb14d1cea08329add3192ace5ba965