### PR TITLE
feat: cargar combos en reportes

### DIFF
--- a/Backend/login-microsoft365/src/main/java/com/miapp/config/SecurityConfig.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/config/SecurityConfig.java
@@ -57,6 +57,7 @@ public class SecurityConfig {
                             "/auth/api/biblioteca/search",
                             "/auth/api/catalogos/**",
                             "/auth/api/equipos/sedes",
+                            "/auth/sede/lista-activo",
                             "/auth/material-bibliografico/especialidad",
                             "/auth/api/nosotros",
                             "/auth/api/horarios/listar",

--- a/Backend/login-microsoft365/src/main/java/com/miapp/controller/SedeController.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/controller/SedeController.java
@@ -1,0 +1,34 @@
+package com.miapp.controller;
+
+import com.miapp.model.Sede;
+import com.miapp.service.SedeService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/auth/sede")
+public class SedeController {
+
+    private final SedeService sedeService;
+
+    public SedeController(SedeService sedeService) {
+        this.sedeService = sedeService;
+    }
+
+    @GetMapping("/lista-activo")
+    public ResponseEntity<?> listarActivos() {
+        try {
+            List<Sede> sedes = sedeService.getSedesActivas();
+            return ResponseEntity.ok(Map.of("status", 0, "data", sedes));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(Map.of("status", -1, "message", e.getMessage()));
+        }
+    }
+}

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/ejemplar-mas-prestado.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/ejemplar-mas-prestado.ts
@@ -11,6 +11,7 @@ import { jsPDF } from 'jspdf';
 import autoTable from 'jspdf-autotable';
 import * as ExcelJS from 'exceljs';
 import { saveAs } from 'file-saver';
+import { ReportesFiltroService } from '../../services/reportes-filtro.service';
 
 @Component({
     selector: 'app-reporte-ejemplar-mas-prestado',
@@ -144,10 +145,28 @@ export class ReporteEjemplarMasPrestado {
 
     constructor(private svc: MaterialBibliograficoService,
                 private messageService: MessageService,
-                private http: HttpClient) {}
+                private http: HttpClient,
+                private filtrosService: ReportesFiltroService) {}
 
     async ngOnInit() {
+        await this.cargarFiltros();
         await this.reporte();
+    }
+
+    private async cargarFiltros() {
+        const filtros = await this.filtrosService.cargarFiltros();
+        this.dataSede = filtros.sedes;
+        this.sedeFiltro = this.dataSede[0];
+        this.dataPrograma = filtros.programas;
+        this.programaFiltro = this.dataPrograma[0];
+        this.dataTipoUsuario = filtros.tipoUsuarios;
+        this.tipoUsuarioFiltro = this.dataTipoUsuario[0];
+        this.dataTipoMaterial = filtros.tiposMaterial;
+        this.tipoMaterialFiltro = this.dataTipoMaterial[0];
+        this.dataEspecialidad = filtros.especialidades;
+        this.especialidadFiltro = this.dataEspecialidad[0];
+        this.dataCiclo = filtros.ciclos;
+        this.cicloFiltro = this.dataCiclo[0];
     }
     async reporte() {
         this.loading = true;

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/ejemplar-no-prestado.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/ejemplar-no-prestado.ts
@@ -11,6 +11,7 @@ import { jsPDF } from 'jspdf';
 import autoTable from 'jspdf-autotable';
 import * as ExcelJS from 'exceljs';
 import { saveAs } from 'file-saver';
+import { ReportesFiltroService } from '../../services/reportes-filtro.service';
 
 @Component({
     selector: 'app-reporte-ejemplar-no-prestado',
@@ -118,11 +119,28 @@ export class ReporteEjemplarNoPrestado {
     constructor(
         private svc: MaterialBibliograficoService,
         private messageService: MessageService,
-        private http: HttpClient
+        private http: HttpClient,
+        private filtrosService: ReportesFiltroService
     ) {}
 
     async ngOnInit() {
+        await this.cargarFiltros();
         await this.reporte();
+    }
+    private async cargarFiltros() {
+        const filtros = await this.filtrosService.cargarFiltros();
+        this.dataSede = filtros.sedes;
+        this.sedeFiltro = this.dataSede[0];
+        this.dataPrograma = filtros.programas;
+        this.programaFiltro = this.dataPrograma[0];
+        this.dataTipoUsuario = filtros.tipoUsuarios;
+        this.tipoUsuarioFiltro = this.dataTipoUsuario[0];
+        this.dataTipoMaterial = filtros.tiposMaterial;
+        this.tipoMaterialFiltro = this.dataTipoMaterial[0];
+        this.dataEspecialidad = filtros.especialidades;
+        this.especialidadFiltro = this.dataEspecialidad[0];
+        this.dataCiclo = filtros.ciclos;
+        this.cicloFiltro = this.dataCiclo[0];
     }
     async reporte() {
         this.loading = true;

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/estudiantes-atendidos.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/estudiantes-atendidos.ts
@@ -12,6 +12,7 @@ import { jsPDF } from 'jspdf';
 import autoTable from 'jspdf-autotable';
 import * as ExcelJS from 'exceljs';
 import { saveAs } from 'file-saver';
+import { ReportesFiltroService } from '../../services/reportes-filtro.service';
 
 interface Row {
     usuario: string;
@@ -158,11 +159,29 @@ export class ReporteEstudiantesAtendidos implements OnInit {
     constructor(
         private prestamosService: PrestamosService,
         private messageService: MessageService,
-        private http: HttpClient
+        private http: HttpClient,
+        private filtrosService: ReportesFiltroService
     ) {}
 
     async ngOnInit() {
+        await this.cargarFiltros();
         await this.reporte();
+    }
+
+    private async cargarFiltros() {
+        const filtros = await this.filtrosService.cargarFiltros();
+        this.dataSede = filtros.sedes;
+        this.sedeFiltro = this.dataSede[0];
+        this.dataPrograma = filtros.programas;
+        this.programaFiltro = this.dataPrograma[0];
+        this.dataTipoUsuario = filtros.tipoUsuarios;
+        this.tipoUsuarioFiltro = this.dataTipoUsuario[0];
+        this.dataTipoMaterial = filtros.tiposMaterial;
+        this.tipoMaterialFiltro = this.dataTipoMaterial[0];
+        this.dataEspecialidad = filtros.especialidades;
+        this.especialidadFiltro = this.dataEspecialidad[0];
+        this.dataCiclo = filtros.ciclos;
+        this.cicloFiltro = this.dataCiclo[0];
     }
 
     async reporte() {

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/inventario-material-bibliografico.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/inventario-material-bibliografico.ts
@@ -12,6 +12,7 @@ import { jsPDF } from 'jspdf';
 import autoTable from 'jspdf-autotable';
 import * as ExcelJS from 'exceljs';
 import { saveAs } from 'file-saver';
+import { ReportesFiltroService } from '../../services/reportes-filtro.service';
 
 @Component({
     selector: 'app-reporte-inventario-material-bibliografico',
@@ -97,10 +98,19 @@ export class ReporteInventarioMaterialBibliografico {
     constructor(
         private materialService: MaterialBibliograficoService,
         private messageService: MessageService,
-        private http: HttpClient
+        private http: HttpClient,
+        private filtrosService: ReportesFiltroService
     ) {}
     async ngOnInit() {
+        await this.cargarFiltros();
         await this.reporte();
+    }
+    private async cargarFiltros() {
+        const filtros = await this.filtrosService.cargarFiltros();
+        this.dataSede = filtros.sedes;
+        this.sedeFiltro = this.dataSede[0];
+        this.dataColeccion = filtros.tiposMaterial;
+        this.coleccionFiltro = this.dataColeccion[0];
     }
     async reporte() {
         this.loading = true;

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/material-bibliografico-existente.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/material-bibliografico-existente.ts
@@ -4,6 +4,7 @@ import { TooltipModule } from 'primeng/tooltip';
 import { TemplateModule } from '../../template.module';
 import { Sedes } from '../../interfaces/sedes';
 import { ClaseGeneral } from '../../interfaces/clase-general';
+import { ReportesFiltroService } from '../../services/reportes-filtro.service';
 
 @Component({
     selector: 'app-reporte-material-bibliografico-existente',
@@ -49,9 +50,17 @@ export class ReporteMaterialBibliograficoExistente {
     dataColeccion: ClaseGeneral[] = [];
     tipo:number=1;
     loading: boolean = true;
-
+    constructor(private filtrosService: ReportesFiltroService) {}
     async ngOnInit() {
+        await this.cargarFiltros();
         await this.reporte();
     }
-    reporte(){}
+    private async cargarFiltros() {
+        const filtros = await this.filtrosService.cargarFiltros();
+        this.dataSede = filtros.sedes;
+        this.sedeFiltro = this.dataSede[0];
+        this.dataColeccion = filtros.tiposMaterial;
+        this.coleccionFiltro = this.dataColeccion[0];
+    }
+    async reporte(){}
 }

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/material-bibliografico-resumen.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/material-bibliografico-resumen.ts
@@ -4,6 +4,7 @@ import { TooltipModule } from 'primeng/tooltip';
 import { TemplateModule } from '../../template.module';
 import { Sedes } from '../../interfaces/sedes';
 import { ClaseGeneral } from '../../interfaces/clase-general';
+import { ReportesFiltroService } from '../../services/reportes-filtro.service';
 
 @Component({
     selector: 'app-reporte-material-bibliografico-resumen',
@@ -52,9 +53,17 @@ export class ReporteMaterialBibliograficoResumen {
     dataColeccion: ClaseGeneral[] = [];
     tipo:number=1;
     loading: boolean = true;
-
+    constructor(private filtrosService: ReportesFiltroService) {}
     async ngOnInit() {
+        await this.cargarFiltros();
         await this.reporte();
     }
-    reporte(){}
+    private async cargarFiltros() {
+        const filtros = await this.filtrosService.cargarFiltros();
+        this.dataSede = filtros.sedes;
+        this.sedeFiltro = this.dataSede[0];
+        this.dataColeccion = filtros.tiposMaterial;
+        this.coleccionFiltro = this.dataColeccion[0];
+    }
+    async reporte(){}
 }

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/reporte-intranet.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/reporte-intranet.ts
@@ -4,6 +4,7 @@ import { TooltipModule } from 'primeng/tooltip';
 import { TemplateModule } from '../../template.module';
 import { Sedes } from '../../interfaces/sedes';
 import { ClaseGeneral } from '../../interfaces/clase-general';
+import { ReportesFiltroService } from '../../services/reportes-filtro.service';
 
 @Component({
     selector: 'app-reporte-intranet',
@@ -106,9 +107,25 @@ export class ReporteIntranet {
     dataTipoPrestamo: ClaseGeneral[] = [];
     tipoPrestamoFiltro: ClaseGeneral = new ClaseGeneral();
     loading: boolean = true;
-
+    constructor(private filtrosService: ReportesFiltroService) {}
     async ngOnInit() {
+        await this.cargarFiltros();
         await this.reporte();
     }
-    reporte(){}
+    private async cargarFiltros() {
+        const filtros = await this.filtrosService.cargarFiltros();
+        this.dataSede = filtros.sedes;
+        this.sedeFiltro = this.dataSede[0];
+        this.dataPrograma = filtros.programas;
+        this.programaFiltro = this.dataPrograma[0];
+        this.dataEscuela = filtros.especialidades;
+        this.escuelaFiltro = this.dataEscuela[0];
+        this.dataTipoUsuario = filtros.tipoUsuarios;
+        this.tipoUsuarioFiltro = this.dataTipoUsuario[0];
+        this.dataEstado = filtros.tiposMaterial;
+        this.estadoFiltro = this.dataEstado[0];
+        this.dataCiclo = filtros.ciclos;
+        this.cicloFiltro = this.dataCiclo[0];
+    }
+    async reporte(){}
 }

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/reporte-prestamo-domicilio.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/reporte-prestamo-domicilio.ts
@@ -4,6 +4,7 @@ import { TooltipModule } from 'primeng/tooltip';
 import { TemplateModule } from '../../template.module';
 import { Sedes } from '../../interfaces/sedes';
 import { ClaseGeneral } from '../../interfaces/clase-general';
+import { ReportesFiltroService } from '../../services/reportes-filtro.service';
 
 @Component({
     selector: 'app-reporte-prestamo-domiclio',
@@ -67,9 +68,19 @@ export class ReportePrestamoDomicilio {
     dataMes: ClaseGeneral[] = [];
     mesFiltro: ClaseGeneral = new ClaseGeneral();
     loading: boolean = true;
-
+    constructor(private filtrosService: ReportesFiltroService) {}
     async ngOnInit() {
+        await this.cargarFiltros();
         await this.reporte();
     }
-    reporte(){}
+    private async cargarFiltros() {
+        const filtros = await this.filtrosService.cargarFiltros();
+        this.dataSede = filtros.sedes;
+        this.sedeFiltro = this.dataSede[0];
+        this.dataPrograma = filtros.programas;
+        this.programaFiltro = this.dataPrograma[0];
+        this.dataEscuela = filtros.especialidades;
+        this.escuelaFiltro = this.dataEscuela[0];
+    }
+    async reporte(){}
 }

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/reporte-prestamo-ensala.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/reporte-prestamo-ensala.ts
@@ -4,6 +4,7 @@ import { TooltipModule } from 'primeng/tooltip';
 import { TemplateModule } from '../../template.module';
 import { Sedes } from '../../interfaces/sedes';
 import { ClaseGeneral } from '../../interfaces/clase-general';
+import { ReportesFiltroService } from '../../services/reportes-filtro.service';
 
 @Component({
     selector: 'app-reporte-prestamo-ensala',
@@ -67,9 +68,19 @@ export class ReportePrestamoEnSala {
     dataMes: ClaseGeneral[] = [];
     mesFiltro: ClaseGeneral = new ClaseGeneral();
     loading: boolean = true;
-
+    constructor(private filtrosService: ReportesFiltroService) {}
     async ngOnInit() {
+        await this.cargarFiltros();
         await this.reporte();
     }
-    reporte(){}
+    private async cargarFiltros() {
+        const filtros = await this.filtrosService.cargarFiltros();
+        this.dataSede = filtros.sedes;
+        this.sedeFiltro = this.dataSede[0];
+        this.dataPrograma = filtros.programas;
+        this.programaFiltro = this.dataPrograma[0];
+        this.dataEscuela = filtros.especialidades;
+        this.escuelaFiltro = this.dataEscuela[0];
+    }
+    async reporte(){}
 }

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/reporte-prestamo-equipo-computo.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/reporte-prestamo-equipo-computo.ts
@@ -16,6 +16,7 @@ import { PrestamosService } from '../../services/prestamos.service';
 import { DetallePrestamo  } from '../../interfaces/detalle-prestamo';
 import { Sedes            } from '../../interfaces/sedes';
 import { ClaseGeneral     } from '../../interfaces/clase-general';
+import { ReportesFiltroService } from '../../services/reportes-filtro.service';
 
 import * as ExcelJS from 'exceljs';
 import { saveAs } from 'file-saver';
@@ -157,19 +158,19 @@ import { HttpClient } from '@angular/common/http';
 export class ReportePrestamoEquipoComputo implements OnInit {
   titulo = 'Préstamo detallado de equipos de cómputo';
 
-  dataSede: Sedes[]        = [];
+  dataSede: Sedes[]              = [];
   dataTipoUsuario: ClaseGeneral[] = [];
   dataEstado: ClaseGeneral[]     = [];
   dataEscuela: ClaseGeneral[]    = [];
   dataPrograma: ClaseGeneral[]   = [];
   dataCiclo: ClaseGeneral[]      = [];
 
-  sedeFiltro!:        number;
-  tipoUsuarioFiltro = '';
+  sedeFiltro:        Sedes        = new Sedes();
+  tipoUsuarioFiltro: ClaseGeneral = new ClaseGeneral();
   estadoFiltro!: number;
-  escuelaFiltro    = '';
-  programaFiltro   = '';
-  cicloFiltro      = '';
+  escuelaFiltro:    ClaseGeneral = new ClaseGeneral();
+  programaFiltro:   ClaseGeneral = new ClaseGeneral();
+  cicloFiltro:      ClaseGeneral = new ClaseGeneral();
 
   fechaInicio!: Date;
   fechaFin!:    Date;
@@ -185,14 +186,29 @@ export class ReportePrestamoEquipoComputo implements OnInit {
   tipoPrestamoFiltro: string | null = null;
 
       constructor(private svc: PrestamosService,
-                    private messageService: MessageService, private http: HttpClient) {}
+                    private messageService: MessageService,
+                    private http: HttpClient,
+                    private filtrosService: ReportesFiltroService) {}
 
       async ngOnInit() {
-        // aquí cargas combos (sedes, tipos, estados…)
-        // y preset de fechas, p.ej:
+        await this.cargarFiltros();
         this.fechaInicio = new Date();
         this.fechaFin    = new Date();
         await this.cargarEstados();
+      }
+
+      private async cargarFiltros() {
+        const filtros = await this.filtrosService.cargarFiltros();
+        this.dataSede = filtros.sedes;
+        this.sedeFiltro = this.dataSede[0];
+        this.dataTipoUsuario = filtros.tipoUsuarios;
+        this.tipoUsuarioFiltro = this.dataTipoUsuario[0];
+        this.dataEscuela = filtros.especialidades;
+        this.escuelaFiltro = this.dataEscuela[0];
+        this.dataPrograma = filtros.programas;
+        this.programaFiltro = this.dataPrograma[0];
+        this.dataCiclo = filtros.ciclos;
+        this.cicloFiltro = this.dataCiclo[0];
       }
 
 async reporte() {
@@ -208,12 +224,12 @@ async reporte() {
     // Forzamos un array vacío si la llamada devolviera undefined
     const data = (await this.svc
       .listar(
-        this.sedeFiltro,
-        this.tipoUsuarioFiltro,
+        this.sedeFiltro.id,
+        this.tipoUsuarioFiltro.id,
         estado,
-        this.escuelaFiltro,
-        this.programaFiltro,
-        this.cicloFiltro,
+        this.escuelaFiltro.id,
+        this.programaFiltro.id,
+        this.cicloFiltro.id,
         fi,
         ff
       )
@@ -237,15 +253,12 @@ async reporte() {
     }
 
   get sedeFiltroLabel(): string {
-    const s = this.dataSede.find(x => x.id === this.sedeFiltro);
-    return s ? s.descripcion : 'Todas';
+    return this.sedeFiltro?.descripcion ?? 'Todas';
   }
 
-get programaFiltroLabel(): string {
-  const idNumerico = Number(this.programaFiltro);
-  const p = this.dataPrograma.find(x => x.id === idNumerico);
-  return p ? p.descripcion : 'Todos';
-}
+  get programaFiltroLabel(): string {
+    return this.programaFiltro?.descripcion ?? 'Todos';
+  }
 
   async exportExcel() {
     if (!this.resultados.length) {

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/reporte-prestamo-escuela-profesional.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/reporte-prestamo-escuela-profesional.ts
@@ -4,6 +4,7 @@ import { TooltipModule } from 'primeng/tooltip';
 import { TemplateModule } from '../../template.module';
 import { Sedes } from '../../interfaces/sedes';
 import { ClaseGeneral } from '../../interfaces/clase-general';
+import { ReportesFiltroService } from '../../services/reportes-filtro.service';
 
 @Component({
     selector: 'app-reporte-prestamo-escuela-profesional',
@@ -113,9 +114,23 @@ export class ReportePrestamoEscuelaProfesional {
     especialidadFiltro: ClaseGeneral = new ClaseGeneral();
     tipo:number=1;
     loading: boolean = true;
-
+    constructor(private filtrosService: ReportesFiltroService) {}
     async ngOnInit() {
+        await this.cargarFiltros();
         await this.reporte();
     }
-    reporte(){}
+    private async cargarFiltros() {
+        const filtros = await this.filtrosService.cargarFiltros();
+        this.dataSede = filtros.sedes;
+        this.sedeFiltro = this.dataSede[0];
+        this.dataPrograma = filtros.programas;
+        this.programaFiltro = this.dataPrograma[0];
+        this.dataTipoUsuario = filtros.tipoUsuarios;
+        this.tipoUsuarioFiltro = this.dataTipoUsuario[0];
+        this.dataEspecialidad = filtros.especialidades;
+        this.especialidadFiltro = this.dataEspecialidad[0];
+        this.dataCiclo = filtros.ciclos;
+        this.cicloFiltro = this.dataCiclo[0];
+    }
+    async reporte(){}
 }

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/reporte-prestamo-lab-virtual.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/reporte-prestamo-lab-virtual.ts
@@ -4,6 +4,7 @@ import { TooltipModule } from 'primeng/tooltip';
 import { TemplateModule } from '../../template.module';
 import { Sedes } from '../../interfaces/sedes';
 import { ClaseGeneral } from '../../interfaces/clase-general';
+import { ReportesFiltroService } from '../../services/reportes-filtro.service';
 
 @Component({
     selector: 'app-reporte-prestamo-lab-virtual',
@@ -67,9 +68,19 @@ export class ReportePrestamoLaboratorioVirtual {
     dataMes: ClaseGeneral[] = [];
     mesFiltro: ClaseGeneral = new ClaseGeneral();
     loading: boolean = true;
-
+    constructor(private filtrosService: ReportesFiltroService) {}
     async ngOnInit() {
+        await this.cargarFiltros();
         await this.reporte();
     }
-    reporte(){}
+    private async cargarFiltros() {
+        const filtros = await this.filtrosService.cargarFiltros();
+        this.dataSede = filtros.sedes;
+        this.sedeFiltro = this.dataSede[0];
+        this.dataPrograma = filtros.programas;
+        this.programaFiltro = this.dataPrograma[0];
+        this.dataEscuela = filtros.especialidades;
+        this.escuelaFiltro = this.dataEscuela[0];
+    }
+    async reporte(){}
 }

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/reporte-prestamo-mat-bibliografico.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/reporte-prestamo-mat-bibliografico.ts
@@ -16,6 +16,7 @@ import { PrestamosService } from '../../services/prestamos.service';
 import { DetallePrestamo  } from '../../interfaces/detalle-prestamo';
 import { Sedes            } from '../../interfaces/sedes';
 import { ClaseGeneral     } from '../../interfaces/clase-general';
+import { ReportesFiltroService } from '../../services/reportes-filtro.service';
 
 import * as ExcelJS from 'exceljs';
 import { saveAs } from 'file-saver';
@@ -155,19 +156,19 @@ import { HttpClient } from '@angular/common/http';
 export class ReportePrestamoMatBibliografico implements OnInit {
   titulo = 'Préstamo detallado de materiales bibliográficos';
 
-  dataSede: Sedes[]        = [];
+  dataSede: Sedes[]              = [];
   dataTipoUsuario: ClaseGeneral[] = [];
   dataEstado: ClaseGeneral[]     = [];
   dataEscuela: ClaseGeneral[]    = [];
   dataPrograma: ClaseGeneral[]   = [];
   dataCiclo: ClaseGeneral[]      = [];
 
-  sedeFiltro!:        number;
-  tipoUsuarioFiltro = '';
+  sedeFiltro:        Sedes        = new Sedes();
+  tipoUsuarioFiltro: ClaseGeneral = new ClaseGeneral();
   estadoFiltro!: number;
-  escuelaFiltro    = '';
-  programaFiltro   = '';
-  cicloFiltro      = '';
+  escuelaFiltro:    ClaseGeneral = new ClaseGeneral();
+  programaFiltro:   ClaseGeneral = new ClaseGeneral();
+  cicloFiltro:      ClaseGeneral = new ClaseGeneral();
 
   fechaInicio!: Date;
   fechaFin!:    Date;
@@ -183,14 +184,29 @@ export class ReportePrestamoMatBibliografico implements OnInit {
   tipoPrestamoFiltro: string | null = null;
 
       constructor(private svc: PrestamosService,
-                    private messageService: MessageService, private http: HttpClient) {}
+                    private messageService: MessageService,
+                    private http: HttpClient,
+                    private filtrosService: ReportesFiltroService) {}
 
       async ngOnInit() {
-        // aquí cargas combos (sedes, tipos, estados…)
-        // y preset de fechas, p.ej:
+        await this.cargarFiltros();
         this.fechaInicio = new Date();
         this.fechaFin    = new Date();
         await this.cargarEstados();
+      }
+
+      private async cargarFiltros() {
+        const filtros = await this.filtrosService.cargarFiltros();
+        this.dataSede = filtros.sedes;
+        this.sedeFiltro = this.dataSede[0];
+        this.dataTipoUsuario = filtros.tipoUsuarios;
+        this.tipoUsuarioFiltro = this.dataTipoUsuario[0];
+        this.dataEscuela = filtros.especialidades;
+        this.escuelaFiltro = this.dataEscuela[0];
+        this.dataPrograma = filtros.programas;
+        this.programaFiltro = this.dataPrograma[0];
+        this.dataCiclo = filtros.ciclos;
+        this.cicloFiltro = this.dataCiclo[0];
       }
 
 async reporte() {
@@ -206,12 +222,12 @@ async reporte() {
     // Forzamos un array vacío si la llamada devolviera undefined
     const data = (await this.svc
       .listar(
-        this.sedeFiltro,
-        this.tipoUsuarioFiltro,
+        this.sedeFiltro.id,
+        this.tipoUsuarioFiltro.id,
         estado,
-        this.escuelaFiltro,
-        this.programaFiltro,
-        this.cicloFiltro,
+        this.escuelaFiltro.id,
+        this.programaFiltro.id,
+        this.cicloFiltro.id,
         fi,
         ff
       )
@@ -235,15 +251,12 @@ async reporte() {
     }
 
   get sedeFiltroLabel(): string {
-    const s = this.dataSede.find(x => x.id === this.sedeFiltro);
-    return s ? s.descripcion : 'Todas';
+    return this.sedeFiltro?.descripcion ?? 'Todas';
   }
 
-get programaFiltroLabel(): string {
-  const idNumerico = Number(this.programaFiltro);
-  const p = this.dataPrograma.find(x => x.id === idNumerico);
-  return p ? p.descripcion : 'Todos';
-}
+  get programaFiltroLabel(): string {
+    return this.programaFiltro?.descripcion ?? 'Todos';
+  }
 
   async exportExcel() {
     if (!this.resultados.length) {

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/usotiempo-biblioteca.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/usotiempo-biblioteca.ts
@@ -7,6 +7,7 @@ import { Sedes } from '../../interfaces/sedes';
 import { ClaseGeneral } from '../../interfaces/clase-general';
 import { PrestamosService } from '../../services/prestamos.service';
 import { EquipoUsoTiempoDTO } from '../../interfaces/reportes/equipo-uso-tiempo';
+import { ReportesFiltroService } from '../../services/reportes-filtro.service';
 
 @Component({
     selector: 'app-reporte-usotiempo-biblioteca',
@@ -109,10 +110,23 @@ export class ReporteUsoTiempoBiblioteca {
 
     constructor(
         private svc: PrestamosService,
-        private messageService: MessageService
+        private messageService: MessageService,
+        private filtrosService: ReportesFiltroService
     ) {}
     async ngOnInit() {
+        await this.cargarFiltros();
         await this.reporte();
+    }
+    private async cargarFiltros() {
+        const filtros = await this.filtrosService.cargarFiltros();
+        this.dataSede = filtros.sedes;
+        this.sedeFiltro = this.dataSede[0];
+        this.dataTipoUsuario = filtros.tipoUsuarios;
+        this.tipoUsuarioFiltro = this.dataTipoUsuario[0];
+        this.dataCiclo = filtros.ciclos;
+        this.cicloFiltro = this.dataCiclo[0];
+        this.dataEscuela = filtros.especialidades;
+        this.escuelaFiltro = this.dataEscuela[0];
     }
     private formatDate(d?: Date): string | undefined {
         return d ? d.toISOString().split('T')[0] : undefined;

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/usuarios-atendidos-biblioteca.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/usuarios-atendidos-biblioteca.ts
@@ -12,6 +12,7 @@ import { jsPDF } from 'jspdf';
 import autoTable from 'jspdf-autotable';
 import * as ExcelJS from 'exceljs';
 import { saveAs } from 'file-saver';
+import { ReportesFiltroService } from '../../services/reportes-filtro.service';
 
 @Component({
     selector: 'app-reporte-usuarios-atendidos-biblioteca',
@@ -144,10 +145,27 @@ export class ReporteUsuariosAtendidosBiblioteca {
     constructor(
         private prestamosService: PrestamosService,
         private messageService: MessageService,
-        private http: HttpClient
+        private http: HttpClient,
+        private filtrosService: ReportesFiltroService
     ) {}
     async ngOnInit() {
+        await this.cargarFiltros();
         await this.reporte();
+    }
+    private async cargarFiltros() {
+        const filtros = await this.filtrosService.cargarFiltros();
+        this.dataSede = filtros.sedes;
+        this.sedeFiltro = this.dataSede[0];
+        this.dataPrograma = filtros.programas;
+        this.programaFiltro = this.dataPrograma[0];
+        this.dataTipoUsuario = filtros.tipoUsuarios;
+        this.tipoUsuarioFiltro = this.dataTipoUsuario[0];
+        this.dataTipoMaterial = filtros.tiposMaterial;
+        this.tipoMaterialFiltro = this.dataTipoMaterial[0];
+        this.dataEspecialidad = filtros.especialidades;
+        this.especialidadFiltro = this.dataEspecialidad[0];
+        this.dataCiclo = filtros.ciclos;
+        this.cicloFiltro = this.dataCiclo[0];
     }
     async reporte() {
         this.loading = true;

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/visitantes-biblioteca-virtual.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/visitantes-biblioteca-virtual.ts
@@ -7,6 +7,7 @@ import { Sedes } from '../../interfaces/sedes';
 import { ClaseGeneral } from '../../interfaces/clase-general';
 import { PrestamosService } from '../../services/prestamos.service';
 import { VisitanteBibliotecaVirtualDTO } from '../../interfaces/reportes/visitante-biblioteca-virtual';
+import { ReportesFiltroService } from '../../services/reportes-filtro.service';
 
 @Component({
     selector: 'app-reporte-visitantes-biblioteca',
@@ -131,9 +132,23 @@ export class ReporteVisitantesBibliotecaVirtual {
     loading: boolean = true;
     resultados: VisitanteBibliotecaVirtualDTO[] = [];
 
-    constructor(private svc: PrestamosService, private messageService: MessageService) {}
+    constructor(private svc: PrestamosService, private messageService: MessageService, private filtrosService: ReportesFiltroService) {}
     async ngOnInit() {
+        await this.cargarFiltros();
         await this.reporte();
+    }
+    private async cargarFiltros() {
+        const filtros = await this.filtrosService.cargarFiltros();
+        this.dataSede = filtros.sedes;
+        this.sedeFiltro = this.dataSede[0];
+        this.dataPrograma = filtros.programas;
+        this.programaFiltro = this.dataPrograma[0];
+        this.dataTipoUsuario = filtros.tipoUsuarios;
+        this.tipoUsuarioFiltro = this.dataTipoUsuario[0];
+        this.dataEscuela = filtros.especialidades;
+        this.escuelaFiltro = this.dataEscuela[0];
+        this.dataCiclo = filtros.ciclos;
+        this.cicloFiltro = this.dataCiclo[0];
     }
     async reporte() {
         this.loading = true;

--- a/Frontend/sakai-ng-master/src/app/biblioteca/services/prestamos.service.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/services/prestamos.service.ts
@@ -95,23 +95,23 @@ export class PrestamosService {
         });
     }
   listar(
-    sede?: number,
-    tipoUsuario?: string,
+    sede?: number | string,
+    tipoUsuario?: number | string,
     tipoPrestamo?: string,
-    escuela?: string,
-    programa?: string,
-    ciclo?: string,
+    escuela?: number | string,
+    programa?: number | string,
+    ciclo?: number | string,
     fechaInicio?: string,
     fechaFin?: string
   ): Observable<DetallePrestamo[]> {
     let params = new HttpParams();
 
-    if (sede != null)           params = params.set('sede', sede.toString());
-    if (tipoUsuario)            params = params.set('tipoUsuario', tipoUsuario);
+    if (sede != null)           params = params.set('sede', String(sede));
+    if (tipoUsuario != null)    params = params.set('tipoUsuario', String(tipoUsuario));
     if (tipoPrestamo)           params = params.set('estado', tipoPrestamo);
-    if (escuela)                params = params.set('escuela', escuela);
-    if (programa)               params = params.set('programa', programa);
-    if (ciclo)                  params = params.set('ciclo', ciclo);
+    if (escuela != null)        params = params.set('escuela', String(escuela));
+    if (programa != null)       params = params.set('programa', String(programa));
+    if (ciclo != null)          params = params.set('ciclo', String(ciclo));
     if (fechaInicio)            params = params.set('fechaInicio', fechaInicio);
     if (fechaFin)               params = params.set('fechaFin', fechaFin);
 

--- a/Frontend/sakai-ng-master/src/app/biblioteca/services/reportes-filtro.service.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/services/reportes-filtro.service.ts
@@ -1,0 +1,216 @@
+import { Injectable } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
+import { GenericoService } from './generico.service';
+import { MaterialBibliograficoService } from './material-bibliografico.service';
+import { AuthService } from './auth.service';
+import { Sedes } from '../interfaces/sedes';
+import { ClaseGeneral } from '../interfaces/clase-general';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ReportesFiltroService {
+  private cacheSedes: Sedes[] | null = null;
+  private cacheTipoMaterial: ClaseGeneral[] | null = null;
+  private cacheEspecialidad: ClaseGeneral[] | null = null;
+  private cachePrograma: ClaseGeneral[] | null = null;
+  private cacheCiclo: ClaseGeneral[] | null = null;
+  private cacheTipoUsuario: ClaseGeneral[] | null = null;
+
+  constructor(
+    private genericoService: GenericoService,
+    private materialService: MaterialBibliograficoService,
+    private authService: AuthService
+  ) {}
+
+  async getSedes(): Promise<Sedes[]> {
+    if (!this.cacheSedes) {
+      try {
+        const res: any = await firstValueFrom(
+          this.genericoService.sedes_get('sede/lista-activo')
+        );
+        const list = Array.isArray(res?.data)
+          ? res.data
+          : Array.isArray(res)
+            ? res
+            : [];
+        this.cacheSedes = [
+          new Sedes({ id: 0, descripcion: 'TODAS LAS SEDES', activo: true }),
+          ...list.map(
+            (s: any) =>
+              new Sedes({
+                id: s.idSede ?? s.id ?? s.codigo ?? 0,
+                descripcion:
+                  s.descripcion ?? s.nombre ?? s.descripcionSede ?? '',
+                activo: s.activo ?? true,
+              })
+          ),
+        ];
+      } catch {
+        this.cacheSedes = [
+          new Sedes({ id: 0, descripcion: 'TODAS LAS SEDES', activo: true }),
+        ];
+      }
+    }
+    return this.cacheSedes ?? [];
+  }
+
+  async getTiposMaterial(): Promise<ClaseGeneral[]> {
+    if (!this.cacheTipoMaterial) {
+      try {
+        const res: any = await firstValueFrom(
+          this.materialService.lista_tipo_material('catalogos/tipomaterial/activos')
+        );
+        const list = Array.isArray(res?.data)
+          ? res.data
+          : Array.isArray(res)
+            ? res
+            : [];
+        this.cacheTipoMaterial = [
+          new ClaseGeneral({ id: 0, descripcion: 'Todos', activo: true, estado: 1 }),
+          ...list.map(
+            (t: any) =>
+              new ClaseGeneral({
+                id: t.tipo?.id ?? t.id,
+                descripcion: t.descripcion,
+                activo: t.activo ?? true,
+                estado: 1,
+              })
+          ),
+        ];
+      } catch {
+        this.cacheTipoMaterial = [
+          new ClaseGeneral({ id: 0, descripcion: 'Todos', activo: true, estado: 1 }),
+        ];
+      }
+    }
+    return this.cacheTipoMaterial ?? [];
+  }
+
+  async getEspecialidades(): Promise<ClaseGeneral[]> {
+    if (!this.cacheEspecialidad) {
+      try {
+        const res: any[] = await firstValueFrom(this.authService.getEspecialidades());
+        this.cacheEspecialidad = [
+          new ClaseGeneral({ id: 0, descripcion: 'Todos', activo: true, estado: 1 }),
+          ...res.map(
+            (e) =>
+              new ClaseGeneral({
+                id: e.idEspecialidad,
+                descripcion: e.descripcion,
+                activo: true,
+                estado: 1,
+              })
+          ),
+        ];
+      } catch {
+        this.cacheEspecialidad = [
+          new ClaseGeneral({ id: 0, descripcion: 'Todos', activo: true, estado: 1 }),
+        ];
+      }
+    }
+    return this.cacheEspecialidad ?? [];
+  }
+
+  async getProgramas(): Promise<ClaseGeneral[]> {
+    if (!this.cachePrograma) {
+      try {
+        const res: any[] = await firstValueFrom(this.authService.getProgramas());
+        this.cachePrograma = [
+          new ClaseGeneral({ id: 0, descripcion: 'Todos', activo: true, estado: 1 }),
+          ...res.map(
+            (p) =>
+              new ClaseGeneral({
+                id: p.idPrograma,
+                descripcion: p.descripcion,
+                activo: true,
+                estado: 1,
+              })
+          ),
+        ];
+      } catch {
+        this.cachePrograma = [
+          new ClaseGeneral({ id: 0, descripcion: 'Todos', activo: true, estado: 1 }),
+        ];
+      }
+    }
+    return this.cachePrograma ?? [];
+  }
+
+  async getCiclos(): Promise<ClaseGeneral[]> {
+    if (!this.cacheCiclo) {
+      try {
+        const res: any = await firstValueFrom(
+          this.genericoService.tipo_get('catalogos/ciclos')
+        );
+        const list = Array.isArray(res?.data)
+          ? res.data
+          : Array.isArray(res)
+            ? res
+            : [];
+        this.cacheCiclo = [
+          new ClaseGeneral({ id: 0, descripcion: 'Todos', activo: true, estado: 1 }),
+          ...list.map(
+            (c: any) =>
+              new ClaseGeneral({
+                id: c.id ?? c.codigo ?? c.ciclo,
+                descripcion: c.descripcion ?? c.nombre ?? c.ciclo,
+                activo: true,
+                estado: 1,
+              })
+          ),
+        ];
+      } catch {
+        this.cacheCiclo = [
+          new ClaseGeneral({ id: 0, descripcion: 'Todos', activo: true, estado: 1 }),
+        ];
+      }
+    }
+    return this.cacheCiclo ?? [];
+  }
+
+  async getTiposUsuario(): Promise<ClaseGeneral[]> {
+    if (!this.cacheTipoUsuario) {
+      try {
+        const res: any = await firstValueFrom(
+          this.genericoService.roles_get('roles/lista-roles')
+        );
+        const list = Array.isArray(res?.data)
+          ? res.data
+          : Array.isArray(res)
+            ? res
+            : [];
+        this.cacheTipoUsuario = [
+          new ClaseGeneral({ id: 0, descripcion: 'Todos', activo: true, estado: 1 }),
+          ...list.map(
+            (r: any) =>
+              new ClaseGeneral({
+                id: r.idRol ?? r.id ?? r.codigo,
+                descripcion: r.descripcion,
+                activo: r.activo ?? true,
+                estado: 1,
+              })
+          ),
+        ];
+      } catch {
+        this.cacheTipoUsuario = [
+          new ClaseGeneral({ id: 0, descripcion: 'Todos', activo: true, estado: 1 }),
+        ];
+      }
+    }
+    return this.cacheTipoUsuario ?? [];
+  }
+
+  async cargarFiltros(): Promise<{ sedes: Sedes[]; tiposMaterial: ClaseGeneral[]; especialidades: ClaseGeneral[]; programas: ClaseGeneral[]; ciclos: ClaseGeneral[]; tipoUsuarios: ClaseGeneral[] }> {
+    const [sedes, tiposMaterial, especialidades, programas, ciclos, tipoUsuarios] = await Promise.all([
+      this.getSedes(),
+      this.getTiposMaterial(),
+      this.getEspecialidades(),
+      this.getProgramas(),
+      this.getCiclos(),
+      this.getTiposUsuario()
+    ]);
+    return { sedes, tiposMaterial, especialidades, programas, ciclos, tipoUsuarios };
+  }
+}
+


### PR DESCRIPTION
## Summary
- agregar servicio de filtros para reportes
- precargar combos en módulos de reportes
- corregir asignaciones de filtros por id
- ajustar filtros en reportes de préstamos para usar objetos y enviar solo IDs
- enviar IDs numéricos en llamadas de reportes
- incluir listado de tipos de usuario en el servicio de filtros y poblar los combos correspondientes
- permitir IDs numéricos o de texto en el servicio de préstamos
- manejar errores al cargar filtros de reportes y agregar opción por defecto "Todos" a cada listado
- transformar la respuesta de sedes a objetos `Sedes` para que se carguen todas las sedes registradas
- corregir ruta de servicio para obtener sedes
- exponer endpoint `/auth/sede/lista-activo` en el backend y habilitarlo en la configuración de seguridad

## Testing
- `npm run build`
- `npm test` *(falla: error TS18003: No inputs were found in config file 'tsconfig.spec.json')*
- `mvn -q test` *(falla: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bea02e3be08329999961400bdc62b4