### PR TITLE
redirigir a inicio tras cerrar sesión

### DIFF
--- a/Frontend/sakai-ng-master/src/app.routes.ts
+++ b/Frontend/sakai-ng-master/src/app.routes.ts
@@ -10,11 +10,13 @@ import { PortalRegistrate } from './app/biblioteca/web/registrate/registrate';
 import { PortalReserva } from './app/biblioteca/web/catalogo/reserva';
 import { Dashboard } from './app/biblioteca/modulos/dashboard/dashboard';
 import { Login } from './app/pages/auth/login';
+import { RoleGuard } from './app/guards/role.guard';
 
 export const appRoutes: Routes = [
     {
         path: 'main',
         component: AppLayout,
+        canActivate: [RoleGuard],
         children: [
             { path: '', component: Dashboard },
             { path: 'mantenimiento', loadChildren: () => import('./app/biblioteca/modulos/mantenimientos/mantenimientos.routes')},

--- a/Frontend/sakai-ng-master/src/app/biblioteca/services/auth.service.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/services/auth.service.ts
@@ -408,7 +408,7 @@ private resetInactivityTimer(): void {
     this.currentUserSubject.next({} as Usuario);
     this.msalService.instance.setActiveAccount(null);
     void this.msalService.instance.clearCache();
-    this.router.navigate(['/auth/login']);
+    this.router.navigate(['/'], { replaceUrl: true });
   }
 
   refreshAccessToken(): Observable<string> {

--- a/Frontend/sakai-ng-master/src/app/guards/role.guard.ts
+++ b/Frontend/sakai-ng-master/src/app/guards/role.guard.ts
@@ -14,12 +14,15 @@ export class RoleGuard implements CanActivate {
     route: ActivatedRouteSnapshot,
     state: RouterStateSnapshot
   ): boolean | UrlTree {
-      // 🚨 Verificar si el usuario está autenticado
+        // 🚨 Verificar si el usuario está autenticado
         if (!this.authService.idAuthenticated()) {
-          console.warn('Usuario no autenticado, redirigiendo a /login');
-          return this.router.createUrlTree(['/login']);
+          console.warn('Usuario no autenticado, redirigiendo al inicio');
+          return this.router.createUrlTree(['/']);
         }
     const requiredRoles: string[] = route.data['roles'] || []; // Obtiene los roles permitidos de la ruta
+    if (requiredRoles.length === 0) {
+      return true;
+    }
     const userRoles: string[] = this.authService.getRoles() || []; // Obtiene los roles del usuario
     // Imprime en consola los roles requeridos y los roles del usuario
         console.log('Roles requeridos:', requiredRoles);


### PR DESCRIPTION
## Resumen
- Redirección de cierre de sesión al inicio con reemplazo de historial.
- RoleGuard actualiza validaciones de autenticación y roles.
- Ruta `main` protegida con guard para evitar acceso tras cerrar sesión.

## Pruebas
- `npm test -- --watch=false` (falla: No inputs were found in tsconfig.spec.json)


------
https://chatgpt.com/codex/tasks/task_e_68c1d46e60408329a795efe687192364