### PR TITLE
Listar ciclos en romanos en filtros de reportes

### DIFF
--- a/Frontend/sakai-ng-master/src/app/biblioteca/services/reportes-filtro.service.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/services/reportes-filtro.service.ts
@@ -139,32 +139,36 @@ export class ReportesFiltroService {
 
   async getCiclos(): Promise<ClaseGeneral[]> {
     if (!this.cacheCiclo) {
-      try {
-        const res: any = await firstValueFrom(
-          this.genericoService.tipo_get('catalogos/ciclos')
-        );
-        const list = Array.isArray(res?.data)
-          ? res.data
-          : Array.isArray(res)
-            ? res
-            : [];
-        this.cacheCiclo = [
-          new ClaseGeneral({ id: 0, descripcion: 'Todos', activo: true, estado: 1 }),
-          ...list.map(
-            (c: any) =>
-              new ClaseGeneral({
-                id: c.id ?? c.codigo ?? c.ciclo,
-                descripcion: c.descripcion ?? c.nombre ?? c.ciclo,
-                activo: true,
-                estado: 1,
-              })
-          ),
-        ];
-      } catch {
-        this.cacheCiclo = [
-          new ClaseGeneral({ id: 0, descripcion: 'Todos', activo: true, estado: 1 }),
-        ];
-      }
+      const romanos = [
+        'I',
+        'II',
+        'III',
+        'IV',
+        'V',
+        'VI',
+        'VII',
+        'VIII',
+        'IX',
+        'X',
+        'XI',
+        'XII',
+        'XIII',
+        'XIV',
+        'XV'
+      ];
+
+      this.cacheCiclo = [
+        new ClaseGeneral({ id: 0, descripcion: 'Todos', activo: true, estado: 1 }),
+        ...romanos.map(
+          (descripcion, idx) =>
+            new ClaseGeneral({
+              id: idx + 1,
+              descripcion,
+              activo: true,
+              estado: 1
+            })
+        )
+      ];
     }
     return this.cacheCiclo ?? [];
   }


### PR DESCRIPTION
## Resumen
- Mostrar los ciclos del I al XV en los combos de reportes
- Usar una lista estática de ciclos para habilitar el filtrado por todos los ciclos

## Testing
- `npm test -- --watch=false` *(falla: TS18003 sin archivos de prueba)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c1bfe4b44c8329bf46e5f0b4ef48b7