### PR TITLE
Muestra codigo de barras al editar detalle de otros

### DIFF
--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/mantenimientos/material-bibliografico/modal-otros.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/mantenimientos/material-bibliografico/modal-otros.ts
@@ -748,6 +748,7 @@ export class ModalOtrosComponent implements OnInit {
         this.formDetalle.patchValue({
             sede: det.sede ?? this.sedesLista.find((s) => s.id === det.codigoSede) ?? null,
             tipoMaterial: det.tipoMaterialId ?? this.tipoMaterialId,
+            codigoBarra: det.codigoBarra ?? null,
             fechaIngreso: det.fechaIngreso ? new Date(det.fechaIngreso) : null,
             horaInicio: det.horaInicio ? this.stringToDate(det.horaInicio) : null,
             horaFin: det.horaFin ? this.stringToDate(det.horaFin) : null,


### PR DESCRIPTION
## Summary
- Incluye el número de código de barras al abrir el formulario de actualización de detalles para materiales "otros"

## Testing
- `npm test -- --watch=false` (falla: No inputs were found in config file 'tsconfig.spec.json')
- `npm run lint` (falla: Missing script: "lint")

------
https://chatgpt.com/codex/tasks/task_e_68c6059dd20483298662433d34b46c08