### PR TITLE
feat: permitir seleccionar rol en login de Microsoft

### DIFF
--- a/Backend/login-microsoft365/src/main/java/com/miapp/controller/AuthController.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/controller/AuthController.java
@@ -96,6 +96,7 @@ public class AuthController {
     @PostMapping("/login-microsoft")
     public ResponseEntity<?> loginMicrosoft(@RequestBody Map<String, String> request) {
         String microsoftToken = request.get("token");
+        String requestedRole = request.get("role");
         Map<String, String> datosMicrosoft = usuarioService.validarYExtraerDatosMicrosoft(microsoftToken);
 
         if (datosMicrosoft == null) {
@@ -118,9 +119,27 @@ public class AuthController {
         }
 
         Usuario usuario = usuarioOpt.get();
-        String rolDescripcion = usuario.getRoles().isEmpty()
-                ? "Sin Rol"
-                : usuario.getRoles().iterator().next().getDescripcion();
+
+        String rolDescripcion;
+        if (requestedRole != null && !requestedRole.isBlank()) {
+            boolean hasRole = usuario.getRoles().stream()
+                    .anyMatch(r -> r.getDescripcion().equalsIgnoreCase(requestedRole));
+            if (!hasRole) {
+                return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                        .body(Map.of("message", "Rol no autorizado"));
+            }
+            rolDescripcion = requestedRole;
+        } else {
+            rolDescripcion = usuario.getRoles().stream()
+                    .filter(r -> r.getDescripcion().equalsIgnoreCase("ESTUDIANTE"))
+                    .findFirst()
+                    .map(Rol::getDescripcion)
+                    .orElseGet(() -> usuario.getRoles().stream()
+                            .findFirst()
+                            .map(Rol::getDescripcion)
+                            .orElse("Sin Rol"));
+        }
+
         usuarioService.incrementarContadorLogins(usuario.getLogin());
         String jwt = jwtUtil.generateToken(usuario.getEmail(), rolDescripcion);
 

--- a/Frontend/sakai-ng-master/src/app/biblioteca/services/auth.service.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/services/auth.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { BehaviorSubject, Observable, of, forkJoin } from 'rxjs';
-import { map, tap } from 'rxjs/operators';
+import { map, tap, switchMap } from 'rxjs/operators';
 import { JwtHelperService } from "@auth0/angular-jwt";
 import { Router } from '@angular/router';
 import * as _ from 'lodash';
@@ -227,60 +227,54 @@ export class AuthService {
 //     return this.http.post<LoginResponse>(`${this.apiUrl}/login-microsoft`, { token: msToken });
 // }
 
-loginMicrosoft() {
-    // Limpia la cuenta activa para evitar reutilizar sesiones previas
-    this.msalService.instance.setActiveAccount(null);
-    this.msalService.loginPopup({ prompt: 'select_account', scopes: ['user.read'] }).subscribe({
-      next: (result: AuthenticationResult) => {
-        console.log('Inicio de sesión exitoso', result);
-        // Establece la cuenta activa y continúa con la obtención del token
+getMicrosoftToken(): Observable<{ email: string; token: string }> {
+    const scopes = ['user.read'];
+    const active = this.msalService.instance.getActiveAccount();
+
+    if (active) {
+      return this.msalService.acquireTokenSilent({ account: active, scopes }).pipe(
+        map(res => ({ email: active.username || '', token: res.accessToken })),
+        catchError(() =>
+          this.msalService.acquireTokenPopup({ scopes }).pipe(
+            map(r => ({ email: r.account?.username || '', token: r.accessToken }))
+          )
+        )
+      );
+    }
+
+    return this.msalService.loginPopup({ prompt: 'select_account', scopes }).pipe(
+      map((result: AuthenticationResult) => {
         this.msalService.instance.setActiveAccount(result.account);
-        this.msalService.acquireTokenSilent({ scopes: ['user.read'] })
-          .pipe(
-            catchError(error => {
-              // Si el token silencioso falla, intenta obtener el token con un popup
-              return this.msalService.acquireTokenPopup({ scopes: ['user.read'] });
-            })
-          ).subscribe({
-            next: (tokenResponse) => {
-              console.log('Token de Microsoft:', tokenResponse.accessToken);
-              this.http.post<LoginResponse>(`${this.apiUrl}/login-microsoft`, { token: tokenResponse.accessToken })
-                .subscribe({
-                  next: (backendResponse) => {
-                    if (backendResponse.token) {
-                      this.setAuthentication(backendResponse.token);
-                      this.currentUserSubject.next(this.getUser());
-                      this.openPendingResource();
-                      this.router.navigate(['/main']);
-                    }
-                  },
-                  error: (error) => {
-                    console.error('Error en autenticación con backend:', error);
-                    if (error.status === 404 && error.error?.email) {
-                      localStorage.setItem('msUserData', JSON.stringify(error.error));
-                      this.router.navigate(['/registrate'], { state: { notRegistered: true } });
-                    } else {
-                      // Cierra el popup (MSAL lo debería cerrar automáticamente) y muestra tu alerta
-                      alert(this.obtenerMensajeError(error));
-                    }
-                  }
-                });
-            },
-            error: (error) => {
-              console.error('Error obteniendo el token de Microsoft:', error);
-              alert(this.obtenerMensajeError(error));
-            },
-          });
-      },
-      error: (error) => {
-        console.error('Error en la autenticación con Microsoft:', error);
-        alert(this.obtenerMensajeError(error));
-      },
-    });
+        return { email: result.account?.username || '', token: result.accessToken };
+      })
+    );
+  }
+
+loginMicrosoft(msToken: string, role: string): void {
+    this.http.post<LoginResponse>(`${this.apiUrl}/login-microsoft`, { token: msToken, role })
+      .subscribe({
+        next: (backendResponse) => {
+          if (backendResponse.token) {
+            this.setAuthentication(backendResponse.token);
+            this.currentUserSubject.next(this.getUser());
+            this.openPendingResource();
+            this.router.navigate(['/main']);
+          }
+        },
+        error: (error) => {
+          console.error('Error en autenticación con backend:', error);
+          if (error.status === 404 && error.error?.email) {
+            localStorage.setItem('msUserData', JSON.stringify(error.error));
+            this.router.navigate(['/registrate'], { state: { notRegistered: true } });
+          } else {
+            alert(this.obtenerMensajeError(error));
+          }
+        }
+      });
   }
 
   // Método para personalizar el mensaje de error
-  private obtenerMensajeError(error: any): string {
+  public obtenerMensajeError(error: any): string {
     const errorMessage =
       error?.error?.message || error?.error || error?.message || error.toString();
     if (typeof errorMessage === 'string' && errorMessage.includes('AADSTS50020')) {
@@ -412,13 +406,9 @@ private resetInactivityTimer(): void {
     localStorage.removeItem(this.TOKEN_NAME);
     localStorage.removeItem(this.REFRESH_NAME);
     this.currentUserSubject.next({} as Usuario);
-    const activeAccount = this.msalService.instance.getActiveAccount();
-    if (activeAccount) {
-      this.msalService.logoutPopup({ mainWindowRedirectUri: '/auth/login' }).subscribe();
-    } else {
-      this.router.navigate(['/auth/login']);
-    }
-    return;
+    this.msalService.instance.setActiveAccount(null);
+    void this.msalService.instance.clearCache();
+    this.router.navigate(['/auth/login']);
   }
 
   refreshAccessToken(): Observable<string> {

--- a/Frontend/sakai-ng-master/src/app/pages/auth/login.ts
+++ b/Frontend/sakai-ng-master/src/app/pages/auth/login.ts
@@ -6,6 +6,7 @@ import { CheckboxModule } from 'primeng/checkbox';
 import { InputTextModule } from 'primeng/inputtext';
 import { PasswordModule } from 'primeng/password';
 import { DropdownModule } from 'primeng/dropdown';
+import { DialogModule } from 'primeng/dialog';
 import { RippleModule } from 'primeng/ripple';
 import { AppFloatingConfigurator } from '../../layout/component/app.floatingconfigurator';
 import { AuthService } from '../../biblioteca/services/auth.service';
@@ -25,6 +26,7 @@ export interface LoginCredentials {
     InputTextModule,
     PasswordModule,
     DropdownModule,
+    DialogModule,
     FormsModule,
     RouterModule,
     RippleModule,
@@ -32,6 +34,18 @@ export interface LoginCredentials {
   ],
   template: `
     <app-floating-configurator />
+    <p-dialog header="Selecciona el tipo de usuario" [(visible)]="roleDialogVisible" [modal]="true" [closable]="false">
+      <p-dropdown
+        [options]="userRoles"
+        optionLabel="label"
+        optionValue="value"
+        [(ngModel)]="credentials.role"
+        appendTo="body"
+      ></p-dropdown>
+      <div class="flex justify-end mt-4">
+        <p-button label="Continuar" (click)="confirmRoleSelection()"></p-button>
+      </div>
+    </p-dialog>
     <div class="bg-surface-50 dark:bg-surface-950 flex items-center justify-center min-h-screen min-w-[100vw] overflow-hidden">
       <div class="flex flex-col items-center justify-center">
         <div style="border-radius: 56px; padding: 0.3rem; background: linear-gradient(180deg, var(--primary-color) 10%, rgba(33, 150, 243, 0) 30%)">
@@ -56,7 +70,17 @@ export interface LoginCredentials {
               <p-password id="password" [(ngModel)]="credentials.password" placeholder="Contraseña" [toggleMask]="true" styleClass="mb-4" [fluid]="true" [feedback]="false"></p-password>
 
               <label for="role" class="block text-surface-900 dark:text-surface-0 font-medium text-xl mb-2">Tipo de usuario</label>
-              <p-dropdown id="role" [options]="userRoles" optionLabel="label" optionValue="value" [(ngModel)]="credentials.role" placeholder="Seleccione un rol" class="w-full md:w-[30rem] mb-4" [disabled]="roleDisabled"></p-dropdown>
+              <p-dropdown
+                id="role"
+                [options]="userRoles"
+                optionLabel="label"
+                optionValue="value"
+                [(ngModel)]="credentials.role"
+                placeholder="Seleccione un rol"
+                class="w-full md:w-[30rem] mb-4"
+                [disabled]="roleDisabled"
+                appendTo="body"
+              ></p-dropdown>
 
               <div class="flex items-center justify-between mt-2 mb-8 gap-8">
                 <div class="flex items-center">
@@ -78,11 +102,48 @@ export class Login implements OnInit {
   userRoles: { label: string; value: string }[] = [];
   roleDisabled = true;
   credentials: LoginCredentials = { email: '', password: '', role: '' };
+  roleDialogVisible = false;
+  msToken: string = '';
 
   constructor(private authService: AuthService, private router: Router) {}
 
   loginWithMicrosoft() {
-    this.authService.loginMicrosoft();
+    this.authService.getMicrosoftToken().subscribe({
+      next: ({ email, token }) => {
+        this.msToken = token;
+        this.authService.getRolesByEmail(email).subscribe({
+          next: roles => {
+            this.userRoles = roles.length ? roles : [{ label: 'ESTUDIANTE', value: 'ESTUDIANTE' }];
+            if (this.userRoles.length > 1) {
+              this.credentials.role = this.userRoles[0].value;
+              this.roleDialogVisible = true;
+            } else {
+              this.credentials.role = this.userRoles[0].value;
+              this.finishMicrosoftLogin();
+            }
+          },
+          error: () => {
+            this.userRoles = [{ label: 'ESTUDIANTE', value: 'ESTUDIANTE' }];
+            this.credentials.role = 'ESTUDIANTE';
+            this.finishMicrosoftLogin();
+          }
+        });
+      },
+      error: (error) => {
+        console.error('Error en la autenticación con Microsoft:', error);
+        alert(this.authService.obtenerMensajeError(error));
+      },
+    });
+  }
+
+  confirmRoleSelection() {
+    this.roleDialogVisible = false;
+    this.finishMicrosoftLogin();
+  }
+
+  private finishMicrosoftLogin() {
+    const role = this.credentials.role || 'ESTUDIANTE';
+    this.authService.loginMicrosoft(this.msToken, role);
   }
 
   ngOnInit(): void {


### PR DESCRIPTION
## Summary
- Permitir indicar rol deseado al autenticarse con Microsoft y validar que pertenezca al usuario
- Obtener token de Microsoft, mostrar selección de rol y completar login desde el frontend
- Agregar diálogo para elegir tipo de usuario cuando existan múltiples roles
- Evitar que el selector de rol dentro del diálogo se recorte anexando su desplegable al `body`
- Optimizar el flujo de autenticación y cierre de sesión con Microsoft para reducir tiempos de carga
- Limpiar la caché de cuentas de MSAL al cerrar sesión

## Testing
- `npm run build`
- `npm test --silent` *(falló: error TS18003: No inputs were found en tsconfig.spec.json)*
- `mvn -q test` *(falló: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68befe8dfc9c8329b81fa42be6cfdb80