### PR TITLE
feat: agregar filtros en reporte de estudiantes atendidos

### DIFF
--- a/Backend/login-microsoft365/src/main/java/com/miapp/controller/PrestamoController.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/controller/PrestamoController.java
@@ -189,8 +189,25 @@ public class PrestamoController {
     }
 
     @GetMapping("/reporte/estudiantes-atendidos")
-    public ResponseEntity<?> reporteEstudiantesAtendidos() {
-        List<com.miapp.model.dto.UsuarioPrestamosDTO> lista = prestamoService.reporteEstudiantesAtendidos();
+    public ResponseEntity<?> reporteEstudiantesAtendidos(
+            @RequestParam(required = false) Long sede,
+            @RequestParam(required = false) Long especialidad,
+            @RequestParam(required = false) Long programa,
+            @RequestParam(required = false) Long ciclo,
+            @RequestParam(required = false) String fechaInicio,
+            @RequestParam(required = false) String fechaFin
+    ) {
+        LocalDateTime inicio = fechaInicio != null ? LocalDate.parse(fechaInicio).atStartOfDay() : null;
+        LocalDateTime fin    = fechaFin != null ? LocalDate.parse(fechaFin).atTime(23,59,59) : null;
+
+        List<com.miapp.model.dto.UsuarioPrestamosDTO> lista = prestamoService.reporteEstudiantesAtendidos(
+                sede != null ? sede.toString() : null,
+                especialidad != null ? especialidad.toString() : null,
+                programa != null ? programa.toString() : null,
+                ciclo != null ? ciclo.toString() : null,
+                inicio,
+                fin
+        );
         return ResponseEntity.ok(Map.of("status","0","data", lista));
     }
 

--- a/Backend/login-microsoft365/src/main/java/com/miapp/repository/DetallePrestamoRepository.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/repository/DetallePrestamoRepository.java
@@ -53,9 +53,21 @@ public interface DetallePrestamoRepository
                     "LEFT JOIN Usuario u ON upper(u.login) = upper(dp.codigoUsuario) " +
                     "LEFT JOIN Sede s ON u.idSede = s.id " +
                     "LEFT JOIN Sede s2 ON dp.codigoSede = str(s2.id) " +
+                    "WHERE (:sede IS NULL OR dp.codigoSede = :sede) " +
+                    "AND (:especialidad IS NULL OR dp.codigoEscuela = :especialidad) " +
+                    "AND (:programa IS NULL OR dp.codigoPrograma = :programa) " +
+                    "AND (:ciclo IS NULL OR dp.codigoCiclo = :ciclo) " +
+                    "AND (:fechaInicio IS NULL OR dp.fechaPrestamo >= :fechaInicio) " +
+                    "AND (:fechaFin IS NULL OR dp.fechaPrestamo <= :fechaFin) " +
                     "GROUP BY dp.codigoUsuario, COALESCE(s.descripcion, s2.descripcion) " +
                     "ORDER BY MAX(dp.id) DESC" )
-    List<com.miapp.model.dto.UsuarioPrestamosDTO> contarPrestamosPorUsuario();
+    List<com.miapp.model.dto.UsuarioPrestamosDTO> contarPrestamosPorUsuario(
+            @org.springframework.data.repository.query.Param("sede") String sede,
+            @org.springframework.data.repository.query.Param("especialidad") String especialidad,
+            @org.springframework.data.repository.query.Param("programa") String programa,
+            @org.springframework.data.repository.query.Param("ciclo") String ciclo,
+            @org.springframework.data.repository.query.Param("fechaInicio") java.time.LocalDateTime fechaInicio,
+            @org.springframework.data.repository.query.Param("fechaFin") java.time.LocalDateTime fechaFin);
 
     /**
      * Devuelve la cantidad de préstamos aprobados por usuario.

--- a/Backend/login-microsoft365/src/main/java/com/miapp/service/PrestamoService.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/service/PrestamoService.java
@@ -459,8 +459,22 @@ public class PrestamoService {
                 .orElseThrow(() -> new RuntimeException("DetallePrestamo no encontrado: " + id));
     }
 
-    public List<com.miapp.model.dto.UsuarioPrestamosDTO> reporteEstudiantesAtendidos() {
-        return detallePrestamoRepository.contarPrestamosPorUsuario();
+    public List<com.miapp.model.dto.UsuarioPrestamosDTO> reporteEstudiantesAtendidos(
+            String sede,
+            String especialidad,
+            String programa,
+            String ciclo,
+            LocalDateTime fechaInicio,
+            LocalDateTime fechaFin
+    ) {
+        return detallePrestamoRepository.contarPrestamosPorUsuario(
+                sede,
+                especialidad,
+                programa,
+                ciclo,
+                fechaInicio,
+                fechaFin
+        );
     }
 
     /**

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/estudiantes-atendidos.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/estudiantes-atendidos.ts
@@ -188,8 +188,18 @@ export class ReporteEstudiantesAtendidos implements OnInit {
     async reporte() {
         this.loading = true;
         try {
+            const fi = this.fechaInicio ? this.fechaInicio.toISOString().split('T')[0] : undefined;
+            const ff = this.fechaFin ? this.fechaFin.toISOString().split('T')[0] : undefined;
             this.resultados = await firstValueFrom(
-                this.prestamosService.reporteEstudiantesAtendidos()
+                this.prestamosService.reporteEstudiantesAtendidos({
+                    sede: this.sedeFiltro?.id,
+                    programa: this.programaFiltro?.id,
+                    especialidad: this.especialidadFiltro?.id,
+                    ciclo: this.cicloFiltro?.id,
+                    tipoMaterial: this.tipoMaterialFiltro?.id,
+                    fechaInicio: fi,
+                    fechaFin: ff,
+                })
             );
         } finally {
             this.loading = false;

--- a/Frontend/sakai-ng-master/src/app/biblioteca/services/prestamos.service.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/services/prestamos.service.ts
@@ -214,10 +214,30 @@ export class PrestamosService {
       return this.http.get<any>(`${this.apiUrl}/api/equipos/estados`);
       }
 
-  reporteEstudiantesAtendidos(): Observable<UsuarioPrestamosDTO[]> {
+  reporteEstudiantesAtendidos(filtros: {
+    sede?: number | string;
+    programa?: number | string;
+    especialidad?: number | string;
+    ciclo?: number | string;
+    tipoMaterial?: number | string;
+    fechaInicio?: string;
+    fechaFin?: string;
+  } = {}): Observable<UsuarioPrestamosDTO[]> {
+      let params = new HttpParams();
+      const agregar = (k: string, v?: number | string | null) => {
+        if (v != null && v !== 0 && v !== '0') params = params.set(k, String(v));
+      };
+      agregar('sede', filtros.sede);
+      agregar('programa', filtros.programa);
+      agregar('especialidad', filtros.especialidad);
+      agregar('ciclo', filtros.ciclo);
+      agregar('tipoMaterial', filtros.tipoMaterial);
+      if (filtros.fechaInicio) params = params.set('fechaInicio', filtros.fechaInicio);
+      if (filtros.fechaFin) params = params.set('fechaFin', filtros.fechaFin);
+
       return this.http
         .get<{status:string, data: UsuarioPrestamosDTO[]}>(
-          `${this.apiUrl}/api/prestamos/reporte/estudiantes-atendidos`
+          `${this.apiUrl}/api/prestamos/reporte/estudiantes-atendidos`, { params }
         )
         .pipe(map(r => r.data ?? []));
   }


### PR DESCRIPTION
## Resumen
- incorporar filtros opcionales en el endpoint `reporte/estudiantes-atendidos`
- aplicar filtros en `PrestamoService` y `DetallePrestamoRepository`
- enviar parámetros desde el frontend para generar el reporte

## Pruebas
- `mvn -q -e -DskipTests package` (falló: Network is unreachable)
- `npm test -- --watch=false --browsers=ChromeHeadless` (falló: TS18003 No inputs were found)


------
https://chatgpt.com/codex/tasks/task_e_68c196c4e2c08329964e0600c535e908