### PR TITLE
feat: mostrar filtros en cabeceras de exportación

### DIFF
--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/ejemplar-mas-prestado.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/ejemplar-mas-prestado.ts
@@ -7,6 +7,7 @@ import { ClaseGeneral } from '../../interfaces/clase-general';
 import { MaterialBibliograficoService } from '../../services/material-bibliografico.service';
 import { EjemplarPrestadoDTO } from '../../interfaces/reportes/ejemplar-prestado';
 import { HttpClient } from '@angular/common/http';
+import { construirCabeceraFiltros, formatearFecha } from '../../utils/exportacion';
 import { jsPDF } from 'jspdf';
 import autoTable from 'jspdf-autotable';
 import * as ExcelJS from 'exceljs';
@@ -212,11 +213,25 @@ export class ReporteEjemplarMasPrestado {
         const buffer = await this.http.get('/assets/logo.png', { responseType: 'arraybuffer' }).toPromise();
         const logoId = wb.addImage({ buffer, extension: 'png' });
         ws.addImage(logoId, { tl: { col: 0.2, row: 0.2 }, ext: { width: 220, height: 80 } });
-        ws.mergeCells('C1', 'E2');
-        const title = ws.getCell('C1');
-        title.value = 'Ejemplares más prestados';
+        ws.addRows([[], [], [], []]); // espacio para la imagen
+        ws.mergeCells('C5', 'E6');
+        const title = ws.getCell('C5');
+        title.value = this.titulo;
         title.alignment = { vertical: 'middle', horizontal: 'center' };
         title.font = { size: 16, bold: true };
+        ws.addRow([]);
+        const filtrosCabecera = construirCabeceraFiltros([
+            { etiqueta: 'Sede', valor: this.sedeFiltro?.descripcion, defecto: 'Todas' },
+            { etiqueta: 'Tipo Material', valor: this.tipoMaterialFiltro?.descripcion, defecto: 'Todos' },
+            { etiqueta: 'Especialidad', valor: this.especialidadFiltro?.descripcion, defecto: 'Todas' },
+            { etiqueta: 'Programa', valor: this.programaFiltro?.descripcion, defecto: 'Todos' },
+            { etiqueta: 'Ciclo', valor: this.cicloFiltro?.descripcion, defecto: 'Todos' },
+            { etiqueta: 'Fecha Inicio', valor: formatearFecha(this.fechaInicio), defecto: 'Todos' },
+            { etiqueta: 'Fecha Fin', valor: formatearFecha(this.fechaFin), defecto: 'Todos' },
+            { etiqueta: 'Fecha emisión', valor: new Date().toLocaleString() }
+        ]);
+        ws.addRow(filtrosCabecera.etiquetas);
+        ws.addRow(filtrosCabecera.valores);
         ws.addRow([]);
         const headerRow = ws.addRow(['ID', 'Título', 'Ciclo', 'Código de localización', 'Nro Ingreso', 'Año', 'Autor', 'Préstamos']);
         headerRow.font = { bold: true };
@@ -249,10 +264,25 @@ export class ReporteEjemplarMasPrestado {
         img.onload = () => {
             doc.addImage(img, 'PNG', 10, 10, 60, 25);
             doc.setFontSize(16);
-            doc.text('Ejemplares más prestados', 80, 20);
-            doc.setFontSize(10);
-            const hoy = new Date();
-            doc.text(`Fecha de emisión: ${hoy.toLocaleDateString()}`, 80, 25);
+            const pageWidth = doc.internal.pageSize.getWidth();
+            doc.text(this.titulo, pageWidth / 2, 20, { align: 'center' });
+            const filtrosCabecera = construirCabeceraFiltros([
+                { etiqueta: 'Sede', valor: this.sedeFiltro?.descripcion, defecto: 'Todas' },
+                { etiqueta: 'Tipo Material', valor: this.tipoMaterialFiltro?.descripcion, defecto: 'Todos' },
+                { etiqueta: 'Especialidad', valor: this.especialidadFiltro?.descripcion, defecto: 'Todas' },
+                { etiqueta: 'Programa', valor: this.programaFiltro?.descripcion, defecto: 'Todos' },
+                { etiqueta: 'Ciclo', valor: this.cicloFiltro?.descripcion, defecto: 'Todos' },
+                { etiqueta: 'Fecha Inicio', valor: formatearFecha(this.fechaInicio), defecto: 'Todos' },
+                { etiqueta: 'Fecha Fin', valor: formatearFecha(this.fechaFin), defecto: 'Todos' },
+                { etiqueta: 'Fecha emisión', valor: new Date().toLocaleString() }
+            ]);
+            autoTable(doc, {
+                head: [filtrosCabecera.etiquetas],
+                body: [filtrosCabecera.valores],
+                startY: 40,
+                styles: { fontSize: 9 }
+            });
+            const inicioTabla = (doc as any).lastAutoTable.finalY + 5;
             autoTable(doc, {
                 head: [['ID', 'Título', 'Ciclo', 'Código de localización', 'Nro Ingreso', 'Año', 'Autor', 'Préstamos']],
                 body: this.resultados.map(r => [
@@ -265,7 +295,7 @@ export class ReporteEjemplarMasPrestado {
                     r.autor,
                     r.totalPrestamos,
                 ]),
-                startY: 35,
+                startY: inicioTabla,
                 styles: { fontSize: 8 },
                 headStyles: { fillColor: [41, 128, 185] }
             });

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/ejemplar-no-prestado.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/ejemplar-no-prestado.ts
@@ -7,6 +7,7 @@ import { ClaseGeneral } from '../../interfaces/clase-general';
 import { MaterialBibliograficoService } from '../../services/material-bibliografico.service';
 import { EjemplarNoPrestadoDTO } from '../../interfaces/reportes/ejemplar-no-prestado';
 import { HttpClient } from '@angular/common/http';
+import { construirCabeceraFiltros, formatearFecha } from '../../utils/exportacion';
 import { jsPDF } from 'jspdf';
 import autoTable from 'jspdf-autotable';
 import * as ExcelJS from 'exceljs';
@@ -184,11 +185,26 @@ export class ReporteEjemplarNoPrestado {
         const buffer = await this.http.get('/assets/logo.png', { responseType: 'arraybuffer' }).toPromise();
         const logoId = wb.addImage({ buffer, extension: 'png' });
         ws.addImage(logoId, { tl: { col: 0.2, row: 0.2 }, ext: { width: 220, height: 80 } });
-        ws.mergeCells('C1', 'H2');
-        const title = ws.getCell('C1');
-        title.value = 'Ejemplares no prestados';
+        ws.addRows([[], [], [], []]); // espacio para la imagen
+        ws.mergeCells('C5', 'H6');
+        const title = ws.getCell('C5');
+        title.value = this.titulo;
         title.alignment = { vertical: 'middle', horizontal: 'center' };
         title.font = { size: 16, bold: true };
+        ws.addRow([]);
+        const filtrosCabecera = construirCabeceraFiltros([
+            { etiqueta: 'Sede', valor: this.sedeFiltro?.descripcion, defecto: 'Todas' },
+            { etiqueta: 'Tipo Material', valor: this.tipoMaterialFiltro?.descripcion, defecto: 'Todos' },
+            { etiqueta: 'Especialidad', valor: this.especialidadFiltro?.descripcion, defecto: 'Todas' },
+            { etiqueta: 'Programa', valor: this.programaFiltro?.descripcion, defecto: 'Todos' },
+            { etiqueta: 'Ciclo', valor: this.cicloFiltro?.descripcion, defecto: 'Todos' },
+            { etiqueta: 'N° ingreso', valor: this.nroIngreso || undefined, defecto: 'Todos' },
+            { etiqueta: 'Fecha Inicio', valor: formatearFecha(this.fechaInicio), defecto: 'Todos' },
+            { etiqueta: 'Fecha Fin', valor: formatearFecha(this.fechaFin), defecto: 'Todos' },
+            { etiqueta: 'Fecha emisión', valor: new Date().toLocaleString() }
+        ]);
+        ws.addRow(filtrosCabecera.etiquetas);
+        ws.addRow(filtrosCabecera.valores);
         ws.addRow([]);
         const headerRow = ws.addRow(['ID', 'Título', 'Código localización', 'N° ingreso', 'Autor personal', 'Año']);
         headerRow.font = { bold: true };
@@ -217,10 +233,26 @@ export class ReporteEjemplarNoPrestado {
         img.onload = () => {
             doc.addImage(img, 'PNG', 10, 10, 60, 25);
             doc.setFontSize(16);
-            doc.text('Ejemplares no prestados', 80, 20);
-            doc.setFontSize(10);
-            const hoy = new Date();
-            doc.text(`Fecha de emisión: ${hoy.toLocaleDateString()}`, 80, 25);
+            const pageWidth = doc.internal.pageSize.getWidth();
+            doc.text(this.titulo, pageWidth / 2, 20, { align: 'center' });
+            const filtrosCabecera = construirCabeceraFiltros([
+                { etiqueta: 'Sede', valor: this.sedeFiltro?.descripcion, defecto: 'Todas' },
+                { etiqueta: 'Tipo Material', valor: this.tipoMaterialFiltro?.descripcion, defecto: 'Todos' },
+                { etiqueta: 'Especialidad', valor: this.especialidadFiltro?.descripcion, defecto: 'Todas' },
+                { etiqueta: 'Programa', valor: this.programaFiltro?.descripcion, defecto: 'Todos' },
+                { etiqueta: 'Ciclo', valor: this.cicloFiltro?.descripcion, defecto: 'Todos' },
+                { etiqueta: 'N° ingreso', valor: this.nroIngreso || undefined, defecto: 'Todos' },
+                { etiqueta: 'Fecha Inicio', valor: formatearFecha(this.fechaInicio), defecto: 'Todos' },
+                { etiqueta: 'Fecha Fin', valor: formatearFecha(this.fechaFin), defecto: 'Todos' },
+                { etiqueta: 'Fecha emisión', valor: new Date().toLocaleString() }
+            ]);
+            autoTable(doc, {
+                head: [filtrosCabecera.etiquetas],
+                body: [filtrosCabecera.valores],
+                startY: 40,
+                styles: { fontSize: 9 }
+            });
+            const inicioTabla = (doc as any).lastAutoTable.finalY + 5;
             autoTable(doc, {
                 head: [['ID', 'Título', 'Código localización', 'N° ingreso', 'Autor personal', 'Año']],
                 body: this.resultados.map((r) => [
@@ -231,7 +263,7 @@ export class ReporteEjemplarNoPrestado {
                     r.autor,
                     r.anio ?? ''
                 ]),
-                startY: 35,
+                startY: inicioTabla,
                 styles: { fontSize: 8 },
                 headStyles: { fillColor: [41, 128, 185] }
             });

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/estudiantes-atendidos.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/estudiantes-atendidos.ts
@@ -13,6 +13,7 @@ import autoTable from 'jspdf-autotable';
 import * as ExcelJS from 'exceljs';
 import { saveAs } from 'file-saver';
 import { ReportesFiltroService } from '../../services/reportes-filtro.service';
+import { construirCabeceraFiltros, formatearFecha } from '../../utils/exportacion';
 
 interface Row {
     usuario: string;
@@ -204,11 +205,25 @@ export class ReporteEstudiantesAtendidos implements OnInit {
         const buffer = await this.http.get('/assets/logo.png', { responseType: 'arraybuffer' }).toPromise();
         const logoId = wb.addImage({ buffer, extension: 'png' });
         ws.addImage(logoId, { tl: { col: 0.2, row: 0.2 }, ext: { width: 220, height: 80 } });
-        ws.mergeCells('C1', 'E2');
-        const title = ws.getCell('C1');
-        title.value = 'Estudiantes atendidos';
+        ws.addRows([[], [], [], []]); // espacio para la imagen
+        ws.mergeCells('C5', 'E6');
+        const title = ws.getCell('C5');
+       title.value = this.titulo;
         title.alignment = { vertical: 'middle', horizontal: 'center' };
         title.font = { size: 16, bold: true };
+        ws.addRow([]);
+        const filtrosCabecera = construirCabeceraFiltros([
+            { etiqueta: 'Sede', valor: this.sedeFiltro?.descripcion, defecto: 'Todas' },
+            { etiqueta: 'Tipo de préstamo', valor: this.tipoMaterialFiltro?.descripcion, defecto: 'Todos' },
+            { etiqueta: 'Especialidad', valor: this.especialidadFiltro?.descripcion, defecto: 'Todas' },
+            { etiqueta: 'Programa', valor: this.programaFiltro?.descripcion, defecto: 'Todos' },
+            { etiqueta: 'Ciclo', valor: this.cicloFiltro?.descripcion, defecto: 'Todos' },
+            { etiqueta: 'Fecha Inicio', valor: formatearFecha(this.fechaInicio), defecto: 'Todos' },
+            { etiqueta: 'Fecha Fin', valor: formatearFecha(this.fechaFin), defecto: 'Todos' },
+            { etiqueta: 'Fecha emisión', valor: new Date().toLocaleString() }
+        ]);
+        ws.addRow(filtrosCabecera.etiquetas);
+        ws.addRow(filtrosCabecera.valores);
         ws.addRow([]);
         const headerRow = ws.addRow(['Usuario', 'Sede', 'Préstamos']);
         headerRow.font = { bold: true };
@@ -230,14 +245,29 @@ export class ReporteEstudiantesAtendidos implements OnInit {
         img.onload = () => {
             doc.addImage(img, 'PNG', 10, 10, 60, 25);
             doc.setFontSize(16);
-            doc.text('Estudiantes atendidos', 80, 20);
-            doc.setFontSize(10);
-            const hoy = new Date();
-            doc.text(`Fecha de emisión: ${hoy.toLocaleDateString()}`, 80, 25);
+            const pageWidth = doc.internal.pageSize.getWidth();
+            doc.text(this.titulo, pageWidth / 2, 20, { align: 'center' });
+            const filtrosCabecera = construirCabeceraFiltros([
+                { etiqueta: 'Sede', valor: this.sedeFiltro?.descripcion, defecto: 'Todas' },
+                { etiqueta: 'Tipo de préstamo', valor: this.tipoMaterialFiltro?.descripcion, defecto: 'Todos' },
+                { etiqueta: 'Especialidad', valor: this.especialidadFiltro?.descripcion, defecto: 'Todas' },
+                { etiqueta: 'Programa', valor: this.programaFiltro?.descripcion, defecto: 'Todos' },
+                { etiqueta: 'Ciclo', valor: this.cicloFiltro?.descripcion, defecto: 'Todos' },
+                { etiqueta: 'Fecha Inicio', valor: formatearFecha(this.fechaInicio), defecto: 'Todos' },
+                { etiqueta: 'Fecha Fin', valor: formatearFecha(this.fechaFin), defecto: 'Todos' },
+                { etiqueta: 'Fecha emisión', valor: new Date().toLocaleString() }
+            ]);
+            autoTable(doc, {
+                head: [filtrosCabecera.etiquetas],
+                body: [filtrosCabecera.valores],
+                startY: 40,
+                styles: { fontSize: 9 }
+            });
+            const inicioTabla = (doc as any).lastAutoTable.finalY + 5;
             autoTable(doc, {
                 head: [['Usuario', 'Sede', 'Préstamos']],
                 body: this.resultados.map(r => [r.usuario, r.sede || '-', r.totalPrestamos]),
-                startY: 35,
+                startY: inicioTabla,
                 styles: { fontSize: 8 },
                 headStyles: { fillColor: [41, 128, 185] }
             });

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/inventario-material-bibliografico.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/inventario-material-bibliografico.ts
@@ -13,6 +13,7 @@ import autoTable from 'jspdf-autotable';
 import * as ExcelJS from 'exceljs';
 import { saveAs } from 'file-saver';
 import { ReportesFiltroService } from '../../services/reportes-filtro.service';
+import { construirCabeceraFiltros } from '../../utils/exportacion';
 
 @Component({
     selector: 'app-reporte-inventario-material-bibliografico',
@@ -158,11 +159,20 @@ export class ReporteInventarioMaterialBibliografico {
         const buffer = await this.http.get('/assets/logo.png', { responseType: 'arraybuffer' }).toPromise();
         const logoId = wb.addImage({ buffer, extension: 'png' });
         ws.addImage(logoId, { tl: { col: 0.2, row: 0.2 }, ext: { width: 220, height: 80 } });
-        ws.mergeCells('C1', 'H2');
-        const title = ws.getCell('C1');
+        ws.addRows([[], [], [], []]); // espacio para la imagen
+        ws.mergeCells('C5', 'H6');
+        const title = ws.getCell('C5');
         title.value = this.titulo;
         title.alignment = { vertical: 'middle', horizontal: 'center' };
         title.font = { size: 16, bold: true };
+        ws.addRow([]);
+        const filtrosCabecera = construirCabeceraFiltros([
+            { etiqueta: 'Sede', valor: this.sedeFiltro?.descripcion, defecto: 'Todas' },
+            { etiqueta: 'Colección', valor: this.coleccionFiltro?.descripcion, defecto: 'Todas' },
+            { etiqueta: 'Fecha emisión', valor: new Date().toLocaleString() }
+        ]);
+        ws.addRow(filtrosCabecera.etiquetas);
+        ws.addRow(filtrosCabecera.valores);
         ws.addRow([]);
         const headerRow = ws.addRow(['N°', 'ID', 'N° Ingreso', 'Tipo Material', 'Título', 'Autor', 'Estado', 'Verificar', 'Observaciones']);
         headerRow.font = { bold: true };
@@ -186,14 +196,24 @@ export class ReporteInventarioMaterialBibliografico {
         img.onload = () => {
             doc.addImage(img, 'PNG', 10, 10, 60, 25);
             doc.setFontSize(16);
-            doc.text(this.titulo, 80, 20);
-            doc.setFontSize(10);
-            const hoy = new Date();
-            doc.text(`Fecha de emisión: ${hoy.toLocaleDateString()}`, 80, 25);
+            const pageWidth = doc.internal.pageSize.getWidth();
+            doc.text(this.titulo, pageWidth / 2, 20, { align: 'center' });
+            const filtrosCabecera = construirCabeceraFiltros([
+                { etiqueta: 'Sede', valor: this.sedeFiltro?.descripcion, defecto: 'Todas' },
+                { etiqueta: 'Colección', valor: this.coleccionFiltro?.descripcion, defecto: 'Todas' },
+                { etiqueta: 'Fecha emisión', valor: new Date().toLocaleString() }
+            ]);
+            autoTable(doc, {
+                head: [filtrosCabecera.etiquetas],
+                body: [filtrosCabecera.valores],
+                startY: 40,
+                styles: { fontSize: 9 }
+            });
+            const inicioTabla = (doc as any).lastAutoTable.finalY + 5;
             autoTable(doc, {
                 head: [['N°', 'ID', 'N° Ingreso', 'Tipo Material', 'Título', 'Autor', 'Estado', 'Verificar', 'Observaciones']],
                 body: this.resultados.map((r, idx) => [idx + 1, r.id, r.numeroIngreso ?? '-', r.tipoMaterial ?? '-', r.titulo ?? '-', r.autor ?? '-', r.estado ?? '-', '', '']),
-                startY: 35,
+                startY: inicioTabla,
                 styles: { fontSize: 8 },
                 headStyles: { fillColor: [41, 128, 185] }
             });

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/material-bibliografico-detallado.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/material-bibliografico-detallado.ts
@@ -17,6 +17,7 @@ import { jsPDF } from 'jspdf';
 import autoTable from 'jspdf-autotable';
 import { HttpClient } from '@angular/common/http';
 import { GenericoService } from '../../services/generico.service';
+import { construirCabeceraFiltros } from '../../utils/exportacion';
 @Component({
     selector: 'app-reporte-material-bibliografico-detallado',
     standalone: true,
@@ -335,11 +336,20 @@ export class ReporteMaterialBibliograficoDetallado {
         const buffer = await this.http.get('/assets/logo.png', { responseType: 'arraybuffer' }).toPromise();
         const logoId = wb.addImage({ buffer, extension: 'png' });
         ws.addImage(logoId, { tl: { col: 0.2, row: 0.2 }, ext: { width: 220, height: 80 } });
-        ws.mergeCells('C1', 'E2');
-        const title = ws.getCell('C1');
+        ws.addRows([[], [], [], []]); // espacio para la imagen
+        ws.mergeCells('C5', 'E6');
+        const title = ws.getCell('C5');
         title.value = this.titulo;
         title.alignment = { vertical: 'middle', horizontal: 'center' };
         title.font = { size: 16, bold: true };
+        ws.addRow([]);
+        const filtrosCabecera = construirCabeceraFiltros([
+            { etiqueta: 'Sede', valor: this.sedeFiltro?.descripcion, defecto: 'Todas' },
+            { etiqueta: 'Colección', valor: this.coleccionFiltro?.descripcion, defecto: 'Todas' },
+            { etiqueta: 'Fecha emisión', valor: new Date().toLocaleString() }
+        ]);
+        ws.addRow(filtrosCabecera.etiquetas);
+        ws.addRow(filtrosCabecera.valores);
         ws.addRow([]);
         const headerRow = ws.addRow(this.columns.map(c => c.header));
         headerRow.font = { bold: true };
@@ -361,14 +371,24 @@ export class ReporteMaterialBibliograficoDetallado {
         img.onload = () => {
             doc.addImage(img, 'PNG', 10, 10, 60, 25);
             doc.setFontSize(16);
-            doc.text(this.titulo, 80, 20);
-            doc.setFontSize(10);
-            const hoy = new Date();
-            doc.text(`Fecha de emisión: ${hoy.toLocaleDateString()}`, 80, 25);
+            const pageWidth = doc.internal.pageSize.getWidth();
+            doc.text(this.titulo, pageWidth / 2, 20, { align: 'center' });
+            const filtrosCabecera = construirCabeceraFiltros([
+                { etiqueta: 'Sede', valor: this.sedeFiltro?.descripcion, defecto: 'Todas' },
+                { etiqueta: 'Colección', valor: this.coleccionFiltro?.descripcion, defecto: 'Todas' },
+                { etiqueta: 'Fecha emisión', valor: new Date().toLocaleString() }
+            ]);
+            autoTable(doc, {
+                head: [filtrosCabecera.etiquetas],
+                body: [filtrosCabecera.valores],
+                startY: 40,
+                styles: { fontSize: 9 }
+            });
+            const inicioTabla = (doc as any).lastAutoTable.finalY + 5;
             autoTable(doc, {
                 head: [this.columns.map(c => c.header)],
                 body: this.data.map(r => this.columns.map(c => this.resolveField(r, c.field))),
-                startY: 35,
+                startY: inicioTabla,
                 styles: { fontSize: 8 },
                 headStyles: { fillColor: [41, 128, 185] }
             });

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/reporte-prestamo-equipo-computo.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/reporte-prestamo-equipo-computo.ts
@@ -22,6 +22,7 @@ import { ReportesFiltroService } from '../../services/reportes-filtro.service';
 import * as ExcelJS from 'exceljs';
 import { saveAs } from 'file-saver';
 import { HttpClient } from '@angular/common/http';
+import { construirCabeceraFiltros, formatearFecha } from '../../utils/exportacion';
 @Component({
     selector: 'app-reporte-prestamo-equipo-computo',
     standalone: true,
@@ -284,22 +285,35 @@ async reporte() {
         tl: { col: 0.2, row: 0.2 },
         ext: { width: 220, height: 80 }
       });
+      ws.addRows([[], [], [], []]); // espacio para la imagen
 
-
-    // 2) Título y fecha
-    ws.mergeCells('C1', 'G2');
-    const tituloCell = ws.getCell('C1');
-    tituloCell.value = 'ESTADÍSTICA MENSUAL DEL SERVICIO';
+    // 2) Título
+    ws.mergeCells('C5', 'G6');
+    const tituloCell = ws.getCell('C5');
+    tituloCell.value = this.titulo;
     tituloCell.alignment = { vertical: 'middle', horizontal: 'center' };
     tituloCell.font = { size: 16, bold: true };
-
-    ws.getCell('C3').value = `Fecha de emisión: ${new Date().toLocaleDateString()}`;
+    ws.addRow([]);
 
     // 3) Filtros
-    ws.getCell('C4').value = `Sede: ${this.sedeFiltroLabel}`;
-    ws.getCell('G3').value = `Programa: ${this.programaFiltroLabel}`;
-    ws.getCell('A5').value = ``;
-    // …
+    const filtrosCabecera = construirCabeceraFiltros([
+      { etiqueta: 'Sede', valor: this.sedeFiltro?.descripcion, defecto: 'Todas' },
+      { etiqueta: 'Tipo Usuario', valor: this.tipoUsuarioFiltro?.descripcion, defecto: 'Todos' },
+      {
+        etiqueta: 'Estado',
+        valor: this.tipoPrestamoLista.find((t) => t.value === this.tipoPrestamoFiltro)?.label,
+        defecto: 'Todos'
+      },
+      { etiqueta: 'Escuela', valor: this.escuelaFiltro?.descripcion, defecto: 'Todas' },
+      { etiqueta: 'Programa', valor: this.programaFiltro?.descripcion, defecto: 'Todos' },
+      { etiqueta: 'Ciclo', valor: this.cicloFiltro?.descripcion, defecto: 'Todos' },
+      { etiqueta: 'Fecha Inicio', valor: formatearFecha(this.fechaInicio), defecto: 'Todos' },
+      { etiqueta: 'Fecha Fin', valor: formatearFecha(this.fechaFin), defecto: 'Todos' },
+      { etiqueta: 'Fecha emisión', valor: new Date().toLocaleString() }
+    ]);
+    ws.addRow(filtrosCabecera.etiquetas);
+    ws.addRow(filtrosCabecera.valores);
+    ws.addRow([]);
 
     // 4) Encabezados de la tabla
     const headerRow = ws.addRow([ 'Equipo', 'Alcance', 'Usuario', 'Especialidad',
@@ -339,28 +353,38 @@ async reporte() {
 
   const doc = new jsPDF({ orientation: 'landscape' });
 
-  // 1) Crear un elemento Image y apuntar a tu logo en assets
   const img = new Image();
   img.src = '/assets/logo.png';
 
   img.onload = () => {
-    // 2) Añadir la imagen al PDF (x=10, y=10, width=40, height=15)
     doc.addImage(img, 'PNG', 10, 10, 60, 25);
-
-    // 3) Escribir título y fecha
     doc.setFontSize(16);
-    doc.text('ESTADÍSTICA MENSUAL DEL SERVICIO', 80, 20);
-    doc.setFontSize(10);
-    const hoy = new Date();
-    doc.text(`Fecha de emisión: ${hoy.toLocaleDateString()}`, 80, 25);
+    const pageWidth = doc.internal.pageSize.getWidth();
+    doc.text(this.titulo, pageWidth / 2, 20, { align: 'center' });
 
-    // 4) Repetir filtros si quieres
-    doc.setFontSize(9);
-    doc.text(`Sede: ${this.sedeFiltroLabel}`, 80, 30);
-    doc.text(`Programa: ${this.programaFiltroLabel}`, 120, 30);
-    // … más filtros …
+    const filtrosCabecera = construirCabeceraFiltros([
+      { etiqueta: 'Sede', valor: this.sedeFiltro?.descripcion, defecto: 'Todas' },
+      { etiqueta: 'Tipo Usuario', valor: this.tipoUsuarioFiltro?.descripcion, defecto: 'Todos' },
+      {
+        etiqueta: 'Estado',
+        valor: this.tipoPrestamoLista.find((t) => t.value === this.tipoPrestamoFiltro)?.label,
+        defecto: 'Todos'
+      },
+      { etiqueta: 'Escuela', valor: this.escuelaFiltro?.descripcion, defecto: 'Todas' },
+      { etiqueta: 'Programa', valor: this.programaFiltro?.descripcion, defecto: 'Todos' },
+      { etiqueta: 'Ciclo', valor: this.cicloFiltro?.descripcion, defecto: 'Todos' },
+      { etiqueta: 'Fecha Inicio', valor: formatearFecha(this.fechaInicio), defecto: 'Todos' },
+      { etiqueta: 'Fecha Fin', valor: formatearFecha(this.fechaFin), defecto: 'Todos' },
+      { etiqueta: 'Fecha emisión', valor: new Date().toLocaleString() }
+    ]);
+    autoTable(doc, {
+      head: [filtrosCabecera.etiquetas],
+      body: [filtrosCabecera.valores],
+      startY: 40,
+      styles: { fontSize: 9 }
+    });
+    const inicioTabla = (doc as any).lastAutoTable.finalY + 5;
 
-    // 5) Generar la tabla con autoTable
     autoTable(doc, {
       head: [[
         'Equipo', 'Alcance', 'Usuario', 'Especialidad',
@@ -378,21 +402,16 @@ async reporte() {
         r.usuarioRecepcion || '-',
         r.fechaRecepcion || '-'
       ]),
-      startY: 35,
+      startY: inicioTabla,
       styles: { fontSize: 8 },
       headStyles: { fillColor: [41, 128, 185] }
     });
 
-    // 6) Guardar el PDF
     doc.save('estadistica_mensual.pdf');
   };
 
   img.onerror = () => {
     console.error('No se pudo cargar /assets/logo.png');
-    // Si quieres, puedes seguir sin logo:
-    // doc.text('ESTADÍSTICA MENSUAL DEL SERVICIO', 10, 20);
-    // autoTable(...)
-    // doc.save(...)
   };
     }
 }

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/reporte-prestamo-mat-bibliografico.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/reporte-prestamo-mat-bibliografico.ts
@@ -22,6 +22,7 @@ import { ReportesFiltroService } from '../../services/reportes-filtro.service';
 import * as ExcelJS from 'exceljs';
 import { saveAs } from 'file-saver';
 import { HttpClient } from '@angular/common/http';
+import { construirCabeceraFiltros, formatearFecha } from '../../utils/exportacion';
 
 @Component({
     selector: 'app-reporte-prestamo-mat-bibliografico',
@@ -279,22 +280,35 @@ async reporte() {
         tl: { col: 0.2, row: 0.2 },
         ext: { width: 220, height: 80 }
       });
+      ws.addRows([[], [], [], []]); // espacio para la imagen
 
-
-    // 2) Título y fecha
-    ws.mergeCells('C1', 'G2');
-    const tituloCell = ws.getCell('C1');
-    tituloCell.value = 'ESTADÍSTICA MENSUAL DEL SERVICIO';
+    // 2) Título
+    ws.mergeCells('C5', 'G6');
+    const tituloCell = ws.getCell('C5');
+    tituloCell.value = this.titulo;
     tituloCell.alignment = { vertical: 'middle', horizontal: 'center' };
     tituloCell.font = { size: 16, bold: true };
-
-    ws.getCell('C3').value = `Fecha de emisión: ${new Date().toLocaleDateString()}`;
+    ws.addRow([]);
 
     // 3) Filtros
-    ws.getCell('C4').value = `Sede: ${this.sedeFiltroLabel}`;
-    ws.getCell('G3').value = `Programa: ${this.programaFiltroLabel}`;
-    ws.getCell('A5').value = ``;
-    // …
+    const filtrosCabecera = construirCabeceraFiltros([
+      { etiqueta: 'Sede', valor: this.sedeFiltro?.descripcion, defecto: 'Todas' },
+      { etiqueta: 'Tipo Usuario', valor: this.tipoUsuarioFiltro?.descripcion, defecto: 'Todos' },
+      {
+        etiqueta: 'Estado',
+        valor: this.tipoPrestamoLista.find((t) => t.value === this.tipoPrestamoFiltro)?.label,
+        defecto: 'Todos'
+      },
+      { etiqueta: 'Especialidad', valor: this.especialidadFiltro?.descripcion, defecto: 'Todas' },
+      { etiqueta: 'Programa', valor: this.programaFiltro?.descripcion, defecto: 'Todos' },
+      { etiqueta: 'Ciclo', valor: this.cicloFiltro?.descripcion, defecto: 'Todos' },
+      { etiqueta: 'Fecha Inicio', valor: formatearFecha(this.fechaInicio), defecto: 'Todos' },
+      { etiqueta: 'Fecha Fin', valor: formatearFecha(this.fechaFin), defecto: 'Todos' },
+      { etiqueta: 'Fecha emisión', valor: new Date().toLocaleString() }
+    ]);
+    ws.addRow(filtrosCabecera.etiquetas);
+    ws.addRow(filtrosCabecera.valores);
+    ws.addRow([]);
 
     // 4) Encabezados de la tabla
     const headerRow = ws.addRow([ 'Material', 'N° Ingreso', 'Usuario', 'Especialidad',
@@ -334,28 +348,38 @@ async reporte() {
 
   const doc = new jsPDF({ orientation: 'landscape' });
 
-  // 1) Crear un elemento Image y apuntar a tu logo en assets
   const img = new Image();
   img.src = '/assets/logo.png';
 
   img.onload = () => {
-    // 2) Añadir la imagen al PDF (x=10, y=10, width=40, height=15)
     doc.addImage(img, 'PNG', 10, 10, 60, 25);
-
-    // 3) Escribir título y fecha
     doc.setFontSize(16);
-    doc.text('ESTADÍSTICA MENSUAL DEL SERVICIO', 80, 20);
-    doc.setFontSize(10);
-    const hoy = new Date();
-    doc.text(`Fecha de emisión: ${hoy.toLocaleDateString()}`, 80, 25);
+    const pageWidth = doc.internal.pageSize.getWidth();
+    doc.text(this.titulo, pageWidth / 2, 20, { align: 'center' });
 
-    // 4) Repetir filtros si quieres
-    doc.setFontSize(9);
-    doc.text(`Sede: ${this.sedeFiltroLabel}`, 80, 30);
-    doc.text(`Programa: ${this.programaFiltroLabel}`, 120, 30);
-    // … más filtros …
+    const filtrosCabecera = construirCabeceraFiltros([
+      { etiqueta: 'Sede', valor: this.sedeFiltro?.descripcion, defecto: 'Todas' },
+      { etiqueta: 'Tipo Usuario', valor: this.tipoUsuarioFiltro?.descripcion, defecto: 'Todos' },
+      {
+        etiqueta: 'Estado',
+        valor: this.tipoPrestamoLista.find((t) => t.value === this.tipoPrestamoFiltro)?.label,
+        defecto: 'Todos'
+      },
+      { etiqueta: 'Especialidad', valor: this.especialidadFiltro?.descripcion, defecto: 'Todas' },
+      { etiqueta: 'Programa', valor: this.programaFiltro?.descripcion, defecto: 'Todos' },
+      { etiqueta: 'Ciclo', valor: this.cicloFiltro?.descripcion, defecto: 'Todos' },
+      { etiqueta: 'Fecha Inicio', valor: formatearFecha(this.fechaInicio), defecto: 'Todos' },
+      { etiqueta: 'Fecha Fin', valor: formatearFecha(this.fechaFin), defecto: 'Todos' },
+      { etiqueta: 'Fecha emisión', valor: new Date().toLocaleString() }
+    ]);
+    autoTable(doc, {
+      head: [filtrosCabecera.etiquetas],
+      body: [filtrosCabecera.valores],
+      startY: 40,
+      styles: { fontSize: 9 }
+    });
+    const inicioTabla = (doc as any).lastAutoTable.finalY + 5;
 
-    // 5) Generar la tabla con autoTable
     autoTable(doc, {
       head: [[
         'Material', 'N° Ingreso', 'Usuario', 'Especialidad',
@@ -373,21 +397,16 @@ async reporte() {
         r.usuarioRecepcion || '-',
         r.fechaRecepcion || '-'
       ]),
-      startY: 35,
+      startY: inicioTabla,
       styles: { fontSize: 8 },
       headStyles: { fillColor: [41, 128, 185] }
     });
 
-    // 6) Guardar el PDF
     doc.save('estadistica_mensual.pdf');
   };
 
   img.onerror = () => {
     console.error('No se pudo cargar /assets/logo.png');
-    // Si quieres, puedes seguir sin logo:
-    // doc.text('ESTADÍSTICA MENSUAL DEL SERVICIO', 10, 20);
-    // autoTable(...)
-    // doc.save(...)
   };
     }
 }

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/usuarios-atendidos-biblioteca.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/usuarios-atendidos-biblioteca.ts
@@ -13,6 +13,7 @@ import autoTable from 'jspdf-autotable';
 import * as ExcelJS from 'exceljs';
 import { saveAs } from 'file-saver';
 import { ReportesFiltroService } from '../../services/reportes-filtro.service';
+import { construirCabeceraFiltros, formatearFecha } from '../../utils/exportacion';
 
 @Component({
     selector: 'app-reporte-usuarios-atendidos-biblioteca',
@@ -186,11 +187,25 @@ export class ReporteUsuariosAtendidosBiblioteca {
         const buffer = await this.http.get('/assets/logo.png', { responseType: 'arraybuffer' }).toPromise();
         const logoId = wb.addImage({ buffer, extension: 'png' });
         ws.addImage(logoId, { tl: { col: 0.2, row: 0.2 }, ext: { width: 220, height: 80 } });
-        ws.mergeCells('C1', 'F2');
-        const title = ws.getCell('C1');
-        title.value = 'Usuarios atendidos';
+        ws.addRows([[], [], [], []]); // espacio para la imagen
+        ws.mergeCells('C5', 'F6');
+        const title = ws.getCell('C5');
+        title.value = this.titulo;
         title.alignment = { vertical: 'middle', horizontal: 'center' };
         title.font = { size: 16, bold: true };
+        ws.addRow([]);
+        const filtrosCabecera = construirCabeceraFiltros([
+            { etiqueta: 'Sede', valor: this.sedeFiltro?.descripcion, defecto: 'Todas' },
+            { etiqueta: 'Tipo Usuario', valor: this.tipoUsuarioFiltro?.descripcion, defecto: 'Todos' },
+            { etiqueta: 'Especialidad', valor: this.especialidadFiltro?.descripcion, defecto: 'Todas' },
+            { etiqueta: 'Programa', valor: this.programaFiltro?.descripcion, defecto: 'Todos' },
+            { etiqueta: 'Ciclo', valor: this.cicloFiltro?.descripcion, defecto: 'Todos' },
+            { etiqueta: 'Fecha Inicio', valor: formatearFecha(this.fechaInicio), defecto: 'Todos' },
+            { etiqueta: 'Fecha Fin', valor: formatearFecha(this.fechaFin), defecto: 'Todos' },
+            { etiqueta: 'Fecha emisión', valor: new Date().toLocaleString() }
+        ]);
+        ws.addRow(filtrosCabecera.etiquetas);
+        ws.addRow(filtrosCabecera.valores);
         ws.addRow([]);
         const headerRow = ws.addRow(['Usuario', 'Sede', 'Préstamos']);
         headerRow.font = { bold: true };
@@ -212,14 +227,29 @@ export class ReporteUsuariosAtendidosBiblioteca {
         img.onload = () => {
             doc.addImage(img, 'PNG', 10, 10, 60, 25);
             doc.setFontSize(16);
-            doc.text('Usuarios atendidos', 80, 20);
-            doc.setFontSize(10);
-            const hoy = new Date();
-            doc.text(`Fecha de emisión: ${hoy.toLocaleDateString()}`, 80, 25);
+            const pageWidth = doc.internal.pageSize.getWidth();
+            doc.text(this.titulo, pageWidth / 2, 20, { align: 'center' });
+            const filtrosCabecera = construirCabeceraFiltros([
+                { etiqueta: 'Sede', valor: this.sedeFiltro?.descripcion, defecto: 'Todas' },
+                { etiqueta: 'Tipo Usuario', valor: this.tipoUsuarioFiltro?.descripcion, defecto: 'Todos' },
+                { etiqueta: 'Especialidad', valor: this.especialidadFiltro?.descripcion, defecto: 'Todas' },
+                { etiqueta: 'Programa', valor: this.programaFiltro?.descripcion, defecto: 'Todos' },
+                { etiqueta: 'Ciclo', valor: this.cicloFiltro?.descripcion, defecto: 'Todos' },
+                { etiqueta: 'Fecha Inicio', valor: formatearFecha(this.fechaInicio), defecto: 'Todos' },
+                { etiqueta: 'Fecha Fin', valor: formatearFecha(this.fechaFin), defecto: 'Todos' },
+                { etiqueta: 'Fecha emisión', valor: new Date().toLocaleString() }
+            ]);
+            autoTable(doc, {
+                head: [filtrosCabecera.etiquetas],
+                body: [filtrosCabecera.valores],
+                startY: 40,
+                styles: { fontSize: 9 }
+            });
+            const inicioTabla = (doc as any).lastAutoTable.finalY + 5;
             autoTable(doc, {
                 head: [['Usuario', 'Sede', 'Préstamos']],
                 body: this.resultados.map((r) => [r.usuario, r.sede || '-', r.totalPrestamos]),
-                startY: 35,
+                startY: inicioTabla,
                 styles: { fontSize: 8 },
                 headStyles: { fillColor: [41, 128, 185] }
             });

--- a/Frontend/sakai-ng-master/src/app/biblioteca/utils/exportacion.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/utils/exportacion.ts
@@ -1,0 +1,21 @@
+export interface FiltroCabecera {
+  etiqueta: string;
+  valor?: string | number;
+  defecto?: string;
+}
+
+export interface CabeceraFiltros {
+  etiquetas: string[];
+  valores: (string | number)[];
+}
+
+export function construirCabeceraFiltros(filtros: FiltroCabecera[]): CabeceraFiltros {
+  return {
+    etiquetas: filtros.map((f) => f.etiqueta),
+    valores: filtros.map((f) => f.valor ?? f.defecto ?? 'Todos')
+  };
+}
+
+export function formatearFecha(fecha?: Date): string | undefined {
+  return fecha ? fecha.toLocaleDateString() : undefined;
+}


### PR DESCRIPTION
## Resumen
- centrar títulos y mostrar filtros en filas separadas
- estructurar filtros en una tabla tanto en exportaciones Excel como PDF
- reservar espacio para el logo en las exportaciones Excel sin superponerlo con la cabecera

## Testing
- `npm test -- --watch=false` *(falla: TS18003 no encontró entradas en tsconfig.spec.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c055d0a55883298b8d4fc0b16569b3