### PR TITLE
Habilitar registro de código de barras en detalles de biblioteca

### DIFF
--- a/Backend/login-microsoft365/src/main/java/com/miapp/model/DetalleBiblioteca.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/model/DetalleBiblioteca.java
@@ -52,8 +52,8 @@ public class DetalleBiblioteca {
     @Column(name = "FECHAINGRESO")
     private LocalDateTime fechaIngreso;
 
-    // Campos “solo lectura” generados por BD
-    @Column(name = "CODIGOBARRA", insertable = false, updatable = false)
+    // Código de barras del ejemplar
+    @Column(name = "CODIGOBARRA")
     private String codigoBarra;
 
     @Column(name = "NUMEROINGRESO")

--- a/Backend/login-microsoft365/src/main/java/com/miapp/service/impl/BibliotecaServiceImpl.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/service/impl/BibliotecaServiceImpl.java
@@ -255,11 +255,19 @@ public class BibliotecaServiceImpl implements BibliotecaService {
         List<DetalleBiblioteca> lista = dto.getDetalles() == null
                 ? List.of()
                 : dto.getDetalles().stream().map(det -> {
-            DetalleBiblioteca e = new DetalleBiblioteca();
+            DetalleBiblioteca e;
+            if (det.getIdDetalleBiblioteca() != null) {
+                e = detalleBibliotecaRepository.findById(det.getIdDetalleBiblioteca())
+                        .orElseGet(DetalleBiblioteca::new);
+            } else {
+                e = new DetalleBiblioteca();
+            }
+
             // 1) Para el UPDATE: conserva el ID de detalle si viene
             if (det.getIdDetalleBiblioteca() != null) {
                 e.setIdDetalle(det.getIdDetalleBiblioteca());
             }
+
             // 2) Sede
             e.setSede(det.getCodigoSede() != null
                     ? sedeRepository.findById(det.getCodigoSede())
@@ -268,7 +276,6 @@ public class BibliotecaServiceImpl implements BibliotecaService {
                     : null);
 
             // 3) Tipo de Material
-            System.out.println("TipoMaterialId: " + det.getTipoMaterialId());
             if (det.getTipoMaterialId() != null) {
                 TipoMaterial tm = tipoMaterialRepository
                         .findById(det.getTipoMaterialId())
@@ -293,6 +300,9 @@ public class BibliotecaServiceImpl implements BibliotecaService {
             e.setCosto(det.getCosto());
             e.setNumeroFactura(det.getNumeroFactura());
             e.setFechaIngreso(det.getFechaIngreso());
+            if (det.getCodigoBarra() != null && !det.getCodigoBarra().isBlank()) {
+                e.setCodigoBarra(det.getCodigoBarra());
+            }
             e.setHoraInicio(det.getHoraInicio());
             e.setHoraFin(det.getHoraFin());
             e.setMaxHoras(det.getMaxHoras());


### PR DESCRIPTION
## Resumen
- Permitir la edición del campo `CODIGOBARRA` en `DetalleBiblioteca` y mantener su valor al actualizar registros existentes.
- Mapear `codigoBarra` desde los DTOs al guardar detalles de material bibliográfico sin sobreescribir valores previos cuando el dato no se envía.
- Evitar que el código de barras se borre si llega una cadena vacía y eliminar trazas de depuración en consola.

## Testing
- `mvn -q test` *(falla: Non-resolvable parent POM, Network is unreachable)*


------
https://chatgpt.com/codex/tasks/task_e_68c4b4a2ad908329b9e4318952a12287