### PR TITLE
feat: permitir filtros en reporte de ejemplares no prestados

### DIFF
--- a/Backend/login-microsoft365/src/main/java/com/miapp/controller/BibliotecaController.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/controller/BibliotecaController.java
@@ -289,8 +289,26 @@ public class BibliotecaController {
     }
 
     @GetMapping("/reporte/ejemplar-no-prestados")
-    public ResponseEntity<?> reporteEjemplarNoPrestado() {
-        return ResponseEntity.ok(Map.of("status", 0, "data", bibliotecaService.reporteEjemplarNoPrestado()));
+    public ResponseEntity<?> reporteEjemplarNoPrestado(@RequestParam(required = false) Long sede,
+                                                       @RequestParam(required = false) Long tipoMaterial,
+                                                       @RequestParam(required = false) Long especialidad,
+                                                       @RequestParam(required = false) Integer ciclo,
+                                                       @RequestParam(required = false) Long numeroIngreso,
+                                                       @RequestParam(required = false)
+                                                       @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+                                                       java.time.LocalDate fechaInicio,
+                                                       @RequestParam(required = false)
+                                                       @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+                                                       java.time.LocalDate fechaFin) {
+        return ResponseEntity.ok(Map.of("status", 0, "data",
+                bibliotecaService.reporteEjemplarNoPrestado(
+                        sede,
+                        tipoMaterial,
+                        especialidad,
+                        ciclo,
+                        numeroIngreso,
+                        fechaInicio,
+                        fechaFin)));
     }
 
 }

--- a/Backend/login-microsoft365/src/main/java/com/miapp/repository/OcurrenciaBibliotecaRepository.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/repository/OcurrenciaBibliotecaRepository.java
@@ -94,7 +94,8 @@ public interface OcurrenciaBibliotecaRepository
             @Param("fechaFin") java.time.LocalDate fechaFin);
 
     /**
-     * Devuelve los ejemplares de material bibliográfico que nunca se han prestado.
+     * Devuelve los ejemplares de material bibliográfico que nunca se han prestado
+     * filtrando por los parámetros indicados.
      */
     @Query(
             "SELECT new com.miapp.model.dto.EjemplarNoPrestadoDTO(" +
@@ -107,7 +108,25 @@ public interface OcurrenciaBibliotecaRepository
                     ") " +
                     "FROM DetalleBiblioteca d " +
                     "JOIN d.biblioteca b " +
-                    "WHERE coalesce(d.cantidadPrestamos,0) = 0 ORDER BY d.idDetalle DESC")
-    List<EjemplarNoPrestadoDTO> reporteEjemplarNoPrestado();
+                    "LEFT JOIN b.ciclos c " +
+                    "WHERE coalesce(d.cantidadPrestamos,0) = 0 " +
+                    "AND d.idEstado = 2 " +
+                    "AND b.idEstado = 2 " +
+                    "AND (:sede IS NULL OR d.sede.id = :sede) " +
+                    "AND (:tipoMaterial IS NULL OR d.tipoMaterial.idTipoMaterial = :tipoMaterial) " +
+                    "AND (:especialidad IS NULL OR b.especialidad.idEspecialidad = :especialidad) " +
+                    "AND (:ciclo IS NULL OR c.ciclo = :ciclo) " +
+                    "AND (:numeroIngreso IS NULL OR d.numeroIngreso = :numeroIngreso) " +
+                    "AND (:fechaInicio IS NULL OR d.fechaInicio >= :fechaInicio) " +
+                    "AND (:fechaFin IS NULL OR d.fechaInicio <= :fechaFin) " +
+                    "ORDER BY d.idDetalle DESC")
+    List<EjemplarNoPrestadoDTO> reporteEjemplarNoPrestado(
+            @Param("sede") Long sede,
+            @Param("tipoMaterial") Long tipoMaterial,
+            @Param("especialidad") Long especialidad,
+            @Param("ciclo") Integer ciclo,
+            @Param("numeroIngreso") Long numeroIngreso,
+            @Param("fechaInicio") java.time.LocalDate fechaInicio,
+            @Param("fechaFin") java.time.LocalDate fechaFin);
 
 }

--- a/Backend/login-microsoft365/src/main/java/com/miapp/service/BibliotecaService.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/service/BibliotecaService.java
@@ -41,5 +41,11 @@ public interface BibliotecaService {
                                                          java.time.LocalDate fechaFin);
 
     /** Reporte de ejemplares que nunca fueron prestados */
-    List<EjemplarNoPrestadoDTO> reporteEjemplarNoPrestado();
+    List<EjemplarNoPrestadoDTO> reporteEjemplarNoPrestado(Long sede,
+                                                          Long tipoMaterial,
+                                                          Long especialidad,
+                                                          Integer ciclo,
+                                                          Long numeroIngreso,
+                                                          java.time.LocalDate fechaInicio,
+                                                          java.time.LocalDate fechaFin);
 }

--- a/Backend/login-microsoft365/src/main/java/com/miapp/service/impl/BibliotecaServiceImpl.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/service/impl/BibliotecaServiceImpl.java
@@ -674,7 +674,20 @@ public class BibliotecaServiceImpl implements BibliotecaService {
     }
 
     @Override
-    public List<EjemplarNoPrestadoDTO> reporteEjemplarNoPrestado() {
-        return ocurrenciaBibliotecaRepository.reporteEjemplarNoPrestado();
+    public List<EjemplarNoPrestadoDTO> reporteEjemplarNoPrestado(Long sede,
+                                                                 Long tipoMaterial,
+                                                                 Long especialidad,
+                                                                 Integer ciclo,
+                                                                 Long numeroIngreso,
+                                                                 java.time.LocalDate fechaInicio,
+                                                                 java.time.LocalDate fechaFin) {
+        return ocurrenciaBibliotecaRepository.reporteEjemplarNoPrestado(
+                sede,
+                tipoMaterial,
+                especialidad,
+                ciclo,
+                numeroIngreso,
+                fechaInicio,
+                fechaFin);
     }
 }

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/ejemplar-no-prestado.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/ejemplar-no-prestado.ts
@@ -150,10 +150,25 @@ export class ReporteEjemplarNoPrestado {
         this.dataCiclo = filtros.ciclos;
         this.cicloFiltro = this.dataCiclo[0];
     }
+    private formatDate(fecha: Date | null): string | undefined {
+        return fecha ? fecha.toISOString().split('T')[0] : undefined;
+    }
     async reporte() {
         this.loading = true;
         try {
-            this.resultados = (await this.svc.reporteEjemplarNoPrestado().toPromise()) ?? [];
+            this.resultados =
+                (await this.svc
+                    .reporteEjemplarNoPrestado({
+                        sede: this.sedeFiltro?.id,
+                        tipoMaterial: this.tipoMaterialFiltro?.id,
+                        especialidad: this.especialidadFiltro?.id,
+                        programa: this.programaFiltro?.id,
+                        ciclo: this.cicloFiltro?.id,
+                        numeroIngreso: this.nroIngreso || undefined,
+                        fechaInicio: this.formatDate(this.fechaInicio),
+                        fechaFin: this.formatDate(this.fechaFin)
+                    })
+                    .toPromise()) ?? [];
         } finally {
             this.loading = false;
         }

--- a/Frontend/sakai-ng-master/src/app/biblioteca/services/material-bibliografico.service.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/services/material-bibliografico.service.ts
@@ -865,9 +865,48 @@ listarUsuariosOcurrencia(id: number): Observable<OcurrenciaUsuario[]> {
       .pipe(map(resp => resp.data));
   }
 
-  reporteEjemplarNoPrestado(): Observable<EjemplarNoPrestadoDTO[]> {
+  reporteEjemplarNoPrestado(filtros: {
+    sede?: number;
+    tipoMaterial?: number;
+    especialidad?: number;
+    programa?: number;
+    ciclo?: number;
+    numeroIngreso?: string;
+    fechaInicio?: string;
+    fechaFin?: string;
+  } = {}): Observable<EjemplarNoPrestadoDTO[]> {
     const headers = new HttpHeaders().set('Authorization', `Bearer ${this.authService.getToken()}`);
-    return this.http.get<{ status: number; data: EjemplarNoPrestadoDTO[] }>(`${this.apiUrl}/api/biblioteca/reporte/ejemplar-no-prestados`, { headers }).pipe(map(resp => resp.data));
+    let params = new HttpParams();
+    if (filtros.sede) {
+      params = params.set('sede', filtros.sede);
+    }
+    if (filtros.tipoMaterial) {
+      params = params.set('tipoMaterial', filtros.tipoMaterial);
+    }
+    if (filtros.especialidad) {
+      params = params.set('especialidad', filtros.especialidad);
+    }
+    if (filtros.programa) {
+      params = params.set('programa', filtros.programa);
+    }
+    if (filtros.ciclo) {
+      params = params.set('ciclo', filtros.ciclo);
+    }
+    if (filtros.numeroIngreso) {
+      params = params.set('numeroIngreso', filtros.numeroIngreso);
+    }
+    if (filtros.fechaInicio) {
+      params = params.set('fechaInicio', filtros.fechaInicio);
+    }
+    if (filtros.fechaFin) {
+      params = params.set('fechaFin', filtros.fechaFin);
+    }
+    return this.http
+      .get<{ status: number; data: EjemplarNoPrestadoDTO[] }>(
+        `${this.apiUrl}/api/biblioteca/reporte/ejemplar-no-prestados`,
+        { headers, params }
+      )
+      .pipe(map(resp => resp.data));
   }
 
 }


### PR DESCRIPTION
## Summary
- permitir filtros en reporte de ejemplares no prestados
- propagar parámetros seleccionados en el front-end

## Testing
- `mvn -q test` *(falló: Network is unreachable)*
- `npm test` *(falló: error TS18003)*

------
https://chatgpt.com/codex/tasks/task_e_68c04d92054c8329bd7c25dab7574c40