### PR TITLE
fix: mostrar código de barras al editar detalles

### DIFF
--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/mantenimientos/material-bibliografico/modal-libro.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/mantenimientos/material-bibliografico/modal-libro.ts
@@ -1443,7 +1443,8 @@ export class ModalLibroComponent implements OnInit {
                 maxHoras: d0.maxHoras ?? null,
                 costo: d0.costo,
                 tipoMaterial: d0.tipoMaterialId,
-                nroFactura: d0.numeroFactura
+                nroFactura: d0.numeroFactura,
+                codigoBarra: d0.codigoBarra
             });
 
             /* ⇓ convertimos TODO el array a DetalleInput[] */
@@ -1463,6 +1464,7 @@ export class ModalLibroComponent implements OnInit {
                     costo: d.costo,
                     numeroFactura: d.numeroFactura,
                     fechaIngreso: d.fechaIngreso,
+                    codigoBarra: d.codigoBarra ?? null,
                     sede: sedeObj,
                     tipoAdquisicion: tipoAdqObj,
                     tipoMaterial: tipoMaterialObj,


### PR DESCRIPTION
## Summary
- aseguro que el campo `codigoBarra` se cargue y se muestre correctamente al editar los ejemplares de material bibliográfico

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(falla: No inputs were found in config file 'tsconfig.spec.json')*


------
https://chatgpt.com/codex/tasks/task_e_68c5c32017208329ba2cdc3af024b1e8