### PR TITLE
Corrige selección de ciclos en edición de material

### DIFF
--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/mantenimientos/material-bibliografico/modal-libro.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/mantenimientos/material-bibliografico/modal-libro.ts
@@ -66,7 +66,7 @@ import { environment } from '../../../../../environments/environment';
                       </div>
                         <div class="flex flex-col md:flex-row gap-x-4 gap-y-2">
                           <div class="flex items-center gap-2 w-full">
-                            <p-checkbox inputId="enSilabo" formControlName="enSilabo" (onChange)="toggleCiclos()"></p-checkbox>
+                            <p-checkbox inputId="enSilabo" binary="true" formControlName="enSilabo" (onChange)="toggleCiclos()"></p-checkbox>
                             <label for="enSilabo">¿El material bibliográfico está incluido dentro del sílabo?</label>
                           </div>
                         </div>
@@ -1511,7 +1511,7 @@ public setData(material: BibliotecaDTO, omitPaisCiudad = false): void {
     notasContenido:clone.notaContenido,
     notaGeneral:   clone.notaGeneral,
     especialidad:  clone.idEspecialidad,
-    enSilabo:      clone.flasyllabus,
+    enSilabo:      !!clone.flasyllabus || (clone.ciclos?.length ?? 0) > 0,
     formatoDigital:clone.fladigitalizado,
     urlPublicacion:clone.urlPublicacion,
     descriptores:  clone.descriptores


### PR DESCRIPTION
## Resumen
- Asegura que al cargar un libro con ciclos, la opción "En Sílabo" aparezca marcada y los ciclos seleccionados.
- Mantiene la selección de ciclos basada en el arreglo recibido del backend.
- Corrige visualización del checkbox para que se marque automáticamente al editar.

## Pruebas
- `npm test -- --watch=false --browsers=ChromeHeadless` (falla: No inputs were found in tsconfig.spec.json)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bfd0b436108329830ecebdfe751e90