### PR TITLE
feat: filtrar préstamos bibliográficos

### DIFF
--- a/Backend/login-microsoft365/src/main/java/com/miapp/controller/BibliotecaController.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/controller/BibliotecaController.java
@@ -193,10 +193,28 @@ public class BibliotecaController {
 
 
 
-    /** Lista los ejemplares prestados (idEstado = 4) */
+    /** Lista los ejemplares prestados filtrando por los parámetros indicados */
     @GetMapping("/prestados")
-    public ResponseEntity<?> listPrestados() {
-        List<DetalleBibliotecaDTO> dtos = detalleService.findDetallesPrestados();
+    public ResponseEntity<?> listPrestados(
+            @RequestParam(value = "fechaPrestamoInicio", required = false) String fechaInicio,
+            @RequestParam(value = "fechaPrestamoFin",    required = false) String fechaFin,
+            @RequestParam(value = "sede",                required = false) Long sedeId,
+            @RequestParam(value = "tipoUsuario",         required = false) Long tipoUsuarioId,
+            @RequestParam(value = "estado",              required = false) String tipoPrestamo,
+            @RequestParam(value = "escuela",             required = false) Long escuelaId,
+            @RequestParam(value = "programa",            required = false) Long programaId,
+            @RequestParam(value = "ciclo",               required = false) String ciclo) {
+
+        List<DetalleBibliotecaDTO> dtos = detalleService.findDetallesPrestados(
+                fechaInicio,
+                fechaFin,
+                sedeId,
+                tipoUsuarioId,
+                tipoPrestamo,
+                escuelaId,
+                programaId,
+                ciclo
+        );
         return ResponseEntity.ok(Map.of("status", 0, "data", dtos));
     }
 

--- a/Backend/login-microsoft365/src/main/java/com/miapp/repository/DetalleBibliotecaRepository.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/repository/DetalleBibliotecaRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -30,6 +31,18 @@ public interface DetalleBibliotecaRepository extends JpaRepository<DetalleBiblio
             "     JOIN FETCH d.biblioteca b " +
             "WHERE d.idEstado = 3")
     List<DetalleBiblioteca> findAllConBibliotecaReservados();
+
+    @Query("""
+            SELECT d
+            FROM DetalleBiblioteca d
+                LEFT JOIN FETCH d.biblioteca b
+                LEFT JOIN FETCH d.sede s
+            WHERE d.fechaPrestamo IS NOT NULL
+              AND (:inicio IS NULL OR d.fechaPrestamo >= :inicio)
+              AND (:fin IS NULL OR d.fechaPrestamo <= :fin)
+            """)
+    List<DetalleBiblioteca> findPrestadosBetween(@Param("inicio") LocalDateTime inicio,
+                                                 @Param("fin") LocalDateTime fin);
 
     /**
      * Retorna el primer detalle que coincida con el número de ingreso indicado.

--- a/Backend/login-microsoft365/src/main/java/com/miapp/service/DetalleBibliotecaService.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/service/DetalleBibliotecaService.java
@@ -13,6 +13,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
 import java.util.AbstractMap;
 import java.util.List;
 import java.util.Optional;
@@ -103,11 +107,70 @@ public class DetalleBibliotecaService {
         };
     }
 
-    /** Devuelve los detalles en estado prestado (idEstado = 4) */
-    public List<DetalleBibliotecaDTO> findDetallesPrestados() {
-        List<DetalleBiblioteca> lista = detalleBibliotecaRepository.findByIdEstado(4L);
-        return lista.stream()
-                .map(mapper::toDetalleDto)
+    /**
+     * Devuelve los detalles prestados filtrando opcionalmente por sede, usuario y otros criterios.
+     */
+    public List<DetalleBibliotecaDTO> findDetallesPrestados(
+            String fechaInicio,
+            String fechaFin,
+            Long sedeId,
+            Long tipoUsuarioId,
+            String tipoPrestamo,
+            Long escuelaId,
+            Long programaId,
+            String ciclo) {
+
+        LocalDateTime inicio = null;
+        LocalDateTime fin    = null;
+        DateTimeFormatter fmt = DateTimeFormatter.ofPattern("dd/MM/yyyy");
+        try {
+            if (fechaInicio != null && !fechaInicio.isBlank()) {
+                inicio = LocalDate.parse(fechaInicio, fmt).atStartOfDay();
+            }
+            if (fechaFin != null && !fechaFin.isBlank()) {
+                fin = LocalDate.parse(fechaFin, fmt).atTime(LocalTime.MAX);
+            }
+        } catch (Exception ignored) {
+        }
+
+        String tipoNormalizado = normalizeTipoPrestamo(tipoPrestamo);
+
+        return detalleBibliotecaRepository.findPrestadosBetween(inicio, fin).stream()
+                // Filtra por sede del detalle
+                .filter(det -> sedeId == null || (det.getSede() != null && sedeId.equals(det.getSede().getId())))
+                // Filtra por tipo de préstamo si corresponde
+                .filter(det -> tipoNormalizado == null ||
+                        tipoNormalizado.equalsIgnoreCase(normalizeTipoPrestamo(det.getTipoPrestamo())))
+                // Asocia usuario para aplicar filtros adicionales
+                .map(det -> new AbstractMap.SimpleEntry<>(det,
+                        usuarioRepository.findByLoginIgnoreCase(det.getCodigoUsuario())))
+                .filter(entry -> {
+                    Usuario u = entry.getValue().orElse(null);
+                    if (tipoUsuarioId != null) {
+                        if (u == null || u.getRoles().stream().noneMatch(r -> r.getIdRol().equals(tipoUsuarioId))) {
+                            return false;
+                        }
+                    }
+                    if (escuelaId != null) {
+                        if (u == null || u.getEspecialidad() == null ||
+                                !u.getEspecialidad().getIdEspecialidad().equals(escuelaId)) {
+                            return false;
+                        }
+                    }
+                    if (programaId != null) {
+                        if (u == null || u.getPrograma() == null ||
+                                !u.getPrograma().getIdPrograma().equals(programaId)) {
+                            return false;
+                        }
+                    }
+                    if (ciclo != null && !ciclo.isBlank()) {
+                        if (u == null || u.getCiclo() == null || !u.getCiclo().equalsIgnoreCase(ciclo)) {
+                            return false;
+                        }
+                    }
+                    return true;
+                })
+                .map(entry -> mapper.toDetalleDto(entry.getKey()))
                 .collect(Collectors.toList());
     }
 

--- a/Frontend/sakai-ng-master/src/app/biblioteca/interfaces/detalle-prestamo.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/interfaces/detalle-prestamo.ts
@@ -1,26 +1,37 @@
-import { Equipo } from './biblioteca-virtual/equipo';
 export interface DetallePrestamo {
   id: number;
-  alcance: string;
-  usuario: string;
-  especialidad: string;
-  equipo: {
-      idEquipo: number; nombreEquipo: string; ip: string;
+  alcance?: string;
+  usuario?: string;
+  especialidad?: string;
+  equipo?: {
+    idEquipo: number;
+    nombreEquipo: string;
+    ip: string;
     sede: {
       descripcion: string;
     };
   };
-    material?: {
-      /** Título o nombre del material */
-      titulo: string;
+  material?: {
+    /** Título o nombre del material */
+    titulo?: string;
+    /** Número de ingreso del material */
+    numeroIngreso?: string;
+    /** Especialidad asociada al material */
+    especialidad?: {
+      descripcion: string;
     };
+  };
+  titulo?: string;
+  numeroIngreso?: string;
   usuarioPrestamo: string;
   codigoUsuario: string;
+  /** Código de sede cuando no se incluye información de equipo */
+  codigoSede?: string;
   tipoPrestamo: string;
   fechaPrestamo: string;
   usuarioRecepcion?: string;
   fechaRecepcion?: string;
-    estado?: {
-      descripcion: string;
-    };
+  estado?: {
+    descripcion: string;
+  };
 }

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/laboratorio-computo/modal-nuevo-ocurrencia.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/laboratorio-computo/modal-nuevo-ocurrencia.ts
@@ -381,10 +381,10 @@ openForEdit(ocurrencia: OcurrenciaDTO) {
 
         // Tabla de materiales:
         this.materiales = [{
-          codigoEquipo: dp.equipo.idEquipo!,
-          nombre: dp.equipo.nombreEquipo!,
+          codigoEquipo: dp.equipo!.idEquipo!,
+          nombre: dp.equipo!.nombreEquipo!,
           cantidad: 1,
-          ip: dp.equipo.ip!
+          ip: dp.equipo!.ip!
         }];
       });
   } else if (ocurrencia.idDetalleBiblioteca) {

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/reporte-prestamo-equipo-computo.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/reporte-prestamo-equipo-computo.ts
@@ -361,12 +361,12 @@ async reporte() {
       ]],
       body: this.resultados.map(r => [
         r.equipo?.nombreEquipo ?? '',
-        r.alcance,
+        r.alcance ?? '',
         r.codigoUsuario ?? r.usuarioPrestamo ?? '',
-        r.especialidad,
+        r.especialidad ?? '',
         r.equipo?.sede?.descripcion ?? '',
-        r.usuarioPrestamo,
-        r.fechaPrestamo,
+        r.usuarioPrestamo ?? '',
+        r.fechaPrestamo ?? '',
         r.usuarioRecepcion || '-',
         r.fechaRecepcion || '-'
       ]),

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/reporte-prestamo-mat-bibliografico.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/reporte-prestamo-mat-bibliografico.ts
@@ -124,7 +124,7 @@ import { HttpClient } from '@angular/common/http';
       <ng-template pTemplate="header">
         <tr>
           <th>Material</th>
-          <th>Alcance</th>
+          <th>N° Ingreso</th>
           <th>Usuario</th>
           <th>Especialidad</th>
           <th>Sede</th>
@@ -136,11 +136,11 @@ import { HttpClient } from '@angular/common/http';
       </ng-template>
       <ng-template pTemplate="body" let-row>
         <tr>
-          <td>{{ row.material?.titulo }}</td>
-          <td>{{ row.alcance }}</td>
+          <td>{{ row.material?.titulo ?? row.titulo }}</td>
+          <td>{{ row.material?.numeroIngreso ?? row.numeroIngreso }}</td>
           <td>{{ row.codigoUsuario }}</td>
-          <td>{{ row.especialidad }}</td>
-          <td>{{ row.equipo?.sede?.descripcion }}</td>
+          <td>{{ row.material?.especialidad?.descripcion ?? row.especialidad }}</td>
+          <td>{{ row.equipo?.sede?.descripcion ?? row.codigoSede }}</td>
           <td>{{ row.usuarioPrestamo }}</td>
           <td>{{ row.fechaPrestamo | date:'dd/MM/yyyy HH:mm' }}</td>
           <td>{{ row.usuarioRecepcion || '-' }}</td>
@@ -190,7 +190,6 @@ export class ReportePrestamoMatBibliografico implements OnInit {
       async ngOnInit() {
         await this.cargarFiltros();
         await this.cargarEstados();
-        await this.reporte();
       }
 
       private async cargarFiltros() {
@@ -203,21 +202,21 @@ export class ReportePrestamoMatBibliografico implements OnInit {
       }
 
 async reporte() {
+  if (!this.fechaInicio || !this.fechaFin) {
+    this.messageService.add({ severity: 'warn', detail: 'Seleccione fecha inicio y fin.' });
+    return;
+  }
+
   this.loading = true;
 
   const pad = (n: number) => n.toString().padStart(2, '0');
-  const fi = this.fechaInicio
-    ? `${pad(this.fechaInicio.getDate())}/${pad(this.fechaInicio.getMonth()+1)}/${this.fechaInicio.getFullYear()}`
-    : undefined;
-  const ff = this.fechaFin
-    ? `${pad(this.fechaFin.getDate())}/${pad(this.fechaFin.getMonth()+1)}/${this.fechaFin.getFullYear()}`
-    : undefined;
+  const fi = `${pad(this.fechaInicio.getDate())}/${pad(this.fechaInicio.getMonth()+1)}/${this.fechaInicio.getFullYear()}`;
+  const ff = `${pad(this.fechaFin.getDate())}/${pad(this.fechaFin.getMonth()+1)}/${this.fechaFin.getFullYear()}`;
   const estado = this.tipoPrestamoFiltro ?? undefined;
 
   try {
-    // Forzamos un array vacío si la llamada devolviera undefined
     const data = (await this.svc
-      .listar(
+      .listarMaterialesPrestados(
         this.sedeFiltro?.id,
         this.tipoUsuarioFiltro?.id,
         estado,
@@ -225,8 +224,7 @@ async reporte() {
         this.programaFiltro?.id,
         this.cicloFiltro?.id,
         fi,
-        ff,
-        'materiales'
+        ff
       )
       .toPromise()) ?? [];
 
@@ -292,7 +290,7 @@ async reporte() {
     // …
 
     // 4) Encabezados de la tabla
-    const headerRow = ws.addRow([ 'Material', 'Alcance', 'Usuario', 'Especialidad',
+    const headerRow = ws.addRow([ 'Material', 'N° Ingreso', 'Usuario', 'Especialidad',
                                                 'Sede', 'Usuario Préstamo', 'Fecha Préstamo',
                                                 'Usuario Recepción', 'Fecha Recepción' ]);
     headerRow.font = { bold: true };
@@ -301,11 +299,11 @@ async reporte() {
     // 5) Filas de datos
     this.resultados.forEach(r => {
       ws.addRow([
-        r.material?.titulo ?? '',
-        r.alcance,
+        r.material?.titulo ?? r.titulo ?? '',
+        r.material?.numeroIngreso ?? r.numeroIngreso ?? '',
         r.codigoUsuario ?? r.usuarioPrestamo ?? '',
-        r.especialidad,
-        r.equipo?.sede?.descripcion ?? '',
+        r.material?.especialidad?.descripcion ?? r.especialidad ?? '',
+        r.equipo?.sede?.descripcion ?? r.codigoSede ?? '',
         r.usuarioPrestamo,
         r.fechaPrestamo,
         r.usuarioRecepcion || '-',
@@ -353,16 +351,16 @@ async reporte() {
     // 5) Generar la tabla con autoTable
     autoTable(doc, {
       head: [[
-        'Material', 'Alcance', 'Usuario', 'Especialidad',
+        'Material', 'N° Ingreso', 'Usuario', 'Especialidad',
         'Sede', 'Usuario Préstamo', 'Fecha Préstamo',
         'Usuario Recepción', 'Fecha Recepción'
       ]],
       body: this.resultados.map(r => [
-        r.material?.titulo ?? '',
-        r.alcance,
+        r.material?.titulo ?? r.titulo ?? '',
+        r.material?.numeroIngreso ?? r.numeroIngreso ?? '',
         r.codigoUsuario ?? r.usuarioPrestamo ?? '',
-        r.especialidad,
-        r.equipo?.sede?.descripcion ?? '',
+        r.material?.especialidad?.descripcion ?? r.especialidad ?? '',
+        r.equipo?.sede?.descripcion ?? r.codigoSede ?? '',
         r.usuarioPrestamo,
         r.fechaPrestamo,
         r.usuarioRecepcion || '-',

--- a/Frontend/sakai-ng-master/src/app/biblioteca/services/prestamos.service.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/services/prestamos.service.ts
@@ -1,11 +1,11 @@
 import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Observable } from 'rxjs';
+import { Observable, of } from 'rxjs';
 import { AuthService } from './auth.service';
 import { environment } from '../../../environments/environment';
 import { Notificacion } from '../interfaces/notificacion';
 import { DetallePrestamo } from '../interfaces/detalle-prestamo';
-import { map } from 'rxjs/operators';
+import { map, catchError } from 'rxjs/operators';
 import { UsuarioPrestamosDTO } from '../interfaces/reportes/usuario-prestamos';
 import { EquipoUsoTiempoDTO } from '../interfaces/reportes/equipo-uso-tiempo';
 import { UsuarioPrestamosEquipoDTO } from '../interfaces/reportes/usuario-prestamos-equipo';
@@ -94,7 +94,7 @@ export class PrestamosService {
             headers: new HttpHeaders().set('Authorization', `Bearer ${this.authService.getToken()}`)
         });
     }
-  listar(
+  public listar(
     sede?: number | string,
     tipoUsuario?: number | string,
     tipoPrestamo?: string,
@@ -119,13 +119,85 @@ export class PrestamosService {
     agregarParam('escuela', escuela);
     agregarParam('programa', programa);
     agregarParam('ciclo', ciclo);
-    if (fechaInicio)            params = params.set('fechaPrestamoInicio', fechaInicio);
-    if (fechaFin)               params = params.set('fechaPrestamoFin', fechaFin);
+    if (fechaInicio)            params = params.set('fechaInicio', fechaInicio);
+    if (fechaFin)               params = params.set('fechaFin', fechaFin);
 
-    const endpoint = `${this.apiUrl}/api/prestamos/reporte/${tipo}`;
+    const endpoint = `${this.apiUrl}/api/prestamos/reporte`;
     return this.http
-      .get<{ status: string; data: DetallePrestamo[] }>(endpoint, { params })
-      .pipe(map(resp => resp.data ?? []));
+      .get<{ status: string; data: DetallePrestamo[] }>(endpoint, {
+        params,
+        headers: new HttpHeaders().set(
+          'Authorization',
+          `Bearer ${this.authService.getToken()}`
+        ),
+      })
+      .pipe(
+        map((resp) => {
+          const data = resp.data ?? [];
+          return tipo === 'materiales'
+            ? data.filter((d) => !d.equipo)
+            : data.filter((d) => d.equipo);
+        })
+      );
+  }
+
+  public listarMaterialesPrestados(
+    sede?: number | string,
+    tipoUsuario?: number | string,
+    tipoPrestamo?: string,
+    escuela?: number | string,
+    programa?: number | string,
+    ciclo?: number | string,
+    fechaInicio?: string,
+    fechaFin?: string
+  ): Observable<DetallePrestamo[]> {
+    let params = new HttpParams();
+
+    const agregarParam = (clave: string, valor?: number | string | null) => {
+      if (valor != null && valor !== 0 && valor !== '0') {
+        params = params.set(clave, String(valor));
+      }
+    };
+
+    agregarParam('sede', sede);
+    agregarParam('tipoUsuario', tipoUsuario);
+    agregarParam('estado', tipoPrestamo);
+    agregarParam('escuela', escuela);
+    agregarParam('programa', programa);
+    agregarParam('ciclo', ciclo);
+    if (fechaInicio) params = params.set('fechaPrestamoInicio', fechaInicio);
+    if (fechaFin) params = params.set('fechaPrestamoFin', fechaFin);
+
+    return this.http
+      .get<{ status: string; data: any[] }>(`${this.apiUrl}/api/biblioteca/prestados`, {
+        params,
+        headers: new HttpHeaders().set(
+          'Authorization',
+          `Bearer ${this.authService.getToken()}`
+        ),
+      })
+      .pipe(
+        map((resp) =>
+          (resp.data ?? []).map((d: any) => ({
+            id: d.idDetalleBiblioteca,
+            material: {
+              titulo: d.biblioteca?.titulo,
+              numeroIngreso: d.numeroIngreso != null ? String(d.numeroIngreso) : undefined,
+              especialidad: { descripcion: d.biblioteca?.especialidadDescripcion ?? '' },
+            },
+            titulo: d.biblioteca?.titulo,
+            numeroIngreso: d.numeroIngreso != null ? String(d.numeroIngreso) : undefined,
+            codigoUsuario: d.codigoUsuario,
+            codigoSede: d.sede?.descripcion ?? d.codigoSede,
+            tipoPrestamo: d.tipoPrestamo,
+            fechaPrestamo: d.fechaPrestamo,
+            usuarioPrestamo: d.usuarioPrestamo,
+            usuarioRecepcion: d.usuarioRecepcion,
+            fechaRecepcion: d.fechaDevolucion,
+          }))
+        ),
+        catchError(() => of<DetallePrestamo[]>([]))
+      );
   }
 
   listarEstados(): Observable<any> {


### PR DESCRIPTION
## Summary
- permitir filtrar préstamos bibliográficos por sede, tipo de usuario, estado, escuela y programa
- aplicar filtros en el servicio usando información del usuario asociado al préstamo

## Testing
- `npm run build`
- `mvn -q test` *(falla: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bf2516dc8c8329a4226ec9fa9e0951