### PR TITLE
Consulta detalle de préstamo por equipo

### DIFF
--- a/Backend/login-microsoft365/src/main/java/com/miapp/controller/PrestamoController.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/controller/PrestamoController.java
@@ -220,6 +220,19 @@ public class PrestamoController {
         return ResponseEntity.ok(Map.of("status","0","data", lista));
     }
 
+    /**
+     * Lista el historial de préstamos de un equipo determinado. Si se envía una sede,
+     * se filtra por dicha sede.
+     */
+    @GetMapping("/equipos/{equipoId}/detalles")
+    public ResponseEntity<?> listarDetallePorEquipo(
+            @PathVariable Long equipoId,
+            @RequestParam(required = false) Long sedeId
+    ) {
+        List<DetallePrestamo> lista = prestamoService.listarPrestamosPorEquipo(equipoId, sedeId);
+        return ResponseEntity.ok(Map.of("status","0","data", lista));
+    }
+
     /** Lista equipos (id, nombre o ip) */
     @GetMapping("/equipos")
     public ResponseEntity<?> listarEquipos(

--- a/Backend/login-microsoft365/src/main/java/com/miapp/repository/DetallePrestamoRepository.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/repository/DetallePrestamoRepository.java
@@ -28,6 +28,10 @@ public interface DetallePrestamoRepository
             String descripcionEstado
     );
 
+    List<DetallePrestamo> findByEquipo_IdEquipo(Long equipoId);
+
+    List<DetallePrestamo> findByEquipo_IdEquipoAndCodigoSede(Long equipoId, String codigoSede);
+
     List<DetallePrestamo> findByEstado_DescripcionIn(List<String> estados);
     List<DetallePrestamo> findByEstado_DescripcionInAndCodigoSedeIgnoreCase(
             List<String> estados, String codigoSede);

--- a/Backend/login-microsoft365/src/main/java/com/miapp/service/PrestamoService.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/service/PrestamoService.java
@@ -201,6 +201,17 @@ public class PrestamoService {
     }
 
     /**
+     * Devuelve el historial de préstamos de un equipo.
+     * Si se envía una sede, se filtra además por dicho código de sede.
+     */
+    public List<DetallePrestamo> listarPrestamosPorEquipo(Long equipoId, Long sedeId) {
+        if (sedeId != null) {
+            return detallePrestamoRepository.findByEquipo_IdEquipoAndCodigoSede(equipoId, sedeId.toString());
+        }
+        return detallePrestamoRepository.findByEquipo_IdEquipo(equipoId);
+    }
+
+    /**
      * Para el listado de devoluciones: solo PRESTADO EN SALA/A DOMICILIO,
      * y si pasan sedeId != null, filtra por ese código de sede.
      */

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/prestamos/biblioteca-virtual/modal-regularizar.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/prestamos/biblioteca-virtual/modal-regularizar.ts
@@ -9,6 +9,7 @@ import { DocumentoService } from '../../../services/documento.service';
 import { BibliotecaVirtualService } from '../../../services/biblioteca-virtual.service';
 import { TemplateModule } from '../../../template.module';
 import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
+import { forkJoin } from 'rxjs';
 @Component({
     selector: 'app-modal-regularizar',
     standalone: true,
@@ -471,14 +472,6 @@ export class ModalRegularizarComponent implements OnInit {
     }
 
 
-    private parseTimeAtDate(time: string, base: Date): Date {
-        const [h, m] = time.split(':').map((n: any) => parseInt(n, 10));
-        const d = new Date(base);
-        d.setHours(h, m, 0, 0);
-        return d;
-    }
-
-
     private autocompletarEquipo(equipo: any, destino: FormGroup) {
         if (!equipo?.id) {
             destino.patchValue({
@@ -493,47 +486,32 @@ export class ModalRegularizarComponent implements OnInit {
             this.duracionSeleccionada = null;
             return;
         }
-        this.bibliotecaVirtualService.listarEquiposPrestamo(String(equipo.id)).subscribe({
-            next: (lista: any[]) => {
-                const detalle = lista?.[0];
-                this.maxHoras = detalle?.maxHoras ?? null;
+
+        const sede = destino.get('sede')?.value;
+        const sedeId = sede?.id ?? sede;
+
+        forkJoin({
+            info: this.bibliotecaVirtualService.listarEquiposPrestamo(String(equipo.id)),
+            detalles: this.bibliotecaVirtualService.listarDetallePrestamoEquipo(equipo.id, sedeId)
+        }).subscribe({
+            next: ({ info, detalles }) => {
+                const registros = (info || []).filter((e: any) => {
+                    const idEq = e.idEquipo ?? e.id;
+                    const sedeEq = e.sede?.id ?? e.idSede;
+                    return idEq === equipo.id && (sedeId == null || sedeEq === sedeId);
+                });
+
+                const base = registros[0] || {};
+                this.maxHoras = base?.maxHoras ?? base?.detallePrestamo?.maxHoras ?? null;
                 this.duracionSeleccionada = this.maxHoras;
 
-                let fechaPrestamo = detalle?.fechaPrestamo ? new Date(detalle.fechaPrestamo) : null;
-                let fechaDevolucion = detalle?.fechaDevolucion ? new Date(detalle.fechaDevolucion) : null;
+                const activo = (detalles || []).find((d: any) => {
+                    const fin = d?.fechaFin ? new Date(d.fechaFin) : null;
+                    return fin && fin.getTime() > Date.now();
+                });
 
-                if (!fechaPrestamo && detalle?.horaInicio) {
-                    fechaPrestamo = this.parseTimeAtDate(detalle.horaInicio, new Date());
-                }
-                if (!fechaDevolucion && detalle?.horaFin) {
-                    const base = fechaPrestamo ?? new Date();
-                    fechaDevolucion = this.parseTimeAtDate(detalle.horaFin, base);
-                }
-
-                destino.patchValue({
-                    fechaPrestamo,
-                    fechaDevolucion,
-                    horaInicio: fechaPrestamo,
-                    horaFin: fechaDevolucion
-                }, { emitEvent: false });
-
-                const estado = (detalle?.estado?.descripcion ?? '').toUpperCase();
-                const prestado = estado === 'PRESTADO' || estado === 'RESERVADO' ||
-                    (fechaDevolucion != null && fechaDevolucion.getTime() > Date.now());
-                if (prestado) {
-                    const disponible = fechaDevolucion ? this.formatearFechaHora(fechaDevolucion) : '';
-                    this.confirmationService.confirm({
-                        header: 'Equipo no disponible',
-                        message: disponible
-                            ? `Equipo prestado a otro usuario.<br/>El equipo se encuentra disponible en este horario:<br/><strong>${disponible}</strong><br/>¿Desea pre-registrar?`
-                            : 'Equipo prestado a otro usuario.',
-                        icon: 'pi pi-exclamation-triangle',
-                        acceptLabel: 'Aceptar',
-                        rejectLabel: 'Cancelar',
-                        closeOnEscape: false,
-                        accept: () => this.establecerHorario(destino, fechaDevolucion || new Date(), true),
-                        reject: () => destino.get('numeroEquipo')?.reset()
-                    });
+                if (activo) {
+                    this.mostrarEquipoNoDisponible(destino, new Date(activo.fechaFin));
                 } else {
                     this.establecerHorario(destino, new Date(), false);
                 }
@@ -552,13 +530,33 @@ export class ModalRegularizarComponent implements OnInit {
         });
     }
 
+    private mostrarEquipoNoDisponible(destino: FormGroup, fin?: Date) {
+        const disponible = fin ? this.formatearFechaHora(fin) : '';
+        this.confirmationService.confirm({
+            header: 'Equipo no disponible',
+            message: disponible
+                ? `Equipo prestado a otro usuario.<br/>El equipo se encuentra disponible en este horario:<br/><strong>${disponible}</strong><br/>¿Desea pre-registrar?`
+                : 'Equipo prestado a otro usuario.',
+            icon: 'pi pi-exclamation-triangle',
+            acceptLabel: 'Aceptar',
+            rejectLabel: 'Cancelar',
+            closeOnEscape: false,
+            accept: () => this.establecerHorario(destino, fin || new Date(), true),
+            reject: () => destino.get('numeroEquipo')?.reset()
+        });
+    }
+
     private establecerHorario(destino: FormGroup, inicio: Date, bloquearInicio: boolean) {
         const fin = new Date(inicio.getTime() + 60 * 60 * 1000);
+        const fechaPrestamo = new Date(inicio.getFullYear(), inicio.getMonth(), inicio.getDate());
+        const fechaDevolucion = new Date(fin.getFullYear(), fin.getMonth(), fin.getDate());
+        const horaInicio = new Date(0, 0, 0, inicio.getHours(), inicio.getMinutes());
+        const horaFin = new Date(0, 0, 0, fin.getHours(), fin.getMinutes());
         destino.patchValue({
-            fechaPrestamo: inicio,
-            fechaDevolucion: fin,
-            horaInicio: inicio,
-            horaFin: fin
+            fechaPrestamo,
+            fechaDevolucion,
+            horaInicio,
+            horaFin
         }, { emitEvent: false });
         this.validarMaxHoras(destino);
         if (bloquearInicio) {

--- a/Frontend/sakai-ng-master/src/app/biblioteca/services/biblioteca-virtual.service.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/services/biblioteca-virtual.service.ts
@@ -109,6 +109,25 @@ export class BibliotecaVirtualService {
             .pipe(map(resp => resp.data));
     }
 
+    listarDetallePrestamoEquipo(equipoId: number, sedeId?: number): Observable<any[]> {
+        let params = new HttpParams();
+        if (sedeId != null) {
+            params = params.set('sedeId', sedeId);
+        }
+        return this.http
+            .get<{ status: string; data: any[] }>(
+                `${this.apiUrl}/api/prestamos/equipos/${equipoId}/detalles`,
+                {
+                    params,
+                    headers: new HttpHeaders().set(
+                        'Authorization',
+                        `Bearer ${this.authService.getToken()}`
+                    )
+                }
+            )
+            .pipe(map(resp => resp.data));
+    }
+
     solicitar(req: any): Observable<any> {
         // antes: this.http.post('/auth/api/prestamos/solicitar', req)
         return this.http.post(`${this.apiUrl}/api/prestamos/solicitar`, req, { headers: new HttpHeaders().set('Authorization', `Bearer ${this.authService.getToken()}`) });


### PR DESCRIPTION
## Resumen
- Se expone `/auth/api/prestamos/equipos/{equipoId}/detalles` para recuperar el historial de préstamos por equipo y sede opcional.
- Se corrige la consulta del repositorio usando `idEquipo` para evitar fallos de arranque y se ajusta el servicio a los nuevos métodos.

## Testing
- `mvn -q test` *(falla: Non-resolvable parent POM - Network is unreachable)*
- `npm test -- --watch=false` *(falla: No inputs were found in config file 'tsconfig.spec.json')*
- `npm run build -- --no-progress`


------
https://chatgpt.com/codex/tasks/task_e_68be7ce29c4c83298f2d7beb81f88c5f