### PR TITLE
feat: mostrar resumen de materiales bibliográficos

### DIFF
--- a/Frontend/sakai-ng-master/src/app/biblioteca/interfaces/reportes/material-bibliografico-resumen.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/interfaces/reportes/material-bibliografico-resumen.ts
@@ -1,0 +1,9 @@
+export interface MaterialBibliograficoResumenDTO {
+    codigo?: string;
+    titulo?: string;
+    autor?: string;
+    editorial?: string;
+    edicion?: string;
+    anio?: string | number;
+    numeroIngreso?: string | number;
+}

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/material-bibliografico-resumen.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/material-bibliografico-resumen.ts
@@ -5,6 +5,10 @@ import { TemplateModule } from '../../template.module';
 import { Sedes } from '../../interfaces/sedes';
 import { ClaseGeneral } from '../../interfaces/clase-general';
 import { ReportesFiltroService } from '../../services/reportes-filtro.service';
+import { MaterialBibliograficoService } from '../../services/material-bibliografico.service';
+import { MaterialBibliograficoResumenDTO } from '../../interfaces/reportes/material-bibliografico-resumen';
+import { firstValueFrom } from 'rxjs';
+import { HttpErrorResponse } from '@angular/common/http';
 
 @Component({
     selector: 'app-reporte-material-bibliografico-resumen',
@@ -20,26 +24,52 @@ import { ReportesFiltroService } from '../../services/reportes-filtro.service';
                         <label for="sede" class="block text-sm font-medium">Local/Filial</label>
                         <p-select [(ngModel)]="sedeFiltro" [options]="dataSede" optionLabel="descripcion" placeholder="Seleccionar" />
                     </div>
-                    
+
                     <div class="flex flex-col gap-2 col-span-7 md:col-span-2 lg:col-span-2">
                     <label for="coleccion" class="block text-sm font-medium">Coleccion</label>
                     <p-select [(ngModel)]="coleccionFiltro" [options]="dataColeccion" optionLabel="descripcion" placeholder="Seleccionar" />
                     </div>
                     <div class="flex items-end">
-            <button 
-                pButton 
-                type="button" 
-                class="p-button-rounded p-button-danger" 
+            <button
+                pButton
+                type="button"
+                class="p-button-rounded p-button-danger"
                 icon="pi pi-search"(click)="reporte()" [disabled]="loading"  pTooltip="Ver reporte" tooltipPosition="bottom">
             </button>
         </div>
                     </div>
-                    
-                   
-               
+
+
+
             </div>
-       
+
     </p-toolbar>
+    <p-table [value]="resultados" [loading]="loading" [paginator]="true" [rows]="10">
+        <ng-template pTemplate="header">
+            <tr>
+                <th>N°</th>
+                <th>Código</th>
+                <th>Título</th>
+                <th>Autor</th>
+                <th>Editorial</th>
+                <th>Edición</th>
+                <th>Año</th>
+                <th>N° Ingreso</th>
+            </tr>
+        </ng-template>
+        <ng-template pTemplate="body" let-row let-i="rowIndex">
+            <tr>
+                <td>{{ i + 1 }}</td>
+                <td>{{ row.codigo || '-' }}</td>
+                <td>{{ row.titulo || '-' }}</td>
+                <td>{{ row.autor || '-' }}</td>
+                <td>{{ row.editorial || '-' }}</td>
+                <td>{{ row.edicion || '-' }}</td>
+                <td>{{ row.anio || '-' }}</td>
+                <td>{{ row.numeroIngreso || '-' }}</td>
+            </tr>
+        </ng-template>
+    </p-table>
 </div>
 `,
             imports: [TemplateModule, TooltipModule],
@@ -53,7 +83,12 @@ export class ReporteMaterialBibliograficoResumen {
     dataColeccion: ClaseGeneral[] = [];
     tipo:number=1;
     loading: boolean = true;
-    constructor(private filtrosService: ReportesFiltroService) {}
+    resultados: MaterialBibliograficoResumenDTO[] = [];
+    constructor(
+        private filtrosService: ReportesFiltroService,
+        private materialService: MaterialBibliograficoService,
+        private messageService: MessageService
+    ) {}
     async ngOnInit() {
         await this.cargarFiltros();
         await this.reporte();
@@ -65,5 +100,52 @@ export class ReporteMaterialBibliograficoResumen {
         this.dataColeccion = filtros.tiposMaterial;
         this.coleccionFiltro = this.dataColeccion[0];
     }
-    async reporte(){}
+    async reporte() {
+        this.loading = true;
+        try {
+            const respuesta = await firstValueFrom(this.materialService.list());
+            const lista = Array.isArray(respuesta) ? respuesta : [];
+            this.resultados = lista.reduce((acc: MaterialBibliograficoResumenDTO[], b: any) => {
+                const detalles = Array.isArray(b.detalles) && b.detalles.length ? b.detalles : [{}];
+                detalles.forEach((d: any) => {
+                    acc.push({
+                        codigo:
+                            d.codigoLocalizacion ??
+                            b.codigoLocalizacion ??
+                            b.codigo ??
+                            '',
+                        titulo: b.titulo ?? b.material?.titulo ?? '',
+                        autor:
+                            [
+                                b.autorPersonal,
+                                b.autorInstitucional,
+                                b.autorSecundario,
+                                b.material?.autorPrincipal,
+                                b.material?.autorSecundario
+                            ]
+                                .filter(Boolean)
+                                .join(' - ') || '',
+                        editorial: b.editorialPublicacion ?? b.material?.editorial ?? '',
+                        edicion: b.edicion ?? b.material?.edicion ?? '',
+                        anio: b.anioPublicacion ?? b.material?.anioPublicacion ?? '',
+                        numeroIngreso:
+                            d.numeroIngreso ??
+                            b.numeroDeIngreso ??
+                            b.numeroIngreso ??
+                            ''
+                    });
+                });
+                return acc;
+            }, []);
+        } catch (err) {
+            console.error(err);
+            let detail = 'No fue posible cargar los datos';
+            if (err instanceof HttpErrorResponse && err.status === 403) {
+                detail = 'No cuenta con permisos para ver la información';
+            }
+            this.messageService.add({ severity: 'error', summary: 'Error', detail });
+        } finally {
+            this.loading = false;
+        }
+    }
 }

--- a/Frontend/sakai-ng-master/src/app/biblioteca/services/material-bibliografico.service.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/services/material-bibliografico.service.ts
@@ -207,11 +207,34 @@ registrarEspecialidad(especialidad: any): Observable<any> {
 
       list(): Observable<BibliotecaDTO[]> {
         return this.http
-          .get<{ status: number; data: BibliotecaDTO[] }>(
-            `${this.apiUrl}/api/biblioteca/list`,
-            { headers: new HttpHeaders().set('Authorization', `Bearer ${this.authService.getToken()}`) }
-          )
-          .pipe(map(r => r.data));
+          .get<any>(`${this.apiUrl}/api/biblioteca/list`, {
+            headers: new HttpHeaders().set('Authorization', `Bearer ${this.authService.getToken()}`)
+          })
+          .pipe(
+            map(res => {
+              // Posibles contenedores donde podría venir la lista
+              const posibles = [res, res?.data, res?.data?.data];
+
+              for (const candidato of posibles) {
+                if (Array.isArray(candidato)) {
+                  return candidato as BibliotecaDTO[];
+                }
+                if (candidato && typeof candidato === 'object') {
+                  if (Array.isArray(candidato.lista)) {
+                    return candidato.lista as BibliotecaDTO[];
+                  }
+                  if (Array.isArray(candidato.data)) {
+                    return candidato.data as BibliotecaDTO[];
+                  }
+                  if (Array.isArray((candidato as any).content)) {
+                    return (candidato as any).content as BibliotecaDTO[];
+                  }
+                }
+              }
+
+              return [] as BibliotecaDTO[];
+            })
+          );
       }
 
       get(id: number): Observable<BibliotecaDTO | undefined> {


### PR DESCRIPTION
## Summary
- handle deeply nested responses from bibliographic list endpoint
- build summary rows defensively from retrieved materials
- extract array from paginated responses in material service

## Testing
- `npm test` (fails: error TS18003: No inputs were found in config file 'tsconfig.spec.json')
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c1da822ea48329833d404d2745ee22