### PR TITLE
feat: enable filters for most borrowed items report

### DIFF
--- a/Backend/login-microsoft365/src/main/java/com/miapp/controller/BibliotecaController.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/controller/BibliotecaController.java
@@ -13,6 +13,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.security.core.Authentication;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.HashMap;
@@ -269,8 +270,22 @@ public class BibliotecaController {
     }
 
     @GetMapping("/reporte/ejemplar-mas-prestado")
-    public ResponseEntity<?> reporteEjemplarMasPrestado() {
-        return ResponseEntity.ok(Map.of("status", 0, "data", bibliotecaService.reporteEjemplarMasPrestado()));
+    public ResponseEntity<?> reporteEjemplarMasPrestado(@RequestParam(required = false) Long sede,
+                                                        @RequestParam(required = false) Long tipoMaterial,
+                                                        @RequestParam(required = false) Long especialidad,
+                                                        @RequestParam(required = false) Integer ciclo,
+                                                        @RequestParam(required = false) Long numeroIngreso,
+                                                        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) java.time.LocalDate fechaInicio,
+                                                        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) java.time.LocalDate fechaFin) {
+        return ResponseEntity.ok(Map.of("status", 0, "data",
+                bibliotecaService.reporteEjemplarMasPrestado(
+                        sede,
+                        tipoMaterial,
+                        especialidad,
+                        ciclo,
+                        numeroIngreso,
+                        fechaInicio,
+                        fechaFin)));
     }
 
     @GetMapping("/reporte/ejemplar-no-prestados")

--- a/Backend/login-microsoft365/src/main/java/com/miapp/repository/OcurrenciaBibliotecaRepository.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/repository/OcurrenciaBibliotecaRepository.java
@@ -76,8 +76,22 @@ public interface OcurrenciaBibliotecaRepository
                     "WHERE coalesce(d.cantidadPrestamos, 0) > 0 " +
                     "AND d.idEstado = 2 " +
                     "AND b.idEstado = 2 " +
+                    "AND (:sede IS NULL OR d.sede.id = :sede) " +
+                    "AND (:tipoMaterial IS NULL OR d.tipoMaterial.idTipoMaterial = :tipoMaterial) " +
+                    "AND (:especialidad IS NULL OR b.especialidad.idEspecialidad = :especialidad) " +
+                    "AND (:ciclo IS NULL OR c.ciclo = :ciclo) " +
+                    "AND (:numeroIngreso IS NULL OR d.numeroIngreso = :numeroIngreso) " +
+                    "AND (:fechaInicio IS NULL OR d.fechaInicio >= :fechaInicio) " +
+                    "AND (:fechaFin IS NULL OR d.fechaInicio <= :fechaFin) " +
                     "ORDER BY d.idDetalle DESC")
-    List<EjemplarPrestadoDTO> reporteEjemplarMasPrestado();
+    List<EjemplarPrestadoDTO> reporteEjemplarMasPrestado(
+            @Param("sede") Long sede,
+            @Param("tipoMaterial") Long tipoMaterial,
+            @Param("especialidad") Long especialidad,
+            @Param("ciclo") Integer ciclo,
+            @Param("numeroIngreso") Long numeroIngreso,
+            @Param("fechaInicio") java.time.LocalDate fechaInicio,
+            @Param("fechaFin") java.time.LocalDate fechaFin);
 
     /**
      * Devuelve los ejemplares de material bibliográfico que nunca se han prestado.

--- a/Backend/login-microsoft365/src/main/java/com/miapp/service/BibliotecaService.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/service/BibliotecaService.java
@@ -32,7 +32,13 @@ public interface BibliotecaService {
     List<DetalleBibliotecaDTO> listarTodosDetallesReservados();
 
     /** Reporte de ejemplares más prestados */
-    List<EjemplarPrestadoDTO> reporteEjemplarMasPrestado();
+    List<EjemplarPrestadoDTO> reporteEjemplarMasPrestado(Long sede,
+                                                         Long tipoMaterial,
+                                                         Long especialidad,
+                                                         Integer ciclo,
+                                                         Long numeroIngreso,
+                                                         java.time.LocalDate fechaInicio,
+                                                         java.time.LocalDate fechaFin);
 
     /** Reporte de ejemplares que nunca fueron prestados */
     List<EjemplarNoPrestadoDTO> reporteEjemplarNoPrestado();

--- a/Backend/login-microsoft365/src/main/java/com/miapp/service/impl/BibliotecaServiceImpl.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/service/impl/BibliotecaServiceImpl.java
@@ -656,8 +656,21 @@ public class BibliotecaServiceImpl implements BibliotecaService {
     }
 
     @Override
-    public List<EjemplarPrestadoDTO> reporteEjemplarMasPrestado() {
-        return ocurrenciaBibliotecaRepository.reporteEjemplarMasPrestado();
+    public List<EjemplarPrestadoDTO> reporteEjemplarMasPrestado(Long sede,
+                                                                Long tipoMaterial,
+                                                                Long especialidad,
+                                                                Integer ciclo,
+                                                                Long numeroIngreso,
+                                                                java.time.LocalDate fechaInicio,
+                                                                java.time.LocalDate fechaFin) {
+        return ocurrenciaBibliotecaRepository.reporteEjemplarMasPrestado(
+                sede,
+                tipoMaterial,
+                especialidad,
+                ciclo,
+                numeroIngreso,
+                fechaInicio,
+                fechaFin);
     }
 
     @Override

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/ejemplar-mas-prestado.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/ejemplar-mas-prestado.ts
@@ -178,12 +178,24 @@ export class ReporteEjemplarMasPrestado {
         this.dataCiclo = filtros.ciclos;
         this.cicloFiltro = this.dataCiclo[0];
     }
+    private formatDate(fecha: Date | null): string | undefined {
+        return fecha ? fecha.toISOString().split('T')[0] : undefined;
+    }
     async reporte() {
         this.loading = true;
         try {
             this.resultados =
                 (await this.svc
-                    .reporteEjemplarMasPrestado()
+                    .reporteEjemplarMasPrestado({
+                        sede: this.sedeFiltro?.id,
+                        tipoMaterial: this.tipoMaterialFiltro?.id,
+                        especialidad: this.especialidadFiltro?.id,
+                        programa: this.programaFiltro?.id,
+                        ciclo: this.cicloFiltro?.id,
+                        numeroIngreso: this.nroIngreso || undefined,
+                        fechaInicio: this.formatDate(this.fechaInicio),
+                        fechaFin: this.formatDate(this.fechaFin)
+                    })
                     .toPromise()) ?? [];
         } finally {
             this.loading = false;

--- a/Frontend/sakai-ng-master/src/app/biblioteca/services/material-bibliografico.service.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/services/material-bibliografico.service.ts
@@ -821,9 +821,48 @@ listarUsuariosOcurrencia(id: number): Observable<OcurrenciaUsuario[]> {
       { headers }
     );
   }
-  reporteEjemplarMasPrestado(): Observable<EjemplarPrestadoDTO[]> {
+  reporteEjemplarMasPrestado(filtros: {
+    sede?: number;
+    tipoMaterial?: number;
+    especialidad?: number;
+    programa?: number;
+    ciclo?: number;
+    numeroIngreso?: string;
+    fechaInicio?: string;
+    fechaFin?: string;
+  } = {}): Observable<EjemplarPrestadoDTO[]> {
     const headers = new HttpHeaders().set('Authorization', `Bearer ${this.authService.getToken()}`);
-    return this.http.get<{ status: number; data: EjemplarPrestadoDTO[] }>(`${this.apiUrl}/api/biblioteca/reporte/ejemplar-mas-prestado`, { headers }).pipe(map(resp => resp.data));
+    let params = new HttpParams();
+    if (filtros.sede) {
+      params = params.set('sede', filtros.sede);
+    }
+    if (filtros.tipoMaterial) {
+      params = params.set('tipoMaterial', filtros.tipoMaterial);
+    }
+    if (filtros.especialidad) {
+      params = params.set('especialidad', filtros.especialidad);
+    }
+    if (filtros.programa) {
+      params = params.set('programa', filtros.programa);
+    }
+    if (filtros.ciclo) {
+      params = params.set('ciclo', filtros.ciclo);
+    }
+    if (filtros.numeroIngreso) {
+      params = params.set('numeroIngreso', filtros.numeroIngreso);
+    }
+    if (filtros.fechaInicio) {
+      params = params.set('fechaInicio', filtros.fechaInicio);
+    }
+    if (filtros.fechaFin) {
+      params = params.set('fechaFin', filtros.fechaFin);
+    }
+    return this.http
+      .get<{ status: number; data: EjemplarPrestadoDTO[] }>(
+        `${this.apiUrl}/api/biblioteca/reporte/ejemplar-mas-prestado`,
+        { headers, params }
+      )
+      .pipe(map(resp => resp.data));
   }
 
   reporteEjemplarNoPrestado(): Observable<EjemplarNoPrestadoDTO[]> {


### PR DESCRIPTION
## Summary
- allow backend `ejemplar-mas-prestado` report to receive optional filter params
- send combo selections from frontend to backend
- add date formatting helper in report component

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*
- `npm test --silent` *(fails: error TS18003, no inputs were found in tsconfig.spec.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c0454ea1c883299b2a5e428a5034e3