### PR TITLE
Elimina opción de cancelación en devoluciones

### DIFF
--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/devoluciones/biblioteca-virtual/biblioteca-virtual.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/devoluciones/biblioteca-virtual/biblioteca-virtual.ts
@@ -19,7 +19,6 @@ import { MaterialBibliograficoService } from '../../../services/material-bibliog
 import { TemplateModule } from '../../../template.module';
 import { BibliotecaVirtualService } from '../../../services/biblioteca-virtual.service';
 import { Tipo } from '../../../interfaces/prestamos/tipo';
-import { DevolucionesService } from '../../../services/devoluciones.service';
 import { PrestamosService } from '../../../services/prestamos.service';
 import { ModalNuevoOcurencia } from '../../laboratorio-computo/modal-nuevo-ocurrencia';
 
@@ -107,7 +106,6 @@ import { ModalNuevoOcurencia } from '../../laboratorio-computo/modal-nuevo-ocurr
                             <th pSortableColumn="fechaPrestamo" style="width: 8rem">Fecha de préstamo<p-sortIcon
                                 field="fechaPrestamo"></p-sortIcon></th>
                             <th style="width: 8rem">Devolver</th>
-                            <th style="width: 8rem">Cancelar</th>
                             <th style="width:8rem">Ocurrencia</th>
                           </tr>
                         </ng-template>
@@ -143,10 +141,6 @@ import { ModalNuevoOcurencia } from '../../laboratorio-computo/modal-nuevo-ocurr
 
                             </td>
                             <td>
-                              <p-button icon="pi pi-times" rounded outlined (click)="cancelar(objeto)" pTooltip="Cancelar"
-                                tooltipPosition="bottom" />
-                            </td>
-                            <td>
                                <p-button
                                  icon="pi pi-file"
                                  rounded
@@ -161,12 +155,12 @@ import { ModalNuevoOcurencia } from '../../laboratorio-computo/modal-nuevo-ocurr
 
                         <ng-template pTemplate="emptymessage">
                           <tr>
-                            <td colspan="8">No se encontraron registros.</td>
+                            <td colspan="9">No se encontraron registros.</td>
                           </tr>
                         </ng-template>
                         <ng-template pTemplate="loadingbody">
                           <tr>
-                            <td colspan="8">Cargando datos. Espere por favor.</td>
+                            <td colspan="9">Cargando datos. Espere por favor.</td>
                           </tr>
                         </ng-template>
                       </p-table>
@@ -186,7 +180,6 @@ export class DevolucionBibliotecaVirtual implements OnInit {
     titulo: string = "Devoluciones";
     data: any[] = [];
     detalle: any[] = [];
-    modulo: string = "aceptaciones";
     loading: boolean = true;
     objeto: Ejemplar = new Ejemplar();
     objetoDialog!: boolean;
@@ -208,7 +201,7 @@ export class DevolucionBibliotecaVirtual implements OnInit {
     todosPrestamos: any[] = [];
     @ViewChild('modalOcurrencia') modal!: ModalNuevoOcurencia;
 
-    constructor(private bibliotecaVirtualService: BibliotecaVirtualService,private devolucionesService: DevolucionesService,private prestamosService: PrestamosService,private materialBibliograficoService: MaterialBibliograficoService, private genericoService: GenericoService, private fb: FormBuilder,
+    constructor(private bibliotecaVirtualService: BibliotecaVirtualService, private prestamosService: PrestamosService,private materialBibliograficoService: MaterialBibliograficoService, private genericoService: GenericoService, private fb: FormBuilder,
         private router: Router, private authService: AuthService, private confirmationService: ConfirmationService, private messageService: MessageService) { }
     async ngOnInit() {
         // this.user = this.authService.getUser();
@@ -395,7 +388,7 @@ onAbrirOcurrencia(item: any) {
             rejectLabel: 'NO',
             accept: () => {
             this.loading = true;
-            this.bibliotecaVirtualService.devolver(objeto.id)     // <-- Llamas a tu DevolucionesService
+            this.bibliotecaVirtualService.devolver(objeto.id)
               .subscribe({
                 next: res => {
                   if (res.status === '0') {
@@ -413,43 +406,6 @@ onAbrirOcurrencia(item: any) {
           }
         });
       }
-    cancelar(objeto: any) {
-        this.confirmationService.confirm({
-            message: '¿Estás seguro(a) de cancelar el prestamo del equipo de computo?',
-            header: 'Confirmar',
-            icon: 'pi pi-exclamation-triangle',
-            acceptLabel: 'SI',
-            rejectLabel: 'NO',
-            accept: () => {
-            this.loading = true;
-            this.bibliotecaVirtualService.cancelar(objeto.id)
-              .subscribe({
-                next: res => {
-                  if (res.status === '0') {
-                    this.messageService.add({
-                      severity: 'success',
-                      detail: 'Préstamo cancelado.'
-                    });
-                    this.listar();    // vuelve a cargar la lista
-                  } else {
-                    this.messageService.add({
-                      severity: 'error',
-                      detail: 'No se pudo cancelar el préstamo.'
-                    });
-                  }
-                },
-                error: () => {
-                  this.messageService.add({
-                    severity: 'error',
-                    detail: 'Error de red al cancelar.'
-                  });
-                }
-              })
-              .add(() => this.loading = false);
-          }
-        });
-      }
-
 
     onRowExpand(event: TableRowExpandEvent) {
     }

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/devoluciones/material-bibliografico/material-bibliografico.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/devoluciones/material-bibliografico/material-bibliografico.ts
@@ -148,7 +148,6 @@ interface PrestamoUsuario {
                 <th>Fecha de préstamo</th>
                 <th>Hora de préstamo</th>
                 <th>Devolver</th>
-                <th>Cancelar</th>
             </tr>
         </ng-template>
         <ng-template pTemplate="body" let-bib>
@@ -166,9 +165,6 @@ interface PrestamoUsuario {
                 </td>
                 <td>
                 <p-button icon="pi pi-check" rounded outlined (click)="devolver(bib)" pTooltip="Devolver" tooltipPosition="bottom"/>
-                </td>
-                <td>
-                <p-button icon="pi pi-times" rounded outlined (click)="cancelar(bib)"pTooltip="Cancelar" tooltipPosition="bottom"/>
                 </td>
             </tr>
         </ng-template>
@@ -203,7 +199,6 @@ export class DevolucionMaterialBibliografico implements OnInit {
     prestadosDetalle: PrestamoUsuario[] = [];
     expandedRows: { [key: string]: boolean } = {};
 
-    modulo: string = "aceptaciones";
     loading: boolean = true;
 
     objetoDialog!: boolean;
@@ -494,35 +489,6 @@ export class DevolucionMaterialBibliografico implements OnInit {
             }
           });
     }
-    cancelar(objeto: any) {
-        this.confirmationService.confirm({
-            message: '¿Estás seguro(a) de cancelar la reserva del ejemplar?',
-            header: 'Confirmar',
-            icon: 'pi pi-exclamation-triangle',
-            acceptLabel: 'SI',
-            rejectLabel: 'NO',
-            accept: () => {
-              this.loading = true;
-              const data = { id: objeto.idDetalleBiblioteca };
-              this.genericoService.conf_event_delete(data, this.modulo + '/cancelar')
-                .subscribe(result => {
-                  if (result.p_status == 0) {
-                    this.objetoDialog = false;
-                    this.messageService.add({ severity: 'success', summary: 'Satisfactorio', detail: 'Registro cancelado.' });
-                    this.listar();
-                  } else {
-                    this.messageService.add({ severity: 'error', summary: 'Error', detail: 'No se pudo realizar el proceso.' });
-                  }
-                  this.loading = false;
-                }
-                  , (error: HttpErrorResponse) => {
-                    this.messageService.add({ severity: 'error', summary: 'Error', detail: 'Ocurrio un error. Intentelo más tarde' });
-                    this.loading = false;
-                  });
-            }
-          });
-    }
-
     regularizarPrestamo(){
 
     }


### PR DESCRIPTION
## Resumen
- Retira la acción "Cancelar" en la devolución de material bibliográfico
- Elimina la opción de cancelar en devoluciones de biblioteca virtual y depura dependencias

## Pruebas
- `npm test -- --watch=false --browsers=ChromeHeadless` *(falla: No inputs were found in config file '/workspace/sistemabiblioteca/Frontend/sakai-ng-master/tsconfig.spec.json')*

------
https://chatgpt.com/codex/tasks/task_e_68c06e7cb3e08329b7f56cf936f140e5