### PR TITLE
Generación automática del número de ingreso

### DIFF
--- a/Backend/login-microsoft365/src/main/java/com/miapp/mapper/BibliotecaMapper.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/mapper/BibliotecaMapper.java
@@ -141,6 +141,7 @@ public class BibliotecaMapper {
         dto.setNotaResumen(b.getNotaResumen());
         dto.setLinkPublicacion(b.getLinkPublicacion());
         dto.setNumeroPaginas(b.getNumeroPaginas());
+        dto.setNumeroDeIngreso(b.getNumeroDeIngreso());
         dto.setFechaIngreso(b.getFechaIngreso());
         dto.setCosto(b.getCosto());
         dto.setNumeroFactura(b.getNumeroFactura());

--- a/Backend/login-microsoft365/src/main/java/com/miapp/model/DetalleBiblioteca.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/model/DetalleBiblioteca.java
@@ -54,7 +54,7 @@ public class DetalleBiblioteca {
     @Column(name = "CODIGOBARRA", insertable = false, updatable = false)
     private String codigoBarra;
 
-    @Column(name = "NUMEROINGRESO", insertable = false, updatable = false)
+    @Column(name = "NUMEROINGRESO")
     private Long numeroIngreso;
 
     @Column(name = "NROEXISTENCIA", insertable = false, updatable = false)

--- a/Backend/login-microsoft365/src/main/java/com/miapp/model/dto/BibliotecaDTO.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/model/dto/BibliotecaDTO.java
@@ -68,6 +68,7 @@ public class BibliotecaDTO {
     private String linkPublicacion;
     private Integer numeroPaginas;
     // numeroDeIngreso lo genera la secuencia en BD, no va en el DTO de entrada
+    private Long numeroDeIngreso;
     private Long sedeId;
     private Long tipoAdquisicionId;
     private LocalDateTime fechaIngreso;

--- a/Backend/login-microsoft365/src/main/java/com/miapp/repository/BibliotecaRepository.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/repository/BibliotecaRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import org.springframework.data.jpa.domain.Specification;
 
@@ -26,4 +27,9 @@ public interface BibliotecaRepository
             "especialidad", "pais", "ciudad", "tipoMaterial"
     })
     Page<Biblioteca> findAll(Specification<Biblioteca> spec, Pageable pageable);
+
+    @Query("SELECT COALESCE(MAX(b.numeroDeIngreso),0) FROM Biblioteca b")
+    Long findMaxNumeroDeIngreso();
+
+    boolean existsByNumeroDeIngreso(Long numeroDeIngreso);
 }

--- a/Backend/login-microsoft365/src/main/java/com/miapp/service/impl/BibliotecaServiceImpl.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/service/impl/BibliotecaServiceImpl.java
@@ -85,6 +85,16 @@ public class BibliotecaServiceImpl implements BibliotecaService {
     public Biblioteca register(BibliotecaDTO dto, MultipartFile portada) {
         // 1) Mapea principal
         Biblioteca bib = mapToEntity(dto);
+
+        Long numeroIngreso = generarNumeroIngreso();
+        bib.setNumeroDeIngreso(numeroIngreso);
+        if (bib.getDetalles() != null) {
+            bib.getDetalles().forEach(d -> {
+                if (d.getNumeroIngreso() == null) {
+                    d.setNumeroIngreso(numeroIngreso);
+                }
+            });
+        }
         if (portada != null && !portada.isEmpty()) {
             String filename = fileStorageService.store(portada);
             bib.setNombreImagen(filename);
@@ -102,6 +112,14 @@ public class BibliotecaServiceImpl implements BibliotecaService {
         // Volvemos a mapearlo por completo (incluyendo detalles)
         Biblioteca bib = mapToEntity(dto);
         bib.setId(id);
+        bib.setNumeroDeIngreso(existente.getNumeroDeIngreso());
+        if (bib.getDetalles() != null) {
+            bib.getDetalles().forEach(d -> {
+                if (d.getNumeroIngreso() == null) {
+                    d.setNumeroIngreso(existente.getNumeroDeIngreso());
+                }
+            });
+        }
         if (portada != null && !portada.isEmpty()) {
             String filename = fileStorageService.store(portada);
             bib.setNombreImagen(filename);
@@ -397,6 +415,15 @@ public class BibliotecaServiceImpl implements BibliotecaService {
                 .stream()
                 .map(mapper::toDetalleDto)
                 .toList();
+    }
+
+    private Long generarNumeroIngreso() {
+        Long max = bibliotecaRepository.findMaxNumeroDeIngreso();
+        long next = (max != null ? max : 0L) + 1L;
+        while (bibliotecaRepository.existsByNumeroDeIngreso(next)) {
+            next++;
+        }
+        return next;
     }
 
     @Transactional


### PR DESCRIPTION
## Resumen
- Generación secuencial del número de ingreso para nuevos materiales y sus detalles.
- Nuevo campo de número de ingreso en DTO y repositorio con utilidades para obtener el máximo.
- Ajustes en mapeos y entidades para permitir guardar el número de ingreso.

## Testing
- `mvn -q test` *(falla: Non-resolvable parent POM... network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bb2f06d368832989400d4927bd6e22