### PR TITLE
Permitir filtros en reporte uso tiempo

### DIFF
--- a/Backend/login-microsoft365/src/main/java/com/miapp/controller/PrestamoController.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/controller/PrestamoController.java
@@ -4,6 +4,7 @@ import com.miapp.model.*;
 import com.miapp.model.dto.OcurrenciaBibliotecaDTO;
 import com.miapp.model.dto.UsuarioPrestamosDTO;
 import com.miapp.service.*;
+import com.miapp.repository.RolRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -25,6 +26,7 @@ public class PrestamoController {
     private final OcurrenciaBibliotecaService ocurrenciaBibliotecaService;
     private final UsuarioService usuarioService;
     private final EquipoService equipoService;
+    private final RolRepository rolRepository;
 
     @PostMapping("/solicitar")
     public ResponseEntity<?> solicitar(@RequestBody SolicitudDTO dto,
@@ -188,6 +190,13 @@ public class PrestamoController {
         return ResponseEntity.ok(Map.of("status","0","data", lista));
     }
 
+    /** Lista todos los tipos de usuario disponibles */
+    @GetMapping("/tipos-usuario")
+    public ResponseEntity<?> listarTiposUsuario() {
+        List<Rol> roles = rolRepository.findAll();
+        return ResponseEntity.ok(Map.of("status", "0", "data", roles));
+    }
+
     @GetMapping("/reporte/estudiantes-atendidos")
     public ResponseEntity<?> reporteEstudiantesAtendidos(
             @RequestParam(required = false) Long sede,
@@ -227,13 +236,24 @@ public class PrestamoController {
 
     @GetMapping("/reporte/uso-tiempo-biblioteca")
     public ResponseEntity<?> reporteUsoTiempoBiblioteca(
+            @RequestParam(required = false) String sede,
+            @RequestParam(required = false) Integer tipoUsuario,
+            @RequestParam(required = false) String ciclo,
+            @RequestParam(required = false) String escuela,
             @RequestParam(required = false) String fechaInicio,
             @RequestParam(required = false) String fechaFin
     ) {
         LocalDateTime inicio = fechaInicio != null ? LocalDate.parse(fechaInicio).atStartOfDay() : LocalDateTime.now().minusMonths(1);
         LocalDateTime fin    = fechaFin != null ? LocalDate.parse(fechaFin).atTime(23,59,59) : LocalDateTime.now();
 
-        List<com.miapp.model.dto.EquipoUsoTiempoDTO> lista = prestamoService.reporteUsoTiempoBiblioteca(inicio, fin);
+        List<com.miapp.model.dto.EquipoUsoTiempoDTO> lista = prestamoService.reporteUsoTiempoBiblioteca(
+                sede,
+                tipoUsuario,
+                ciclo,
+                escuela,
+                inicio,
+                fin
+        );
         return ResponseEntity.ok(Map.of("status","0","data", lista));
     }
 

--- a/Backend/login-microsoft365/src/main/java/com/miapp/service/PrestamoService.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/service/PrestamoService.java
@@ -486,11 +486,19 @@ public class PrestamoService {
     }
 
     public List<com.miapp.model.dto.EquipoUsoTiempoDTO> reporteUsoTiempoBiblioteca(
+            String sede,
+            Integer tipoUsuario,
+            String ciclo,
+            String escuela,
             LocalDateTime fechaInicio,
             LocalDateTime fechaFin
     ) {
         List<DetallePrestamo> prestamos = detallePrestamoRepository.findAll(
                 Specification.where(conFetchEquipoYSede())
+                        .and(DetallePrestamoSpecs.porSede(sede))
+                        .and(DetallePrestamoSpecs.porTipoUsuario(tipoUsuario))
+                        .and(DetallePrestamoSpecs.porCiclo(ciclo))
+                        .and(DetallePrestamoSpecs.porEscuela(escuela))
                         .and(DetallePrestamoSpecs.entreFechas(fechaInicio, fechaFin))
                         // se ignoran los préstamos en estado "RESERVADO"
                         .and(DetallePrestamoSpecs.excluirEstadoDescripcion("RESERVADO"))

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/usotiempo-biblioteca.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/usotiempo-biblioteca.ts
@@ -118,14 +118,21 @@ export class ReporteUsoTiempoBiblioteca {
         await this.reporte();
     }
     private async cargarFiltros() {
-        const filtros = await this.filtrosService.cargarFiltros();
-        this.dataSede = filtros.sedes;
+        const [sedes, tipoUsuarios, ciclos, especialidades] = await Promise.all([
+            this.filtrosService.getSedes(),
+            this.filtrosService.getTiposUsuario(),
+            this.filtrosService.getCiclos(),
+            this.filtrosService.getEspecialidades()
+        ]);
+
+        this.dataSede = sedes;
+        this.dataTipoUsuario = tipoUsuarios;
+        this.dataCiclo = ciclos;
+        this.dataEscuela = especialidades;
+
         this.sedeFiltro = this.dataSede[0];
-        this.dataTipoUsuario = filtros.tipoUsuarios;
         this.tipoUsuarioFiltro = this.dataTipoUsuario[0];
-        this.dataCiclo = filtros.ciclos;
         this.cicloFiltro = this.dataCiclo[0];
-        this.dataEscuela = filtros.especialidades;
         this.escuelaFiltro = this.dataEscuela[0];
     }
     private formatDate(d?: Date): string | undefined {
@@ -135,7 +142,17 @@ export class ReporteUsoTiempoBiblioteca {
     async reporte() {
         this.loading = true;
         try {
-            this.resultados = (await firstValueFrom(this.svc.reporteUsoTiempoBiblioteca(this.formatDate(this.fechaInicio), this.formatDate(this.fechaFin)))) ?? [];
+            this.resultados =
+                (await firstValueFrom(
+                    this.svc.reporteUsoTiempoBiblioteca(
+                        this.formatDate(this.fechaInicio),
+                        this.formatDate(this.fechaFin),
+                        this.sedeFiltro?.id,
+                        this.tipoUsuarioFiltro?.id,
+                        this.cicloFiltro?.id,
+                        this.escuelaFiltro?.id
+                    )
+                )) ?? [];
         } catch (error: any) {
             const msg = error?.status === 403 ? 'No autorizado para ver el reporte.' : 'No fue posible cargar los datos.';
             this.messageService.add({ severity: 'error', detail: msg });

--- a/Frontend/sakai-ng-master/src/app/biblioteca/services/prestamos.service.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/services/prestamos.service.ts
@@ -246,8 +246,26 @@ export class PrestamosService {
         return this.http.get<{ status: string; data: UsuarioPrestamosEquipoDTO[] }>(`${this.apiUrl}/api/prestamos/reporte/usuarios-atendidos-biblioteca`).pipe(map((r) => r.data ?? []));
     }
 
-    reporteUsoTiempoBiblioteca(fechaInicio?: string, fechaFin?: string): Observable<EquipoUsoTiempoDTO[]> {
+    reporteUsoTiempoBiblioteca(
+        fechaInicio?: string,
+        fechaFin?: string,
+        sede?: number | string,
+        tipoUsuario?: number | string,
+        ciclo?: number | string,
+        escuela?: number | string
+    ): Observable<EquipoUsoTiempoDTO[]> {
         let params = new HttpParams();
+
+        const addParam = (key: string, value?: number | string | null) => {
+            if (value != null && value !== 0 && value !== '0') {
+                params = params.set(key, String(value));
+            }
+        };
+
+        addParam('sede', sede);
+        addParam('tipoUsuario', tipoUsuario);
+        addParam('ciclo', ciclo);
+        addParam('escuela', escuela);
         if (fechaInicio) params = params.set('fechaInicio', fechaInicio);
         if (fechaFin) params = params.set('fechaFin', fechaFin);
 

--- a/Frontend/sakai-ng-master/src/app/biblioteca/services/reportes-filtro.service.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/services/reportes-filtro.service.ts
@@ -173,7 +173,7 @@ export class ReportesFiltroService {
     if (!this.cacheTipoUsuario) {
       try {
         const res: any = await firstValueFrom(
-          this.genericoService.roles_get('roles/lista-roles')
+          this.genericoService.tipo_get('api/prestamos/tipos-usuario')
         );
         const list = Array.isArray(res?.data)
           ? res.data


### PR DESCRIPTION
## Resumen
- Expone en backend un listado de roles para poblar el filtro de tipo de usuario
- El servicio de filtros consume el nuevo endpoint y construye opciones para el combo
- Ajusta la carga de filtros del reporte de uso de tiempo para mostrar correctamente los tipos de usuario

## Pruebas
- `mvn -q test` *(falla: Non-resolvable parent POM)*
- `npm test` *(falla: error TS18003: No inputs were found in config file)*

------
https://chatgpt.com/codex/tasks/task_e_68c1ae49aa8c8329a3b36e00cd6acb77