### PR TITLE
feat: agregar detalles en reporte de ejemplares no prestados

### DIFF
--- a/Backend/login-microsoft365/src/main/java/com/miapp/model/dto/EjemplarNoPrestadoDTO.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/model/dto/EjemplarNoPrestadoDTO.java
@@ -6,13 +6,26 @@ package com.miapp.model.dto;
 public class EjemplarNoPrestadoDTO {
     private Long idDetalle;
     private String titulo;
+    private String codigoLocalizacion;
+    private Long numeroIngreso;
+    private String autor;
+    private Integer anio;
 
     public EjemplarNoPrestadoDTO() {
     }
 
-    public EjemplarNoPrestadoDTO(Long idDetalle, String titulo) {
+    public EjemplarNoPrestadoDTO(Long idDetalle,
+                                 String titulo,
+                                 String codigoLocalizacion,
+                                 Long numeroIngreso,
+                                 String autor,
+                                 Integer anio) {
         this.idDetalle = idDetalle;
         this.titulo = titulo;
+        this.codigoLocalizacion = codigoLocalizacion;
+        this.numeroIngreso = numeroIngreso;
+        this.autor = autor;
+        this.anio = anio;
     }
 
     public Long getIdDetalle() {
@@ -29,5 +42,37 @@ public class EjemplarNoPrestadoDTO {
 
     public void setTitulo(String titulo) {
         this.titulo = titulo;
+    }
+
+    public String getCodigoLocalizacion() {
+        return codigoLocalizacion;
+    }
+
+    public void setCodigoLocalizacion(String codigoLocalizacion) {
+        this.codigoLocalizacion = codigoLocalizacion;
+    }
+
+    public Long getNumeroIngreso() {
+        return numeroIngreso;
+    }
+
+    public void setNumeroIngreso(Long numeroIngreso) {
+        this.numeroIngreso = numeroIngreso;
+    }
+
+    public String getAutor() {
+        return autor;
+    }
+
+    public void setAutor(String autor) {
+        this.autor = autor;
+    }
+
+    public Integer getAnio() {
+        return anio;
+    }
+
+    public void setAnio(Integer anio) {
+        this.anio = anio;
     }
 }

--- a/Backend/login-microsoft365/src/main/java/com/miapp/repository/OcurrenciaBibliotecaRepository.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/repository/OcurrenciaBibliotecaRepository.java
@@ -99,7 +99,11 @@ public interface OcurrenciaBibliotecaRepository
     @Query(
             "SELECT new com.miapp.model.dto.EjemplarNoPrestadoDTO(" +
                     " d.idDetalle," +
-                    " b.titulo" +
+                    " b.titulo," +
+                    " b.codigoLocalizacion," +
+                    " d.numeroIngreso," +
+                    " b.autorPersonal," +
+                    " b.anioPublicacion" +
                     ") " +
                     "FROM DetalleBiblioteca d " +
                     "JOIN d.biblioteca b " +

--- a/Frontend/sakai-ng-master/src/app/biblioteca/interfaces/reportes/ejemplar-no-prestado.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/interfaces/reportes/ejemplar-no-prestado.ts
@@ -1,4 +1,8 @@
 export interface EjemplarNoPrestadoDTO {
     idDetalle: number;
     titulo: string;
+    codigoLocalizacion: string;
+    numeroIngreso: number | null;
+    autor: string;
+    anio: number | null;
 }

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/ejemplar-no-prestado.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/ejemplar-no-prestado.ts
@@ -71,12 +71,20 @@ import { ReportesFiltroService } from '../../services/reportes-filtro.service';
                     <tr>
                         <th>ID</th>
                         <th>Título</th>
+                        <th>Código localización</th>
+                        <th>N° ingreso</th>
+                        <th>Autor personal</th>
+                        <th>Año</th>
                     </tr>
                 </ng-template>
                 <ng-template pTemplate="body" let-row>
                     <tr>
                         <td>{{ row.idDetalle }}</td>
                         <td>{{ row.titulo }}</td>
+                        <td>{{ row.codigoLocalizacion }}</td>
+                        <td>{{ row.numeroIngreso }}</td>
+                        <td>{{ row.autor }}</td>
+                        <td>{{ row.anio }}</td>
                     </tr>
                 </ng-template>
             </p-table>
@@ -161,16 +169,23 @@ export class ReporteEjemplarNoPrestado {
         const buffer = await this.http.get('/assets/logo.png', { responseType: 'arraybuffer' }).toPromise();
         const logoId = wb.addImage({ buffer, extension: 'png' });
         ws.addImage(logoId, { tl: { col: 0.2, row: 0.2 }, ext: { width: 220, height: 80 } });
-        ws.mergeCells('C1', 'E2');
+        ws.mergeCells('C1', 'H2');
         const title = ws.getCell('C1');
         title.value = 'Ejemplares no prestados';
         title.alignment = { vertical: 'middle', horizontal: 'center' };
         title.font = { size: 16, bold: true };
         ws.addRow([]);
-        const headerRow = ws.addRow(['ID', 'Título']);
+        const headerRow = ws.addRow(['ID', 'Título', 'Código localización', 'N° ingreso', 'Autor personal', 'Año']);
         headerRow.font = { bold: true };
         headerRow.alignment = { horizontal: 'center' };
-        this.resultados.forEach((r) => ws.addRow([r.idDetalle, r.titulo]));
+        this.resultados.forEach((r) => ws.addRow([
+            r.idDetalle,
+            r.titulo,
+            r.codigoLocalizacion,
+            r.numeroIngreso ?? '',
+            r.autor,
+            r.anio ?? ''
+        ]));
         ws.columns.forEach((col) => (col.width = 25));
         const buf = await wb.xlsx.writeBuffer();
         saveAs(new Blob([buf]), 'ejemplares_no_prestados.xlsx');
@@ -192,8 +207,15 @@ export class ReporteEjemplarNoPrestado {
             const hoy = new Date();
             doc.text(`Fecha de emisión: ${hoy.toLocaleDateString()}`, 80, 25);
             autoTable(doc, {
-                head: [['ID', 'Título']],
-                body: this.resultados.map((r) => [r.idDetalle, r.titulo]),
+                head: [['ID', 'Título', 'Código localización', 'N° ingreso', 'Autor personal', 'Año']],
+                body: this.resultados.map((r) => [
+                    r.idDetalle,
+                    r.titulo,
+                    r.codigoLocalizacion,
+                    r.numeroIngreso ?? '',
+                    r.autor,
+                    r.anio ?? ''
+                ]),
                 startY: 35,
                 styles: { fontSize: 8 },
                 headStyles: { fillColor: [41, 128, 185] }


### PR DESCRIPTION
## Resumen
- ampliar DTO y consulta para incluir código, ingreso, autor y año de ejemplares no prestados
- mostrar y exportar las nuevas columnas en el reporte de ejemplares no prestados

## Pruebas
- `mvn -q test` *(falla: Non-resolvable parent POM)*
- `npm test` *(falla: No inputs were found in config file)*

------
https://chatgpt.com/codex/tasks/task_e_68c049d4d99483299eb7b9cf73cc279a