### PR TITLE
Corrige carga de ciudad y especialidad al editar material bibliográfico

### DIFF
--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/mantenimientos/material-bibliografico/material-bibliografico.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/mantenimientos/material-bibliografico/material-bibliografico.ts
@@ -401,18 +401,16 @@ onSaved(): void {
 
     switch (objeto.tipoMaterialId ?? this.tipoRecursoFiltro?.tipo?.id) {
       case 1: // Libro
-        await this.modalLibro.ListaEspecialidad();
-        await this.modalLibro.ListaPais();
-        this.modalLibro.editarRegistro(objeto, idTipo);
+        await this.modalLibro.editarRegistro(objeto, idTipo);
         break;
       case 2: // Revista
-        this.modalRevista.editarBiblioteca(objeto, idTipo);
+        await this.modalRevista.editarBiblioteca(objeto, idTipo);
         break;
       case 3: // Tesis
-        this.modalTesis.editarBiblioteca(objeto, idTipo);
+        await this.modalTesis.editarBiblioteca(objeto, idTipo);
         break;
       default: // Otros
-        this.modalOtros.editarBiblioteca(objeto, idTipo);
+        await this.modalOtros.editarBiblioteca(objeto, idTipo);
         break;
     }
 }

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/mantenimientos/material-bibliografico/modal-libro.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/mantenimientos/material-bibliografico/modal-libro.ts
@@ -1379,7 +1379,10 @@ export class ModalLibroComponent implements OnInit {
             descripcion: clone.descriptor,
             notasContenido: clone.notaContenido,
             notaGeneral: clone.notaGeneral,
-            especialidad: clone.idEspecialidad,
+            // Ajustamos la especialidad para contemplar distintas estructuras
+            especialidad: clone.idEspecialidad ??
+                (clone.especialidad as any)?.idEspecialidad ??
+                (clone.especialidad as any)?.id ?? null,
             enSilabo: !!clone.flasyllabus || (clone.ciclos?.length ?? 0) > 0,
             formatoDigital: clone.fladigitalizado,
             urlPublicacion: clone.urlPublicacion,


### PR DESCRIPTION
## Resumen
- Ajusta la asignación de especialidad al cargar datos del libro para considerar diferentes estructuras retornadas por el API.
- Centraliza la edición de registros delegando la carga completa al modal correspondiente.

## Pruebas
- `npm test -- --watch=false` *(falló: No inputs were found in config file)*


------
https://chatgpt.com/codex/tasks/task_e_68c5fd4ba6948329a08c93b831bee8dc