### PR TITLE
Manejar fechas sin hora en préstamos bibliográficos

### DIFF
--- a/Backend/login-microsoft365/src/main/java/com/miapp/mapper/BibliotecaMapper.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/mapper/BibliotecaMapper.java
@@ -8,6 +8,8 @@ import com.miapp.repository.EstadoRepository;
 import lombok.RequiredArgsConstructor;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 @Component
 @RequiredArgsConstructor
@@ -389,8 +391,24 @@ public class BibliotecaMapper {
                     .ifPresent(e -> tmp.setEstadoDescripcion(e.getDescripcion()));
         }
         tmp.setCantidadPrestamos(d.getCantidadPrestamos());
-        tmp.setFechaPrestamo(d.getFechaPrestamo());
-        tmp.setFechaDevolucion(d.getFechaFin());
+
+        // Combinar fecha y hora para exponer un LocalDateTime completo
+        LocalDateTime fPrestamo = null;
+        if (d.getFechaInicio() != null) {
+            LocalTime hi = d.getHoraInicio() != null ? LocalTime.parse(d.getHoraInicio()) : LocalTime.MIDNIGHT;
+            fPrestamo = LocalDateTime.of(d.getFechaInicio(), hi);
+        } else if (d.getFechaPrestamo() != null) {
+            fPrestamo = d.getFechaPrestamo();
+        }
+        tmp.setFechaPrestamo(fPrestamo);
+
+        LocalDateTime fDevolucion = null;
+        if (d.getFechaFin() != null) {
+            LocalTime hf = d.getHoraFin() != null ? LocalTime.parse(d.getHoraFin()) : LocalTime.MIDNIGHT;
+            fDevolucion = LocalDateTime.of(d.getFechaFin(), hf);
+        }
+        tmp.setFechaDevolucion(fDevolucion);
+
         tmp.setFechaReserva(d.getFechaSolicitud());
 
         return tmp;

--- a/Backend/login-microsoft365/src/main/java/com/miapp/model/DetalleBiblioteca.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/model/DetalleBiblioteca.java
@@ -8,6 +8,8 @@ import org.hibernate.annotations.NotFound;
 import org.hibernate.annotations.NotFoundAction;
 
 import java.math.BigDecimal;
+import com.miapp.util.LocalDateAttributeConverter;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Data
@@ -76,14 +78,16 @@ public class DetalleBiblioteca {
     @Column(name = "FECHASOLICITUD", length = 20)
     private String fechaSolicitud;       // por ejemplo: "2025-06-01"
 
-    @Column(name = "FECHA_INICIO")
-    private LocalDateTime fechaInicio;   // inicio de préstamo/reserva
+    @Convert(converter = LocalDateAttributeConverter.class)
+    @Column(name = "FECHA_INICIO", columnDefinition = "TIMESTAMP")
+    private LocalDate fechaInicio;       // inicio de préstamo/reserva (solo fecha)
 
     @Column(name = "FECHAPRESTAMO")
     private LocalDateTime fechaPrestamo; // cuándo realmente se entregó el ejemplar
 
-    @Column(name = "FECHA_FIN")
-    private LocalDateTime fechaFin;      // fecha de devolución o fin del préstamo
+    @Convert(converter = LocalDateAttributeConverter.class)
+    @Column(name = "FECHA_FIN", columnDefinition = "TIMESTAMP")
+    private LocalDate fechaFin;          // fecha de devolución o fin del préstamo (solo fecha)
 
     @Column(name = "TIPOPRESTAMO", length = 80)
     private String tipoPrestamo;         // ej. "A DOMICILIO", "EN SALA", etc.

--- a/Backend/login-microsoft365/src/main/java/com/miapp/scheduler/BibliotecaReminderScheduler.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/scheduler/BibliotecaReminderScheduler.java
@@ -9,6 +9,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 
@@ -33,7 +34,9 @@ public class BibliotecaReminderScheduler {
         LocalDateTime now = LocalDateTime.now();
         for (DetalleBiblioteca d : prestamos) {
             if (d.getFechaFin() == null) continue;
-            long horas = ChronoUnit.HOURS.between(now, d.getFechaFin());
+            LocalTime hf = d.getHoraFin() != null ? LocalTime.parse(d.getHoraFin()) : LocalTime.MIDNIGHT;
+            LocalDateTime fechaFin = LocalDateTime.of(d.getFechaFin(), hf);
+            long horas = ChronoUnit.HOURS.between(now, fechaFin);
             if (horas == 24) {
                 emailService.sendMaterialReturnReminder(d, 24, ChronoUnit.HOURS);
             } else if (horas == 0) {

--- a/Backend/login-microsoft365/src/main/java/com/miapp/service/EmailService.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/service/EmailService.java
@@ -7,6 +7,8 @@ import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 
@@ -80,10 +82,15 @@ public class EmailService {
         msg.setTo("moranpedro0398@gmail.com");
         msg.setSubject("Confirmación de préstamo del material "
                 + detalle.getBiblioteca().getTitulo());
+        LocalDateTime fechaDev = null;
+        if (detalle.getFechaFin() != null) {
+            LocalTime hf = detalle.getHoraFin() != null ? LocalTime.parse(detalle.getHoraFin()) : LocalTime.MIDNIGHT;
+            fechaDev = LocalDateTime.of(detalle.getFechaFin(), hf);
+        }
         msg.setText("Tu préstamo ha sido registrado.\n" +
                 "Fecha devolución: " +
-                (detalle.getFechaFin() != null
-                        ? detalle.getFechaFin().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"))
+                (fechaDev != null
+                        ? fechaDev.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"))
                         : "N/A"));
         mailSender.send(msg);
     }
@@ -103,8 +110,13 @@ public class EmailService {
 
     public void sendMaterialReturnReminder(DetalleBiblioteca detalle, long amount, ChronoUnit unit) {
         String unitName = unit == ChronoUnit.HOURS ? "horas" : "minutos";
-        String fecha = detalle.getFechaFin() != null
-                ? detalle.getFechaFin().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"))
+        LocalDateTime fechaDev = null;
+        if (detalle.getFechaFin() != null) {
+            LocalTime hf = detalle.getHoraFin() != null ? LocalTime.parse(detalle.getHoraFin()) : LocalTime.MIDNIGHT;
+            fechaDev = LocalDateTime.of(detalle.getFechaFin(), hf);
+        }
+        String fecha = fechaDev != null
+                ? fechaDev.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"))
                 : "N/A";
 
         SimpleMailMessage msg = new SimpleMailMessage();
@@ -120,8 +132,13 @@ public class EmailService {
     }
 
     public void sendMaterialOverdue(DetalleBiblioteca detalle) {
-        String fecha = detalle.getFechaFin() != null
-                ? detalle.getFechaFin().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"))
+        LocalDateTime fechaDev2 = null;
+        if (detalle.getFechaFin() != null) {
+            LocalTime hf = detalle.getHoraFin() != null ? LocalTime.parse(detalle.getHoraFin()) : LocalTime.MIDNIGHT;
+            fechaDev2 = LocalDateTime.of(detalle.getFechaFin(), hf);
+        }
+        String fecha = fechaDev2 != null
+                ? fechaDev2.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"))
                 : "N/A";
         SimpleMailMessage msg = new SimpleMailMessage();
         msg.setFrom(from);

--- a/Backend/login-microsoft365/src/main/java/com/miapp/service/PrestamoService.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/service/PrestamoService.java
@@ -22,8 +22,10 @@ import org.springframework.data.domain.Sort;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.OffsetDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeParseException;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
@@ -255,20 +257,23 @@ public class PrestamoService {
                 det.setCodigoUsuario(cod.toString());
             }
         }
-        Object fechaPrestamoObj = datos.get("fechaPrestamo");
-        LocalDateTime fechaPrestamo = null;
-        if (fechaPrestamoObj instanceof String fpStr && !fpStr.isBlank()) {
-            fechaPrestamo = OffsetDateTime.parse(fpStr).toLocalDateTime();
+        LocalDate fechaInicio = parseFecha(datos.get("fechaPrestamo"));
+        LocalTime horaInicio = parseHora(datos.get("horaInicio"));
+        if (fechaInicio == null) {
+            fechaInicio = LocalDate.now();
         }
-        if (fechaPrestamo == null) {
-            fechaPrestamo = LocalDateTime.now();
+        if (horaInicio == null) {
+            horaInicio = LocalTime.MIDNIGHT;
         }
-        det.setFechaPrestamo(fechaPrestamo);
-        det.setFechaInicio(fechaPrestamo);
+        det.setFechaPrestamo(LocalDateTime.of(fechaInicio, horaInicio));
+        det.setFechaInicio(fechaInicio);
+        det.setHoraInicio(horaInicio.toString());
 
-        Object fechaDevolucionObj = datos.get("fechaDevolucion");
-        if (fechaDevolucionObj instanceof String fdStr && !fdStr.isBlank()) {
-            det.setFechaFin(OffsetDateTime.parse(fdStr).toLocalDateTime());
+        LocalDate fechaFin = parseFecha(datos.get("fechaDevolucion"));
+        LocalTime horaFin = parseHora(datos.get("horaFin"));
+        det.setFechaFin(fechaFin);
+        if (horaFin != null) {
+            det.setHoraFin(horaFin.toString());
         }
         det.setUsuarioModificacion(usuario);
 
@@ -285,6 +290,26 @@ public class PrestamoService {
 
         DetalleBiblioteca saved = detalleBibliotecaRepository.save(det);
         return bibliotecaMapper.toDetalleDto(saved);
+    }
+
+    private LocalDate parseFecha(Object valor) {
+        if (valor instanceof String s && !s.isBlank()) {
+            try {
+                return s.contains("T") ? LocalDateTime.parse(s).toLocalDate() : LocalDate.parse(s);
+            } catch (DateTimeParseException ignore) {
+            }
+        }
+        return null;
+    }
+
+    private LocalTime parseHora(Object valor) {
+        if (valor instanceof String s && !s.isBlank()) {
+            try {
+                return s.contains("T") ? LocalDateTime.parse(s).toLocalTime() : LocalTime.parse(s);
+            } catch (DateTimeParseException ignore) {
+            }
+        }
+        return null;
     }
 
     public List<DetallePrestamo> reporte(

--- a/Backend/login-microsoft365/src/main/java/com/miapp/util/LocalDateAttributeConverter.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/util/LocalDateAttributeConverter.java
@@ -1,0 +1,24 @@
+package com.miapp.util;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import java.sql.Timestamp;
+import java.time.LocalDate;
+
+/**
+ * Convierte LocalDate a Timestamp para compatibilidad con columnas TIMESTAMP
+ * preservando solo la fecha (hora 00:00:00).
+ */
+@Converter(autoApply = false)
+public class LocalDateAttributeConverter implements AttributeConverter<LocalDate, Timestamp> {
+
+    @Override
+    public Timestamp convertToDatabaseColumn(LocalDate attribute) {
+        return attribute == null ? null : Timestamp.valueOf(attribute.atStartOfDay());
+    }
+
+    @Override
+    public LocalDate convertToEntityAttribute(Timestamp dbData) {
+        return dbData == null ? null : dbData.toLocalDateTime().toLocalDate();
+    }
+}


### PR DESCRIPTION
## Resumen
- Guardar solo la fecha en `fechaInicio` y `fechaFin` del detalle de biblioteca
- Separar y almacenar horas en `PrestamoService.regularizarPrestamo`
- Recombinar fecha y hora en mapper, notificaciones y recordatorios
- Convertir automáticamente `LocalDate` a `Timestamp` para evitar errores de esquema
- Parsear fechas y horas sin zona horaria al regularizar préstamos

## Testing
- `mvn -q test` *(falla: Non-resolvable parent POM)*
- `npm test` *(falla: error TS18003: No inputs were found in config file)*

------
https://chatgpt.com/codex/tasks/task_e_68bcf259aa9883299ac414dee918e267