### PR TITLE
Cambia filtro de escuela a especialidad y registra ciclos de sílabo

### DIFF
--- a/Backend/login-microsoft365/src/main/java/com/miapp/config/BibliotecaCicloSequenceInitializer.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/config/BibliotecaCicloSequenceInitializer.java
@@ -1,0 +1,40 @@
+package com.miapp.config;
+
+import jakarta.annotation.PostConstruct;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class BibliotecaCicloSequenceInitializer {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public BibliotecaCicloSequenceInitializer(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    @PostConstruct
+    public void initializeSequence() {
+        Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM USER_SEQUENCES WHERE SEQUENCE_NAME = 'SEQ_BIBLIOTECACICLO'",
+                Integer.class);
+        Long max = jdbcTemplate.queryForObject(
+                "SELECT COALESCE(MAX(IDBIBLIOTECACICLO),0) FROM BIBLIOTECACICLO",
+                Long.class);
+        long next = (max == null ? 0 : max) + 1;
+        if (count != null && count == 0) {
+            jdbcTemplate.execute(
+                    "CREATE SEQUENCE SEQ_BIBLIOTECACICLO START WITH " + next + " INCREMENT BY 1 NOCACHE NOCYCLE");
+        } else {
+            Long seqNext = jdbcTemplate.queryForObject(
+                    "SELECT LAST_NUMBER FROM USER_SEQUENCES WHERE SEQUENCE_NAME = 'SEQ_BIBLIOTECACICLO'",
+                    Long.class);
+            if (seqNext != null && seqNext < next) {
+                long diff = next - seqNext;
+                jdbcTemplate.execute("ALTER SEQUENCE SEQ_BIBLIOTECACICLO INCREMENT BY " + diff);
+                jdbcTemplate.queryForObject("SELECT SEQ_BIBLIOTECACICLO.NEXTVAL FROM dual", Long.class);
+                jdbcTemplate.execute("ALTER SEQUENCE SEQ_BIBLIOTECACICLO INCREMENT BY 1");
+            }
+        }
+    }
+}

--- a/Backend/login-microsoft365/src/main/java/com/miapp/controller/BibliotecaController.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/controller/BibliotecaController.java
@@ -201,7 +201,7 @@ public class BibliotecaController {
             @RequestParam(value = "sede",                required = false) Long sedeId,
             @RequestParam(value = "tipoUsuario",         required = false) Long tipoUsuarioId,
             @RequestParam(value = "estado",              required = false) String tipoPrestamo,
-            @RequestParam(value = "escuela",             required = false) Long escuelaId,
+            @RequestParam(value = "especialidad",        required = false) Long especialidadId,
             @RequestParam(value = "programa",            required = false) Long programaId,
             @RequestParam(value = "ciclo",               required = false) String ciclo) {
 
@@ -211,7 +211,7 @@ public class BibliotecaController {
                 sedeId,
                 tipoUsuarioId,
                 tipoPrestamo,
-                escuelaId,
+                especialidadId,
                 programaId,
                 ciclo
         );

--- a/Backend/login-microsoft365/src/main/java/com/miapp/mapper/BibliotecaMapper.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/mapper/BibliotecaMapper.java
@@ -107,6 +107,19 @@ public class BibliotecaMapper {
             b.setTipoAdquisicion(ta);
         }
 
+        if (dto.getCiclos() != null) {
+            List<BibliotecaCiclo> ciclos = dto.getCiclos().stream()
+                    .distinct()
+                    .map(c -> {
+                        BibliotecaCiclo bc = new BibliotecaCiclo();
+                        bc.setCiclo(c);
+                        bc.setBiblioteca(b);
+                        bc.setIdEstado(1L);
+                        return bc;
+                    }).collect(Collectors.toList());
+            b.setCiclos(ciclos);
+        }
+
         return b;
     }
 
@@ -212,6 +225,13 @@ public class BibliotecaMapper {
                     b.getEspecialidad().getIdEspecialidad(),
                     b.getEspecialidad().getDescripcion()
             ));
+        }
+        if (b.getCiclos() != null) {
+            dto.setCiclos(
+                    b.getCiclos().stream()
+                            .map(BibliotecaCiclo::getCiclo)
+                            .collect(Collectors.toList())
+            );
         }
         return dto;
     }

--- a/Backend/login-microsoft365/src/main/java/com/miapp/model/Biblioteca.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/model/Biblioteca.java
@@ -128,4 +128,10 @@ public class Biblioteca {
             orphanRemoval = true,
             fetch = FetchType.LAZY)
     private List<DetalleBiblioteca> detalles = new ArrayList<>();
+
+    @OneToMany(mappedBy = "biblioteca",
+            cascade = CascadeType.ALL,
+            orphanRemoval = true,
+            fetch = FetchType.LAZY)
+    private List<BibliotecaCiclo> ciclos = new ArrayList<>();
 }

--- a/Backend/login-microsoft365/src/main/java/com/miapp/model/BibliotecaCiclo.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/model/BibliotecaCiclo.java
@@ -1,0 +1,30 @@
+package com.miapp.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "BIBLIOTECACICLO")
+public class BibliotecaCiclo {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "biblio_ciclo_seq")
+    @SequenceGenerator(name = "biblio_ciclo_seq", sequenceName = "SEQ_BIBLIOTECACICLO", allocationSize = 1)
+    @Column(name = "IDBIBLIOTECACICLO")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "IDBIBLIOTECAESPECIALIDAD", referencedColumnName = "IDBIBLIOTECA")
+    private Biblioteca biblioteca;
+
+    @Column(name = "IDCICLO")
+    private Integer ciclo;
+
+    @Column(name = "IDESTADO")
+    private Long idEstado;
+}

--- a/Backend/login-microsoft365/src/main/java/com/miapp/model/dto/BibliotecaDTO.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/model/dto/BibliotecaDTO.java
@@ -85,4 +85,5 @@ public class BibliotecaDTO {
     private SedeDTO sede;
     private TipoAdquisicionDTO tipoAdquisicion;
     private List<DetalleBibliotecaDTO> detalles = new ArrayList<>();
+    private List<Integer> ciclos = new ArrayList<>();
 }

--- a/Backend/login-microsoft365/src/main/java/com/miapp/repository/BibliotecaCicloRepository.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/repository/BibliotecaCicloRepository.java
@@ -1,0 +1,13 @@
+package com.miapp.repository;
+
+import com.miapp.model.BibliotecaCiclo;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface BibliotecaCicloRepository extends JpaRepository<BibliotecaCiclo, Long> {
+    @Modifying
+    @Query("delete from BibliotecaCiclo bc where bc.biblioteca.id = :bibliotecaId")
+    void deleteByBibliotecaId(@Param("bibliotecaId") Long bibliotecaId);
+}

--- a/Backend/login-microsoft365/src/main/java/com/miapp/service/DetalleBibliotecaService.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/service/DetalleBibliotecaService.java
@@ -116,7 +116,7 @@ public class DetalleBibliotecaService {
             Long sedeId,
             Long tipoUsuarioId,
             String tipoPrestamo,
-            Long escuelaId,
+            Long especialidadId,
             Long programaId,
             String ciclo) {
 
@@ -141,6 +141,10 @@ public class DetalleBibliotecaService {
                 // Filtra por tipo de préstamo si corresponde
                 .filter(det -> tipoNormalizado == null ||
                         tipoNormalizado.equalsIgnoreCase(normalizeTipoPrestamo(det.getTipoPrestamo())))
+                // Filtra por especialidad de la cabecera Biblioteca
+                .filter(det -> especialidadId == null ||
+                        (det.getBiblioteca() != null && det.getBiblioteca().getEspecialidad() != null &&
+                                especialidadId.equals(det.getBiblioteca().getEspecialidad().getIdEspecialidad())))
                 // Asocia usuario para aplicar filtros adicionales
                 .map(det -> new AbstractMap.SimpleEntry<>(det,
                         usuarioRepository.findByLoginIgnoreCase(det.getCodigoUsuario())))
@@ -148,12 +152,6 @@ public class DetalleBibliotecaService {
                     Usuario u = entry.getValue().orElse(null);
                     if (tipoUsuarioId != null) {
                         if (u == null || u.getRoles().stream().noneMatch(r -> r.getIdRol().equals(tipoUsuarioId))) {
-                            return false;
-                        }
-                    }
-                    if (escuelaId != null) {
-                        if (u == null || u.getEspecialidad() == null ||
-                                !u.getEspecialidad().getIdEspecialidad().equals(escuelaId)) {
                             return false;
                         }
                     }

--- a/Backend/login-microsoft365/src/main/java/com/miapp/service/impl/BibliotecaServiceImpl.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/service/impl/BibliotecaServiceImpl.java
@@ -46,6 +46,7 @@ public class BibliotecaServiceImpl implements BibliotecaService {
     private final NotificacionService notificacionService;
     private final EmailService emailService;
     private final FileStorageService fileStorageService;
+    private final BibliotecaCicloRepository bibliotecaCicloRepository;
 
     public BibliotecaServiceImpl(BibliotecaRepository bibliotecaRepository,
                                  TipoAdquisicionRepository tipoAdquisicionRepository,
@@ -62,7 +63,8 @@ public class BibliotecaServiceImpl implements BibliotecaService {
                                  OcurrenciaBibliotecaRepository ocurrenciaBibliotecaRepository,
                                  NotificacionService notificacionService,
                                  EmailService emailService,
-                                 FileStorageService fileStorageService) {
+                                 FileStorageService fileStorageService,
+                                 BibliotecaCicloRepository bibliotecaCicloRepository) {
         this.bibliotecaRepository = bibliotecaRepository;
         this.tipoAdquisicionRepository  = tipoAdquisicionRepository;
         this.especialidadRepository = especialidadRepository;
@@ -79,6 +81,7 @@ public class BibliotecaServiceImpl implements BibliotecaService {
         this.notificacionService = notificacionService;
         this.emailService = emailService;
         this.fileStorageService = fileStorageService;
+        this.bibliotecaCicloRepository = bibliotecaCicloRepository;
     }
 
     @Override
@@ -108,6 +111,8 @@ public class BibliotecaServiceImpl implements BibliotecaService {
     public Biblioteca update(Long id, BibliotecaDTO dto, MultipartFile portada) {
         Biblioteca existente = bibliotecaRepository.findById(id)
                 .orElseThrow(() -> new RuntimeException("No existe Biblioteca " + id));
+        // Eliminamos los ciclos existentes para evitar duplicidades
+        bibliotecaCicloRepository.deleteByBibliotecaId(id);
 
         // Volvemos a mapearlo por completo (incluyendo detalles)
         Biblioteca bib = mapToEntity(dto);
@@ -231,6 +236,20 @@ public class BibliotecaServiceImpl implements BibliotecaService {
                     .orElseThrow(() -> new RuntimeException("TipoMaterial no encontrado: " + dto.getTipoMaterialId()));
             b.setTipoMaterial(tm);
         }
+
+        b.getCiclos().clear();
+        if (dto.getCiclos() != null) {
+            List<BibliotecaCiclo> ciclos = dto.getCiclos().stream()
+                    .map(c -> {
+                        BibliotecaCiclo bc = new BibliotecaCiclo();
+                        bc.setCiclo(c);
+                        bc.setBiblioteca(b);
+                        bc.setIdEstado(1L);
+                        return bc;
+                    }).collect(Collectors.toList());
+            b.getCiclos().addAll(ciclos);
+        }
+
         List<DetalleBiblioteca> lista = dto.getDetalles() == null
                 ? List.of()
                 : dto.getDetalles().stream().map(det -> {

--- a/Frontend/sakai-ng-master/src/app/biblioteca/interfaces/material-bibliografico/biblioteca.model.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/interfaces/material-bibliografico/biblioteca.model.ts
@@ -78,6 +78,7 @@ export interface BibliotecaDTO {
     sede?: Sedes | null;
     tipoAdquisicion?: TipoAdquisicion | null;
     detalles?: DetalleBibliotecaDTO[];
+    ciclos?: number[];
 }
 
 export interface DetalleBibliotecaDTO {

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/mantenimientos/material-bibliografico/modal-libro.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/mantenimientos/material-bibliografico/modal-libro.ts
@@ -64,19 +64,19 @@ import { environment } from '../../../../../environments/environment';
                           <app-input-validation [form]="formLibro" modelo="especialidad" ver="especialidad"></app-input-validation>
                         </div>
                       </div>
-                      <div class="flex flex-col md:flex-row gap-x-4 gap-y-2">
-                        <div class="flex flex-col gap-4 w-full">
+                        <div class="flex flex-col md:flex-row gap-x-4 gap-y-2">
+                          <div class="flex items-center gap-2 w-full">
+                            <p-checkbox inputId="enSilabo" formControlName="enSilabo" (onChange)="toggleCiclos()"></p-checkbox>
+                            <label for="enSilabo">¿El material bibliográfico está incluido dentro del sílabo?</label>
+                          </div>
                         </div>
-                      </div>
-                      <div class="flex flex-col md:flex-row gap-x-4 gap-y-2" *ngIf="formLibro.get('enSilabo')?.value">
+                        <div class="flex flex-col md:flex-row gap-x-4 gap-y-2" *ngIf="formLibro.get('enSilabo')?.value">
                         <div class="flex flex-col gap-2 w-full py-2">
                           <label class="font-semibold">Seleccione los ciclos:</label>
                           <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-7 gap-2">
                             <div class="flex items-center" *ngFor="let ciclo of ciclos">
-                              <p-checkbox [id]="'checkCiclo' + ciclo.label" name="option" [value]="ciclo.value"
-                                formControlName="{{ ciclo.formControl }}"></p-checkbox>
+                              <p-checkbox [inputId]="'checkCiclo' + ciclo.label" binary="true" [formControlName]="ciclo.formControl"></p-checkbox>
                               <label [for]="'checkCiclo' + ciclo.label" class="ml-2">{{ ciclo.label }}</label>
-
                             </div>
                           </div>
 
@@ -513,7 +513,8 @@ export class ModalLibroComponent implements OnInit {
         { label: 'XI', value: 11, formControl: 'cicloXI' },
         { label: 'XII', value: 12, formControl: 'cicloXII' },
         { label: 'XIII', value: 13, formControl: 'cicloXIII' },
-        { label: 'XIV', value: 14, formControl: 'cicloXIV' }
+        { label: 'XIV', value: 14, formControl: 'cicloXIV' },
+        { label: 'XV', value: 15, formControl: 'cicloXV' }
     ];
     isEdit = false;
     selectedIndex!: number;
@@ -550,6 +551,8 @@ export class ModalLibroComponent implements OnInit {
             especialidad: [this.objetoLibro.especialidad, Validators.required],
             tipoMaterialId: [null],
 
+            enSilabo: [this.objetoLibro.enSilabo || false],
+            formatoDigital: [this.objetoLibro.formatoDigital || false],
             urlPublicacion: [this.objetoLibro.urlPublicacion],
             descripcion: [this.objetoLibro.descriptores, [
                 Validators.required,
@@ -564,6 +567,22 @@ export class ModalLibroComponent implements OnInit {
                 Validators.maxLength(100),
                 Validators.pattern('^[a-zA-Z0-9áéíóúÁÉÍÓÚñÑ\\s./()-]+$') // Permite letras, números, espacios, punto, guion, slash y paréntesis
             ]]
+            ,
+            cicloI: [false],
+            cicloII: [false],
+            cicloIII: [false],
+            cicloIV: [false],
+            cicloV: [false],
+            cicloVI: [false],
+            cicloVII: [false],
+            cicloVIII: [false],
+            cicloIX: [false],
+            cicloX: [false],
+            cicloXI: [false],
+            cicloXII: [false],
+            cicloXIII: [false],
+            cicloXIV: [false],
+            cicloXV: [false]
         });
         this.formEditorial = this.fb.group({
             autorOpcion:[null,Validators.required],
@@ -913,6 +932,9 @@ private buildDto(): BibliotecaDTO {
     };
   });
 
+  const ciclosSeleccionados = this.ciclos
+    .filter(c => this.formLibro.get(c.formControl)?.value)
+    .map(c => c.value);
 
   return {
     /* ------ claves y datos propios de Biblioteca ------ */
@@ -948,6 +970,8 @@ private buildDto(): BibliotecaDTO {
     flasyllabus     : !!libro.enSilabo,
     fladigitalizado : !!libro.formatoDigital,
     linkPublicacion : libro.urlPublicacion,
+
+    ciclos          : ciclosSeleccionados,
 
     usuarioCreacion   : decoded.sub,
     fechaCreacion     : new Date().toISOString(),
@@ -1487,10 +1511,14 @@ public setData(material: BibliotecaDTO, omitPaisCiudad = false): void {
     notasContenido:clone.notaContenido,
     notaGeneral:   clone.notaGeneral,
     especialidad:  clone.idEspecialidad,
-    enSilabo:      clone.enSilabo,
-    formatoDigital:clone.formatoDigital,
+    enSilabo:      clone.flasyllabus,
+    formatoDigital:clone.fladigitalizado,
     urlPublicacion:clone.urlPublicacion,
     descriptores:  clone.descriptores
+  });
+
+  this.ciclos.forEach(c => {
+    this.formLibro.get(c.formControl)?.setValue(clone.ciclos?.includes(c.value) ?? false);
   });
 
   /*-------------------------------------------------------

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/reporte-prestamo-mat-bibliografico.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/reporte-prestamo-mat-bibliografico.ts
@@ -70,10 +70,10 @@ import { HttpClient } from '@angular/common/http';
           </p-dropdown>
         </div>
         <div class="field col-12 md:col-3">
-          <label>Escuela</label>
+          <label>Especialidad</label>
           <p-dropdown
             class="text-base text-color surface-overlay p-2 border-1 border-solid surface-border border-round appearance-none outline-none focus:border-primary w-full"
-            [options]="dataEscuela" optionLabel="descripcion" [(ngModel)]="escuelaFiltro" placeholder="Todas">
+            [options]="dataEspecialidad" optionLabel="descripcion" [(ngModel)]="especialidadFiltro" placeholder="Todas">
           </p-dropdown>
         </div>
         <div class="field col-12 md:col-3">
@@ -162,13 +162,13 @@ export class ReportePrestamoMatBibliografico implements OnInit {
   dataSede: Sedes[]               = [];
   dataTipoUsuario: ClaseGeneral[] = [];
   dataEstado: ClaseGeneral[]      = [];
-  dataEscuela: ClaseGeneral[]     = [];
+  dataEspecialidad: ClaseGeneral[] = [];
   dataPrograma: ClaseGeneral[]    = [];
   dataCiclo: ClaseGeneral[]       = [];
 
   sedeFiltro?:        Sedes;
   tipoUsuarioFiltro?: ClaseGeneral;
-  escuelaFiltro?:     ClaseGeneral;
+  especialidadFiltro?: ClaseGeneral;
   programaFiltro?:    ClaseGeneral;
   cicloFiltro?:       ClaseGeneral;
 
@@ -199,7 +199,7 @@ export class ReportePrestamoMatBibliografico implements OnInit {
         const filtros = await this.filtrosService.cargarFiltros();
         this.dataSede        = filtros.sedes;
         this.dataTipoUsuario = filtros.tipoUsuarios;
-        this.dataEscuela     = filtros.especialidades;
+        this.dataEspecialidad = filtros.especialidades;
         this.dataPrograma    = filtros.programas;
         this.dataCiclo       = filtros.ciclos;
       }
@@ -227,7 +227,7 @@ async reporte() {
         this.sedeFiltro?.id,
         this.tipoUsuarioFiltro?.id,
         estado,
-        this.escuelaFiltro?.id,
+        this.especialidadFiltro?.id,
         this.programaFiltro?.id,
         this.cicloFiltro?.id,
         fi,

--- a/Frontend/sakai-ng-master/src/app/biblioteca/services/prestamos.service.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/services/prestamos.service.ts
@@ -145,7 +145,7 @@ export class PrestamosService {
     sede?: number | string,
     tipoUsuario?: number | string,
     tipoPrestamo?: string,
-    escuela?: number | string,
+    especialidad?: number | string,
     programa?: number | string,
     ciclo?: number | string,
     fechaInicio?: string,
@@ -162,7 +162,7 @@ export class PrestamosService {
     agregarParam('sede', sede);
     agregarParam('tipoUsuario', tipoUsuario);
     agregarParam('estado', tipoPrestamo);
-    agregarParam('escuela', escuela);
+    agregarParam('especialidad', especialidad);
     agregarParam('programa', programa);
     agregarParam('ciclo', ciclo);
     if (fechaInicio) params = params.set('fechaPrestamoInicio', fechaInicio);


### PR DESCRIPTION
## Resumen
- Se generan los identificadores de `BibliotecaCiclo` mediante la secuencia `SEQ_BIBLIOTECACICLO` y se limpia correctamente la tabla antes de registrar nuevos ciclos.
- Se evita registrar ciclos duplicados al mapear la lista desde el DTO.
- El filtro de "Escuela" se renombró a "Especialidad" en backend y frontend para buscar por este campo.
- Al arrancar la aplicación se valida la existencia de la secuencia `SEQ_BIBLIOTECACICLO`, creándola o ajustando su valor al correlativo de la tabla.

## Pruebas
- `mvn -q test` *(falla: Non-resolvable parent POM: Network is unreachable)*
- `npm test -- --watch=false` *(falla: error TS18003: No inputs were found en tsconfig.spec.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bfb3f0d36483298f2fd19b006329ff