### PR TITLE
Regularizar préstamos por número de ingreso

### DIFF
--- a/Backend/login-microsoft365/src/main/java/com/miapp/controller/BibliotecaController.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/controller/BibliotecaController.java
@@ -232,6 +232,14 @@ public class BibliotecaController {
                 : ResponseEntity.notFound().build();
     }
 
+    @GetMapping("/detalles/numero-ingreso/{numero}")
+    public ResponseEntity<DetalleBibliotecaDTO> getDetalleByNumeroIngreso(@PathVariable("numero") Long numeroIngreso) {
+        DetalleBibliotecaDTO dto = detalleService.findByNumeroIngreso(numeroIngreso);
+        return dto != null
+                ? ResponseEntity.ok(dto)
+                : ResponseEntity.notFound().build();
+    }
+
     /** Endpoint para obtener todos los detalles reservados (con su “biblioteca” anidada) */
     @GetMapping("/detalles-reservados")
     public ResponseEntity<Map<String, Object>> getDetallesReservados() {

--- a/Backend/login-microsoft365/src/main/java/com/miapp/mapper/BibliotecaMapper.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/mapper/BibliotecaMapper.java
@@ -389,6 +389,8 @@ public class BibliotecaMapper {
                     .ifPresent(e -> tmp.setEstadoDescripcion(e.getDescripcion()));
         }
         tmp.setCantidadPrestamos(d.getCantidadPrestamos());
+        tmp.setFechaPrestamo(d.getFechaPrestamo());
+        tmp.setFechaDevolucion(d.getFechaFin());
         tmp.setFechaReserva(d.getFechaSolicitud());
 
         return tmp;

--- a/Backend/login-microsoft365/src/main/java/com/miapp/model/dto/DetalleBibliotecaDTO.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/model/dto/DetalleBibliotecaDTO.java
@@ -108,6 +108,12 @@ public class DetalleBibliotecaDTO {
     /** Correo electrónico del usuario */
     private String correoUsuario;
 
+    /** Fecha en la que se prestó el material */
+    private LocalDateTime fechaPrestamo;
+
+    /** Fecha de devolución del material */
+    private LocalDateTime fechaDevolucion;
+
     /** Fecha de la reserva */
     private String fechaReserva;
 }

--- a/Backend/login-microsoft365/src/main/java/com/miapp/repository/DetalleBibliotecaRepository.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/repository/DetalleBibliotecaRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface DetalleBibliotecaRepository extends JpaRepository<DetalleBiblioteca, Long> {
     // devuelve todos los detalles de una biblioteca
@@ -29,4 +30,11 @@ public interface DetalleBibliotecaRepository extends JpaRepository<DetalleBiblio
             "     JOIN FETCH d.biblioteca b " +
             "WHERE d.idEstado = 3")
     List<DetalleBiblioteca> findAllConBibliotecaReservados();
+
+    /**
+     * Retorna el primer detalle que coincida con el número de ingreso indicado.
+     * Se usa {@code findFirst} para evitar excepciones cuando existan múltiples
+     * registros con el mismo número.
+     */
+    Optional<DetalleBiblioteca> findFirstByNumeroIngreso(Long numeroIngreso);
 }

--- a/Backend/login-microsoft365/src/main/java/com/miapp/service/DetalleBibliotecaService.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/service/DetalleBibliotecaService.java
@@ -117,4 +117,11 @@ public class DetalleBibliotecaService {
                 .map(mapper::toDetalleDto)
                 .orElse(null);
     }
+
+    /** Obtiene un detalle por número de ingreso y lo mapea a DTO */
+    public DetalleBibliotecaDTO findByNumeroIngreso(Long numeroIngreso) {
+        return detalleBibliotecaRepository.findFirstByNumeroIngreso(numeroIngreso)
+                .map(mapper::toDetalleDto)
+                .orElse(null);
+    }
 }

--- a/Backend/login-microsoft365/src/main/java/com/miapp/service/PrestamoService.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/service/PrestamoService.java
@@ -241,8 +241,8 @@ public class PrestamoService {
     }
 
     public DetalleBibliotecaDTO regularizarPrestamo(Map<String, Object> datos, String usuario) {
-        Long id = Long.valueOf(String.valueOf(datos.get("idDetalleBiblioteca")));
-        DetalleBiblioteca det = detalleBibliotecaRepository.findById(id)
+        Long numeroIngreso = Long.valueOf(String.valueOf(datos.get("numeroIngreso")));
+        DetalleBiblioteca det = detalleBibliotecaRepository.findFirstByNumeroIngreso(numeroIngreso)
                 .orElseThrow(() -> new RuntimeException("Detalle no encontrado"));
 
         if (datos.get("usuarioPrestamo") instanceof Map<?, ?> up) {
@@ -255,11 +255,20 @@ public class PrestamoService {
                 det.setCodigoUsuario(cod.toString());
             }
         }
-        if (datos.get("fechaPrestamo") != null) {
-            det.setFechaPrestamo(OffsetDateTime.parse(datos.get("fechaPrestamo").toString()).toLocalDateTime());
+        Object fechaPrestamoObj = datos.get("fechaPrestamo");
+        LocalDateTime fechaPrestamo = null;
+        if (fechaPrestamoObj instanceof String fpStr && !fpStr.isBlank()) {
+            fechaPrestamo = OffsetDateTime.parse(fpStr).toLocalDateTime();
         }
-        if (datos.get("fechaDevolucion") != null) {
-            det.setFechaFin(OffsetDateTime.parse(datos.get("fechaDevolucion").toString()).toLocalDateTime());
+        if (fechaPrestamo == null) {
+            fechaPrestamo = LocalDateTime.now();
+        }
+        det.setFechaPrestamo(fechaPrestamo);
+        det.setFechaInicio(fechaPrestamo);
+
+        Object fechaDevolucionObj = datos.get("fechaDevolucion");
+        if (fechaDevolucionObj instanceof String fdStr && !fdStr.isBlank()) {
+            det.setFechaFin(OffsetDateTime.parse(fdStr).toLocalDateTime());
         }
         det.setUsuarioModificacion(usuario);
 

--- a/Frontend/sakai-ng-master/src/app/biblioteca/interfaces/material-bibliografico/biblioteca.model.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/interfaces/material-bibliografico/biblioteca.model.ts
@@ -124,6 +124,8 @@ export interface DetalleBibliotecaDTO {
     /** Tipo de préstamo de la reserva */
     tipoPrestamo?: string | null;
     /** Fecha de la reserva */
+    fechaPrestamo?: string | null;
+    fechaDevolucion?: string | null;
     fechaReserva?: string | null;
     /** Detalle puede venir anidado con datos de la biblioteca */
     biblioteca?: BibliotecaDTO;

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/devoluciones/material-bibliografico/material-bibliografico.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/devoluciones/material-bibliografico/material-bibliografico.ts
@@ -155,7 +155,7 @@ interface PrestamoUsuario {
                 <td>{{ bib.biblioteca?.titulo || '-' }}</td>
                 <td>{{ bib.biblioteca?.id }}</td>
                 <td>{{ bib.numeroIngreso }}</td>
-                <td>{{ bib.fechaReserva | date:'dd-MM-yyyy' }}</td>
+                <td>{{ bib.fechaPrestamo | date:'dd-MM-yyyy' }}</td>
                 <td>
                 <p-button icon="pi pi-check" rounded outlined (click)="devolver(bib)" pTooltip="Devolver" tooltipPosition="bottom"/>
                 </td>

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/prestamos/material-bibliografico/modal-regularizar.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/prestamos/material-bibliografico/modal-regularizar.ts
@@ -383,7 +383,7 @@ export class ModalRegularizarComponent implements OnInit {
             this.objeto = null;
             return;
         }
-        this.materialBibliograficoService.getDetalleBiblioteca(numero).subscribe({
+        this.materialBibliograficoService.getDetalleBibliotecaPorNumeroIngreso(numero).subscribe({
             next: (detalle: DetalleBibliotecaDTO) => {
                 this.objeto = detalle;
                 if (detalle?.tipoMaterial) {
@@ -393,6 +393,10 @@ export class ModalRegularizarComponent implements OnInit {
                     this.tipoMaterialLista = [];
                     destino.get('tipoMaterial')?.setValue(null);
                 }
+                destino.patchValue({
+                    fechaPrestamo: detalle.fechaPrestamo ? new Date(detalle.fechaPrestamo) : null,
+                    fechaDevolucion: detalle.fechaDevolucion ? new Date(detalle.fechaDevolucion) : null
+                }, { emitEvent: false });
             },
             error: () => {
                 this.tipoMaterialLista = [];
@@ -411,10 +415,12 @@ export class ModalRegularizarComponent implements OnInit {
         this.form.reset({ tipoBuscar: 1 });
         this.formOtroUsuario.reset({ devolver: false });
         if (detalle) {
-            const fechaPrestamo = detalle.fechaReserva ? new Date(detalle.fechaReserva) : null;
-            const fechaDevolucion = fechaPrestamo
-                ? new Date(fechaPrestamo.getTime() + 7 * 24 * 60 * 60 * 1000)
-                : null;
+            const fechaPrestamo = detalle.fechaPrestamo ? new Date(detalle.fechaPrestamo) : null;
+            const fechaDevolucion = detalle.fechaDevolucion
+                ? new Date(detalle.fechaDevolucion)
+                : (fechaPrestamo
+                    ? new Date(fechaPrestamo.getTime() + 7 * 24 * 60 * 60 * 1000)
+                    : null);
             if (detalle.tipoMaterial) {
                 this.tipoMaterialLista = [detalle.tipoMaterial];
             }
@@ -449,8 +455,12 @@ export class ModalRegularizarComponent implements OnInit {
                 ...datosRaw,
                 tipoDocumento: this.obtenerCodigoDocumento(datosRaw.tipoDocumento)
             };
-        const id = this.objeto?.idDetalleBiblioteca;
-        const payload = { ...datos, idDetalleBiblioteca: id };
+        const payload = {
+            ...datos,
+            numeroIngreso: Number(datos.numeroIngreso),
+            fechaPrestamo: datos.fechaPrestamo?.toISOString(),
+            fechaDevolucion: datos.fechaDevolucion?.toISOString()
+        };
         this.materialBibliograficoService.regularizarPrestamo(payload).subscribe({
             next: (resp: any) => {
                 this.loading = false;

--- a/Frontend/sakai-ng-master/src/app/biblioteca/services/material-bibliografico.service.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/services/material-bibliografico.service.ts
@@ -561,6 +561,13 @@ crearOcurrencia(dto: OcurrenciaDTO): Observable<OcurrenciaDTO> {
     );
   }
 
+  getDetalleBibliotecaPorNumeroIngreso(numero: number): Observable<DetalleBibliotecaDTO> {
+    return this.http.get<DetalleBibliotecaDTO>(
+      `${this.apiUrl}/api/biblioteca/detalles/numero-ingreso/${numero}`,
+      { headers: this.headers }
+    );
+  }
+
     /** Lista usuarios; permite filtrar por código/email y tipo de usuario */
     listarUsuarios(
       search?: string,


### PR DESCRIPTION
## Resumen
- valida y guarda la fecha de préstamo al regularizar incluso si viene vacía
- el modal completa automáticamente las fechas al buscar por número de ingreso
- la tabla de devoluciones muestra la fecha de préstamo registrada

## Pruebas
- `npm test` *(falla: No inputs were found in config file)*
- `mvn -q test` *(falla: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bb357cd3b483298966d9b9b2aec6af