### PR TITLE
Manejar respuestas nulas al consultar documento

### DIFF
--- a/Frontend/sakai-ng-master/src/app/biblioteca/web/registrate/registrate.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/web/registrate/registrate.ts
@@ -373,6 +373,35 @@ export class PortalRegistrate implements OnInit {
         }
     }
 
+    private resetDocumentoForm(): void {
+        this.form.patchValue({
+            id: 0,
+            nombreUsuario: '',
+            apellidoPaterno: '',
+            apellidoMaterno: '',
+            fechaNacimiento: '',
+            email: '',
+            ADDRESS: '',
+            AGE: 0,
+            CAMPUS: '',
+            CELL: '',
+            CITY: '',
+            COUNTRY: '',
+            COUNTY: '',
+            EMAIL_INST: '',
+            EMPLID: '',
+            FEC_NAC: '',
+            NAME: '',
+            NATIONAL_ID: '',
+            NATIONAL_ID_TYPE: '',
+            PHONE: '',
+            SEX: '',
+            STATE: ''
+        });
+        this.fieldsDisabled = false;
+        this.form.get('fechaNacimiento')?.enable();
+    }
+
     registrar() {
         if (this.form.invalid) {
           this.messageService.add({ severity: 'error', summary: 'Error', detail: 'Por favor complete el formulario correctamente.' });
@@ -423,6 +452,11 @@ export class PortalRegistrate implements OnInit {
       }
       this.documentoService.consultar(tipo, numero).subscribe({
           next: (data) => {
+              if (!data) {
+                  this.resetDocumentoForm();
+                  this.messageService.add({severity:'warn', summary:'Sin resultados', detail:'Documento no encontrado. Complete los datos manualmente.'});
+                  return;
+              }
               const nombres = data.NAME ? data.NAME.split(',')[1]?.trim() || '' : '';
               const apellidos = data.NAME ? data.NAME.split(',')[0]?.trim() || '' : '';
               const apellidoParts = apellidos.split(' ');
@@ -457,33 +491,8 @@ export class PortalRegistrate implements OnInit {
               this.form.get('fechaNacimiento')?.disable();
           },
           error: () => {
-              this.form.patchValue({
-                  id: 0,
-                  nombreUsuario: '',
-                  apellidoPaterno: '',
-                  apellidoMaterno: '',
-                  fechaNacimiento: '',
-                  email: '',
-                  ADDRESS: '',
-                  AGE: 0,
-                  CAMPUS: '',
-                  CELL: '',
-                  CITY: '',
-                  COUNTRY: '',
-                  COUNTY: '',
-                  EMAIL_INST: '',
-                  EMPLID: '',
-                  FEC_NAC: '',
-                  NAME: '',
-                  NATIONAL_ID: '',
-                  NATIONAL_ID_TYPE: '',
-                  PHONE: '',
-                  SEX: '',
-                  STATE: ''
-              });
+              this.resetDocumentoForm();
               this.messageService.add({severity:'warn', summary:'Sin resultados', detail:'Documento no encontrado. Complete los datos manualmente.'});
-              this.fieldsDisabled = false;
-              this.form.get('fechaNacimiento')?.enable();
           }
       });
   }


### PR DESCRIPTION
## Summary
- Añade resetDocumentoForm para limpiar el formulario y habilitar campos
- Maneja respuestas nulas del servicio de documentos para evitar errores al dividir un `NAME`

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(falla: No inputs were found in config file '/workspace/sistemabiblioteca/Frontend/sakai-ng-master/tsconfig.spec.json')*


------
https://chatgpt.com/codex/tasks/task_e_68c1c1d4c2fc83298df77b44d69b7bfa