### PR TITLE
Corrige guardado de periodicidad y detalles de revista

### DIFF
--- a/Backend/login-microsoft365/src/main/java/com/miapp/controller/MaterialBibliograficoController.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/controller/MaterialBibliograficoController.java
@@ -22,19 +22,22 @@ public class MaterialBibliograficoController {
     private final IdiomaService idiomaService;
     private final CiudadService ciudadService;
     private final TipoAdquisicionService tipoAdquisicionService;
+    private final PeriodicidadService periodicidadService;
 
     public MaterialBibliograficoController(MaterialBibliograficoService service,
                                            EspecialidadService especialidadService,
                                            PaisService paisService,
                                            IdiomaService idiomaService,
                                            CiudadService ciudadService,
-                                           TipoAdquisicionService tipoAdquisicionService) {
+                                           TipoAdquisicionService tipoAdquisicionService,
+                                           PeriodicidadService periodicidadService) {
         this.service = service;
         this.especialidadService = especialidadService;
         this.paisService = paisService;
         this.idiomaService = idiomaService;
         this.ciudadService = ciudadService;
         this.tipoAdquisicionService = tipoAdquisicionService;
+        this.periodicidadService = periodicidadService;
     }
 
     @PostMapping("/register")
@@ -148,6 +151,12 @@ public class MaterialBibliograficoController {
     @GetMapping("/adquisicion")
     public ResponseEntity<?> Adquiscion() {
         List<TipoAdquisicion> all = tipoAdquisicionService.listAll();
+        return ResponseEntity.ok(Map.of("status", 0, "data", all));
+    }
+
+    @GetMapping("/periodicidad")
+    public ResponseEntity<?> listarPeriodicidad() {
+        List<Periodicidad> all = periodicidadService.listAll();
         return ResponseEntity.ok(Map.of("status", 0, "data", all));
     }
 

--- a/Backend/login-microsoft365/src/main/java/com/miapp/service/PeriodicidadService.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/service/PeriodicidadService.java
@@ -1,0 +1,20 @@
+package com.miapp.service;
+
+import com.miapp.model.Periodicidad;
+import com.miapp.repository.PeriodicidadRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class PeriodicidadService {
+    private final PeriodicidadRepository periodicidadRepository;
+
+    public PeriodicidadService(PeriodicidadRepository periodicidadRepository) {
+        this.periodicidadRepository = periodicidadRepository;
+    }
+
+    public List<Periodicidad> listAll() {
+        return periodicidadRepository.findAll();
+    }
+}

--- a/Backend/login-microsoft365/src/main/java/com/miapp/service/impl/BibliotecaServiceImpl.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/service/impl/BibliotecaServiceImpl.java
@@ -49,6 +49,7 @@ public class BibliotecaServiceImpl implements BibliotecaService {
     private final EmailService emailService;
     private final FileStorageService fileStorageService;
     private final BibliotecaCicloRepository bibliotecaCicloRepository;
+    private final PeriodicidadRepository periodicidadRepository;
 
     public BibliotecaServiceImpl(BibliotecaRepository bibliotecaRepository,
                                  TipoAdquisicionRepository tipoAdquisicionRepository,
@@ -66,7 +67,8 @@ public class BibliotecaServiceImpl implements BibliotecaService {
                                  NotificacionService notificacionService,
                                  EmailService emailService,
                                  FileStorageService fileStorageService,
-                                 BibliotecaCicloRepository bibliotecaCicloRepository) {
+                                 BibliotecaCicloRepository bibliotecaCicloRepository,
+                                 PeriodicidadRepository periodicidadRepository) {
         this.bibliotecaRepository = bibliotecaRepository;
         this.tipoAdquisicionRepository  = tipoAdquisicionRepository;
         this.especialidadRepository = especialidadRepository;
@@ -84,6 +86,7 @@ public class BibliotecaServiceImpl implements BibliotecaService {
         this.emailService = emailService;
         this.fileStorageService = fileStorageService;
         this.bibliotecaCicloRepository = bibliotecaCicloRepository;
+        this.periodicidadRepository = periodicidadRepository;
     }
 
     @Override
@@ -172,6 +175,7 @@ public class BibliotecaServiceImpl implements BibliotecaService {
         b.setIssn(dto.getIssn());
         b.setRutaImagen(dto.getRutaImagen());
         b.setNombreImagen(dto.getNombreImagen());
+        b.setFechaIngreso(dto.getFechaIngreso());
         b.setIdEstado(dto.getEstadoId());
         b.setExistencias(dto.getExistencias());
         // … asigna aquí todos tus campos de BibliotecaDTO a Biblioteca …
@@ -214,6 +218,15 @@ public class BibliotecaServiceImpl implements BibliotecaService {
             b.setCiudad(c);
         } else {
             b.setCiudad(null);
+        }
+
+        // **mapea Periodicidad**
+        if (dto.getPeriodicidadId() != null) {
+            Periodicidad p = periodicidadRepository.findById(dto.getPeriodicidadId())
+                    .orElseThrow(() -> new RuntimeException("Periodicidad no encontrada: " + dto.getPeriodicidadId()));
+            b.setPeriodicidad(p);
+        } else {
+            b.setPeriodicidad(null);
         }
 
         // **mapea Idioma**
@@ -303,6 +316,8 @@ public class BibliotecaServiceImpl implements BibliotecaService {
             if (det.getCodigoBarra() != null && !det.getCodigoBarra().isBlank()) {
                 e.setCodigoBarra(det.getCodigoBarra());
             }
+            e.setNumeroIngreso(det.getNumeroIngreso());
+            e.setNroExistencia(det.getNroExistencia());
             e.setHoraInicio(det.getHoraInicio());
             e.setHoraFin(det.getHoraFin());
             e.setMaxHoras(det.getMaxHoras());

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/mantenimientos/material-bibliografico/modal-otros.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/mantenimientos/material-bibliografico/modal-otros.ts
@@ -589,7 +589,7 @@ export class ModalOtrosComponent implements OnInit {
     }
     async ListaPeriodicidad() {
         try {
-            const result: any = await this.materialBibliograficoService.lista_periodicidad('material-bibliografico/ciudad').toPromise();
+            const result: any = await this.materialBibliograficoService.lista_periodicidad('material-bibliografico/periodicidad').toPromise();
             if (result.status == 0) {
                 this.periodicidadLista = result.data;
             }

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/mantenimientos/material-bibliografico/modal-revista.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/mantenimientos/material-bibliografico/modal-revista.ts
@@ -200,7 +200,7 @@ import { environment } from '../../../../../environments/environment';
                     [rowHover]="true"
                     styleClass="p-datatable-gridlines"
                     [paginator]="true"
-                    [globalFilterFields]="['id', 'codigoBarra', 'existencias', 'sede.descripcion', 'tipoMaterial.descripcion', 'fechaIngreso', 'tipoAdquisicion.descripcion', 'costo', 'nroFactura']"
+                    [globalFilterFields]="['id', 'codigoBarra', 'existencias', 'sede.descripcion', 'tipoMaterial.descripcion', 'fechaIngreso', 'tipoAdquisicion.descripcion', 'costo', 'numeroFactura']"
                     responsiveLayout="scroll"
                 >
                     <ng-template pTemplate="caption">
@@ -219,7 +219,7 @@ import { environment } from '../../../../../environments/environment';
                             <th pSortableColumn="tipoAdquisicion.descripcion" style="min-width:200px">Tipo Adquisici&oacute;n<p-sortIcon field="tipoAdquisicion.descripcion"></p-sortIcon></th>
                             <th pSortableColumn="codigoBarra">Código Barra <p-sortIcon field="codigoBarra"></p-sortIcon></th>
                             <th style="width: 8rem" pSortableColumn="costo">Costo <p-sortIcon field="costo"></p-sortIcon></th>
-                            <th pSortableColumn="nroFactura">Nro Factura <p-sortIcon field="nroFactura"></p-sortIcon></th>
+                            <th pSortableColumn="numeroFactura">Nro Factura <p-sortIcon field="numeroFactura"></p-sortIcon></th>
                             <th pSortableColumn="fechaIngreso">Fecha Ingreso <p-sortIcon field="fechaIngreso"></p-sortIcon></th>
                             <th style="width: 4rem">Opciones</th>
                         </tr>
@@ -242,7 +242,7 @@ import { environment } from '../../../../../environments/environment';
                                 {{ detalle.costo }}
                             </td>
                             <td>
-                                {{ detalle.nroFactura }}
+                                {{ detalle.numeroFactura }}
                             </td>
                             <td>
                                 {{ detalle.fechaIngreso | date: 'dd-MM-yyyy' }}
@@ -669,7 +669,9 @@ export class ModalRevistaComponent implements OnInit {
     }
     async ListaPeriodicidad() {
         try {
-            const result: any = await this.materialBibliograficoService.lista_periodicidad('material-bibliografico/ciudad').toPromise();
+            const result: any = await this.materialBibliograficoService
+                .lista_periodicidad('material-bibliografico/periodicidad')
+                .toPromise();
             if (result.status == 0) {
                 this.periodicidadLista = result.data;
             }
@@ -749,9 +751,9 @@ export class ModalRevistaComponent implements OnInit {
             const data = await this.materialBibliograficoService.listarDetallesPorBiblioteca(idBib, false).toPromise();
 
             this.detalles = (data ?? []).map((d) => {
-                const sedeId = d.codigoSede ?? d.biblioteca?.sedeId ?? null;
-                const tipoMat = d.tipoMaterialId ?? d.biblioteca?.tipoMaterialId ?? null;
-                const tipoAdq = d.tipoAdquisicionId ?? d.biblioteca?.tipoAdquisicionId ?? null;
+                const sedeId = d.codigoSede ?? (d as any).sedeId ?? (d as any).sede?.id ?? d.biblioteca?.sedeId ?? null;
+                const tipoMat = d.tipoMaterialId ?? d.tipoMaterial?.id ?? d.biblioteca?.tipoMaterialId ?? null;
+                const tipoAdq = d.tipoAdquisicionId ?? d.tipoAdquisicion?.id ?? d.biblioteca?.tipoAdquisicionId ?? null;
 
                 const sedeObj = this.sedesLista.find((s) => s.id === sedeId) ?? null;
                 const tipoMatObj = this.tipoMaterialLista.find((t) => t.id === tipoMat) ?? null;
@@ -766,9 +768,10 @@ export class ModalRevistaComponent implements OnInit {
                     horaFin: d.horaFin ?? null,
                     maxHoras: d.maxHoras ?? null,
                     costo: d.costo ?? null,
-                    numeroFactura: d.numeroFactura ?? null,
-                    fechaIngreso: d.fechaIngreso ?? null,
+                    numeroFactura: d.numeroFactura ?? d.nroFactura ?? null,
+                    fechaIngreso: d.fechaIngreso ?? (d as any).fecha_ingreso ?? null,
                     codigoBarra: d.codigoBarra ?? null,
+                    existencias: (d as any).existencias ?? (d as any).nroExistencia ?? null,
                     sede: sedeObj,
                     tipoMaterial: tipoMatObj,
                     tipoAdquisicion: tipoAdqObj,
@@ -920,6 +923,7 @@ export class ModalRevistaComponent implements OnInit {
                     codigoSede: sedeId,
                     tipoAdquisicionId: tipoAdqId,
                     tipoMaterialId: tipoMaterialId, // ← añade esta línea
+                    existencias: this.formDetalle.value.existencias,
                     codigoBarra: this.formDetalle.value.codigoBarra,
                     horaInicio: this.timeToString(this.formDetalle.value.horaInicio ?? null),
                     horaFin: this.timeToString(this.formDetalle.value.horaFin ?? null),
@@ -984,10 +988,12 @@ export class ModalRevistaComponent implements OnInit {
                 fechaIngreso: d.fechaIngreso ?? null,
                 portadaLibroImg: d.portadaLibroImg ?? null,
                 codigoBarra: d.codigoBarra ?? null,
-                existencias: d.existencias,
+                nroExistencia: d.existencias != null ? Number(d.existencias) : undefined,
                 idEstado: 1
             };
         });
+
+        const fechaIngreso = this.detalles[0]?.fechaIngreso ?? undefined;
 
         return {
             /* ------ claves y datos propios de Biblioteca ------ */
@@ -1010,7 +1016,9 @@ export class ModalRevistaComponent implements OnInit {
             rutaImagen: keepPortada ? (this.selectedFile ? undefined : (this.rutaImagen ?? undefined)) : null,
             nombreImagen: keepPortada ? (this.selectedFile ? undefined : (this.nombreImagen ?? undefined)) : null,
             linkPublicacion: revista.urlPublicacion,
-            periodicidadId: this.formRevista.value.periodicidad,
+            periodicidadId: revista.periodicidad != null ? Number(revista.periodicidad) : undefined,
+            fechaIngreso,
+            existencias: this.detalles.length,
             usuarioCreacion: decoded.sub,
             fechaCreacion: new Date().toISOString(),
 

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/mantenimientos/material-bibliografico/modal-tesis.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/mantenimientos/material-bibliografico/modal-tesis.ts
@@ -638,7 +638,7 @@ export class ModalTesisComponent implements OnInit {
     }
     async ListaPeriodicidad() {
         try {
-            const result: any = await this.materialBibliograficoService.lista_periodicidad('material-bibliografico/ciudad').toPromise();
+            const result: any = await this.materialBibliograficoService.lista_periodicidad('material-bibliografico/periodicidad').toPromise();
             if (result.status === 0) {
                 this.periodicidadLista = result.data;
             }

--- a/Frontend/sakai-ng-master/src/app/biblioteca/services/material-bibliografico.service.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/services/material-bibliografico.service.ts
@@ -127,11 +127,10 @@ api_libros_lista(modulo: any): Observable<any> {
     );
 //     return this.http.get<any[]>('assets/demo/biblioteca/material-bibliografico/revistas.json');
   }
-  lista_periodicidad(modulo: any):Observable<any>{
-    /*return this.http.get<any[]>(`${this.apiUrl}/${modulo}`
-    ,{ headers: new HttpHeaders().set('Authorization',`Bearer ${this.authService.getToken()}`)}
-    );*/
-    return this.http.get<any[]>('assets/demo/biblioteca/data.json');
+  lista_periodicidad(modulo: any): Observable<any> {
+    const token = this.authService.getToken();
+    const options = token ? { headers: new HttpHeaders().set('Authorization', `Bearer ${token}`) } : {};
+    return this.http.get<any[]>(`${this.apiUrl}/api/${modulo}`, options);
   }
   api_otros_lista(modulo: any):Observable<any>{
     /*return this.http.get<any[]>(`${this.apiUrl}/${modulo}`
@@ -525,6 +524,12 @@ registrarEspecialidad(especialidad: any): Observable<any> {
     }
     if (d.estadoDescripcion && !det.estadoDescripcion) {
       det.estadoDescripcion = d.estadoDescripcion;
+    }
+    if (det.existencias == null && (d.nroExistencia != null || d.existencias != null)) {
+      det.existencias = String(d.nroExistencia ?? d.existencias);
+    }
+    if (!det.numeroFactura && d.nroFactura != null) {
+      det.numeroFactura = d.nroFactura;
     }
     return det as DetalleBibliotecaDTO;
   }


### PR DESCRIPTION
## Resumen
- Asigna la fecha de ingreso al mapear `BibliotecaDTO` en el servicio backend
- Propaga el número de existencia desde el backend e incluye al registrar ejemplares de revista
- Calcula y envía `existencias` y `fechaIngreso` al guardar una revista
- Expone el endpoint `/periodicidad` y consume su lista en los modales
- Conserva `nroExistencia` al actualizar la revista y muestra local, tipo de adquisición, fecha de ingreso y número de factura en la tabla de detalles

## Pruebas
- `mvn -q test` *(falla: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.3)*
- `npm test -- --watch=false --browsers=ChromeHeadless` *(falla: Error TS18003: No inputs were found in config file)*
- `npm run build -- --progress=false`


------
https://chatgpt.com/codex/tasks/task_e_68c5c5cb81988329a1a59a282a95d020