### PR TITLE
feat: módulos de motivo y programa de acción

### DIFF
--- a/Backend/login-microsoft365/src/main/java/com/miapp/controller/MotivoAccionController.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/controller/MotivoAccionController.java
@@ -1,0 +1,77 @@
+package com.miapp.controller;
+
+import com.miapp.model.MotivoAccion;
+import com.miapp.service.MotivoAccionService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/auth/motivoaccion")
+public class MotivoAccionController {
+
+    private final MotivoAccionService motivoAccionService;
+
+    public MotivoAccionController(MotivoAccionService motivoAccionService) {
+        this.motivoAccionService = motivoAccionService;
+    }
+
+    @GetMapping("/lista-activo")
+    public ResponseEntity<?> listarActivos() {
+        List<MotivoAccion> motivos = motivoAccionService.listActivos();
+        return ResponseEntity.ok(Map.of("status", 0, "data", motivos));
+    }
+
+    @GetMapping("/lista")
+    public ResponseEntity<?> listarTodos() {
+        List<MotivoAccion> motivos = motivoAccionService.listAll();
+        return ResponseEntity.ok(Map.of("status", 0, "data", motivos));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<?> obtener(@PathVariable Long id) {
+        try {
+            MotivoAccion motivo = motivoAccionService.getById(id);
+            return ResponseEntity.ok(Map.of("status", 0, "data", motivo));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(Map.of("status", -1, "message", e.getMessage()));
+        }
+    }
+
+    @PostMapping
+    public ResponseEntity<?> crear(@RequestBody MotivoAccion motivo) {
+        try {
+            MotivoAccion saved = motivoAccionService.create(motivo);
+            return ResponseEntity.ok(Map.of("status", 0, "data", saved));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(Map.of("status", -1, "message", e.getMessage()));
+        }
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<?> actualizar(@PathVariable Long id, @RequestBody MotivoAccion motivo) {
+        try {
+            MotivoAccion updated = motivoAccionService.update(id, motivo);
+            return ResponseEntity.ok(Map.of("status", 0, "data", updated));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(Map.of("status", -1, "message", e.getMessage()));
+        }
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<?> eliminar(@PathVariable Long id) {
+        try {
+            motivoAccionService.delete(id);
+            return ResponseEntity.ok(Map.of("status", 0));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(Map.of("status", -1, "message", e.getMessage()));
+        }
+    }
+}

--- a/Backend/login-microsoft365/src/main/java/com/miapp/controller/ProgramaAccionController.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/controller/ProgramaAccionController.java
@@ -1,0 +1,77 @@
+package com.miapp.controller;
+
+import com.miapp.model.ProgramaAccion;
+import com.miapp.service.ProgramaAccionService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/auth/programaaccion")
+public class ProgramaAccionController {
+
+    private final ProgramaAccionService programaAccionService;
+
+    public ProgramaAccionController(ProgramaAccionService programaAccionService) {
+        this.programaAccionService = programaAccionService;
+    }
+
+    @GetMapping("/lista-activo")
+    public ResponseEntity<?> listarActivos() {
+        List<ProgramaAccion> programas = programaAccionService.listActivos();
+        return ResponseEntity.ok(Map.of("status", 0, "data", programas));
+    }
+
+    @GetMapping("/lista")
+    public ResponseEntity<?> listarTodos() {
+        List<ProgramaAccion> programas = programaAccionService.listAll();
+        return ResponseEntity.ok(Map.of("status", 0, "data", programas));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<?> obtener(@PathVariable Long id) {
+        try {
+            ProgramaAccion programa = programaAccionService.getById(id);
+            return ResponseEntity.ok(Map.of("status", 0, "data", programa));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(Map.of("status", -1, "message", e.getMessage()));
+        }
+    }
+
+    @PostMapping
+    public ResponseEntity<?> crear(@RequestBody ProgramaAccion programa) {
+        try {
+            ProgramaAccion saved = programaAccionService.create(programa);
+            return ResponseEntity.ok(Map.of("status", 0, "data", saved));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(Map.of("status", -1, "message", e.getMessage()));
+        }
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<?> actualizar(@PathVariable Long id, @RequestBody ProgramaAccion programa) {
+        try {
+            ProgramaAccion updated = programaAccionService.update(id, programa);
+            return ResponseEntity.ok(Map.of("status", 0, "data", updated));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(Map.of("status", -1, "message", e.getMessage()));
+        }
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<?> eliminar(@PathVariable Long id) {
+        try {
+            programaAccionService.delete(id);
+            return ResponseEntity.ok(Map.of("status", 0));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(Map.of("status", -1, "message", e.getMessage()));
+        }
+    }
+}

--- a/Backend/login-microsoft365/src/main/java/com/miapp/model/MotivoAccion.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/model/MotivoAccion.java
@@ -1,0 +1,25 @@
+package com.miapp.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "MOTIVO_ACCION")
+public class MotivoAccion {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "IDMOTIVOACCION")
+    private Long idMotivoAccion;
+
+    @Column(name = "DESCRIPCION", length = 100, nullable = false)
+    private String descripcion;
+
+    @Column(name = "ESTADO", columnDefinition = "NUMBER(1)")
+    private Boolean estado = true;
+}

--- a/Backend/login-microsoft365/src/main/java/com/miapp/model/ProgramaAccion.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/model/ProgramaAccion.java
@@ -1,0 +1,25 @@
+package com.miapp.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "PROGRAMA_ACCION")
+public class ProgramaAccion {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "IDPROGRAMAACCION")
+    private Long idProgramaAccion;
+
+    @Column(name = "DESCRIPCION", length = 100, nullable = false)
+    private String descripcion;
+
+    @Column(name = "ESTADO", columnDefinition = "NUMBER(1)")
+    private Boolean estado = true;
+}

--- a/Backend/login-microsoft365/src/main/java/com/miapp/repository/MotivoAccionRepository.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/repository/MotivoAccionRepository.java
@@ -1,0 +1,12 @@
+package com.miapp.repository;
+
+import com.miapp.model.MotivoAccion;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface MotivoAccionRepository extends JpaRepository<MotivoAccion, Long> {
+    List<MotivoAccion> findByEstadoTrue();
+}

--- a/Backend/login-microsoft365/src/main/java/com/miapp/repository/ProgramaAccionRepository.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/repository/ProgramaAccionRepository.java
@@ -1,0 +1,12 @@
+package com.miapp.repository;
+
+import com.miapp.model.ProgramaAccion;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ProgramaAccionRepository extends JpaRepository<ProgramaAccion, Long> {
+    List<ProgramaAccion> findByEstadoTrue();
+}

--- a/Backend/login-microsoft365/src/main/java/com/miapp/service/MotivoAccionService.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/service/MotivoAccionService.java
@@ -1,0 +1,52 @@
+package com.miapp.service;
+
+import com.miapp.model.MotivoAccion;
+import com.miapp.repository.MotivoAccionRepository;
+import jakarta.transaction.Transactional;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class MotivoAccionService {
+
+    private final MotivoAccionRepository repository;
+
+    public MotivoAccionService(MotivoAccionRepository repository) {
+        this.repository = repository;
+    }
+
+    public List<MotivoAccion> listAll() {
+        return repository.findAll();
+    }
+
+    public List<MotivoAccion> listActivos() {
+        return repository.findByEstadoTrue();
+    }
+
+    public MotivoAccion getById(Long id) {
+        return repository.findById(id)
+                .orElseThrow(() -> new RuntimeException("MotivoAccion no encontrado"));
+    }
+
+    @Transactional
+    public MotivoAccion create(MotivoAccion motivo) {
+        motivo.setIdMotivoAccion(null);
+        return repository.save(motivo);
+    }
+
+    @Transactional
+    public MotivoAccion update(Long id, MotivoAccion datos) {
+        MotivoAccion motivo = getById(id);
+        motivo.setDescripcion(datos.getDescripcion());
+        motivo.setEstado(datos.getEstado());
+        return repository.save(motivo);
+    }
+
+    @Transactional
+    public void delete(Long id) {
+        MotivoAccion motivo = getById(id);
+        motivo.setEstado(false);
+        repository.save(motivo);
+    }
+}

--- a/Backend/login-microsoft365/src/main/java/com/miapp/service/ProgramaAccionService.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/service/ProgramaAccionService.java
@@ -1,0 +1,52 @@
+package com.miapp.service;
+
+import com.miapp.model.ProgramaAccion;
+import com.miapp.repository.ProgramaAccionRepository;
+import jakarta.transaction.Transactional;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class ProgramaAccionService {
+
+    private final ProgramaAccionRepository repository;
+
+    public ProgramaAccionService(ProgramaAccionRepository repository) {
+        this.repository = repository;
+    }
+
+    public List<ProgramaAccion> listAll() {
+        return repository.findAll();
+    }
+
+    public List<ProgramaAccion> listActivos() {
+        return repository.findByEstadoTrue();
+    }
+
+    public ProgramaAccion getById(Long id) {
+        return repository.findById(id)
+                .orElseThrow(() -> new RuntimeException("ProgramaAccion no encontrado"));
+    }
+
+    @Transactional
+    public ProgramaAccion create(ProgramaAccion programa) {
+        programa.setIdProgramaAccion(null);
+        return repository.save(programa);
+    }
+
+    @Transactional
+    public ProgramaAccion update(Long id, ProgramaAccion datos) {
+        ProgramaAccion programa = getById(id);
+        programa.setDescripcion(datos.getDescripcion());
+        programa.setEstado(datos.getEstado());
+        return repository.save(programa);
+    }
+
+    @Transactional
+    public void delete(Long id) {
+        ProgramaAccion programa = getById(id);
+        programa.setEstado(false);
+        repository.save(programa);
+    }
+}

--- a/Frontend/sakai-ng-master/src/app/biblioteca/configuracion/configuracion.routes.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/configuracion/configuracion.routes.ts
@@ -5,11 +5,15 @@ import { EspecialidadesComponent } from '../modulos/mantenimientos/especialidade
 import { TipoRecursoComponent } from './tipo-recurso/tipo-recurso';
 import { AutorComponent } from './autor/autor';
 import { EditorialComponent } from './editorial/editorial';
+import { MotivoAccionComponent } from '../modulos/mantenimientos/motivo-accion/motivo-accion';
+import { ProgramaAccionComponent } from '../modulos/mantenimientos/programa-accion/programa-accion';
 
 export default [
     { path: 'sedes', component: SedesComponent },
     { path: 'programas', component: ProgramasComponent },
     { path: 'especialidades', component: EspecialidadesComponent },
+    { path: 'motivos-accion', component: MotivoAccionComponent, data: { roles: ['ROLE_MOTIVO_ACCION'] } },
+    { path: 'programas-accion', component: ProgramaAccionComponent, data: { roles: ['ROLE_PROGRAMA_ACCION'] } },
     { path: 'tipo-recurso', component: TipoRecursoComponent },
     { path: 'autor', component: AutorComponent },
     { path: 'editorial', component: EditorialComponent },

--- a/Frontend/sakai-ng-master/src/app/biblioteca/interfaces/motivo-accion.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/interfaces/motivo-accion.ts
@@ -1,0 +1,11 @@
+export class MotivoAccion {
+    id: number;
+    descripcion: string;
+    estado: boolean;
+    constructor(init?: Partial<MotivoAccion>) {
+        this.id = 0;
+        this.descripcion = '';
+        this.estado = true;
+        Object.assign(this, init);
+    }
+}

--- a/Frontend/sakai-ng-master/src/app/biblioteca/interfaces/programa-accion.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/interfaces/programa-accion.ts
@@ -1,0 +1,11 @@
+export class ProgramaAccion {
+    id: number;
+    descripcion: string;
+    estado: boolean;
+    constructor(init?: Partial<ProgramaAccion>) {
+        this.id = 0;
+        this.descripcion = '';
+        this.estado = true;
+        Object.assign(this, init);
+    }
+}

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/mantenimientos/motivo-accion/motivo-accion.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/mantenimientos/motivo-accion/motivo-accion.ts
@@ -1,0 +1,163 @@
+import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
+import { TemplateModule } from '../../../template.module';
+import { MotivoAccion } from '../../../interfaces/motivo-accion';
+import { MotivoAccionService } from '../../../services/motivo-accion.service';
+import { MessageService, ConfirmationService } from 'primeng/api';
+import { Table } from 'primeng/table';
+
+@Component({
+  selector: 'app-motivo-accion',
+  standalone: true,
+  imports: [TemplateModule],
+  providers: [MessageService, ConfirmationService],
+  template: `
+    <p-toolbar styleClass="mb-6">
+      <ng-template #start>
+        <p-button label="Nuevo Motivo" icon="pi pi-plus" (onClick)="openNew()" />
+      </ng-template>
+    </p-toolbar>
+    <p-table
+      #dt1
+      [value]="motivos"
+      dataKey="id"
+      [rows]="10"
+      [paginator]="true"
+      [rowsPerPageOptions]="[10, 25, 50]"
+      [showCurrentPageReport]="true"
+      currentPageReportTemplate="Mostrando {first} a {last} de {totalRecords} registros"
+      [rowHover]="true"
+      styleClass="p-datatable-gridlines"
+      [globalFilterFields]="['descripcion','estado']"
+      [loading]="loading"
+      responsiveLayout="scroll"
+    >
+      <ng-template pTemplate="caption">
+        <div class="flex items-center justify-between">
+          <p-button [outlined]="true" icon="pi pi-filter-slash" label="Limpiar" (click)="clear(dt1)" />
+          <p-iconfield>
+            <input pInputText #filter type="text" placeholder="Filtrar" (input)="onGlobalFilter(dt1,$event)" />
+          </p-iconfield>
+        </div>
+      </ng-template>
+      <ng-template pTemplate="header">
+        <tr>
+          <th pSortableColumn="descripcion">Descripción<p-sortIcon field="descripcion"></p-sortIcon></th>
+          <th pSortableColumn="estado" style="width:8rem">Activo<p-sortIcon field="estado"></p-sortIcon></th>
+          <th style="width:8rem">Acciones</th>
+        </tr>
+      </ng-template>
+      <ng-template pTemplate="body" let-motivo>
+        <tr>
+          <td>{{ motivo.descripcion }}</td>
+          <td>
+            <p-tag [value]="motivo.estado ? 'Sí' : 'No'" [severity]="motivo.estado ? 'success' : 'danger'"></p-tag>
+          </td>
+          <td>
+            <p-button icon="pi pi-pencil" rounded outlined class="mr-2" (onClick)="edit(motivo)"></p-button>
+            <p-button icon="pi pi-trash" severity="danger" rounded outlined (onClick)="confirmDelete(motivo)"></p-button>
+          </td>
+        </tr>
+      </ng-template>
+      <ng-template pTemplate="emptymessage">
+        <tr>
+          <td colspan="3">No se encontraron registros.</td>
+        </tr>
+      </ng-template>
+      <ng-template pTemplate="loadingbody">
+        <tr>
+          <td colspan="3">Cargando datos. Espere por favor.</td>
+        </tr>
+      </ng-template>
+    </p-table>
+
+    <p-dialog [(visible)]="dialog" header="Motivo" [modal]="true" [style]="{width: '400px'}" (onHide)="hideDialog()">
+      <div class="flex flex-col gap-3">
+        <div>
+          <label class="font-bold">Descripción</label>
+          <input pInputText [(ngModel)]="motivo.descripcion" placeholder="Descripción del motivo" />
+        </div>
+        <div>
+          <p-checkbox [(ngModel)]="motivo.estado" binary="true" label="Activo"></p-checkbox>
+        </div>
+      </div>
+      <ng-template #footer>
+        <p-button label="Guardar" (onClick)="save()" />
+      </ng-template>
+    </p-dialog>
+    <p-confirmDialog></p-confirmDialog>
+  `
+})
+export class MotivoAccionComponent implements OnInit {
+  motivos: MotivoAccion[] = [];
+  dialog = false;
+  motivo: MotivoAccion = new MotivoAccion();
+  loading = false;
+  @ViewChild('filter') filter!: ElementRef;
+
+  constructor(
+    private motivoService: MotivoAccionService,
+    private messageService: MessageService,
+    private confirmationService: ConfirmationService
+  ) {}
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  load() {
+    this.loading = true;
+    this.motivoService.list().subscribe(data => {
+      this.motivos = data;
+      this.loading = false;
+    });
+  }
+
+  openNew() {
+    this.motivo = new MotivoAccion();
+    this.dialog = true;
+  }
+
+  edit(m: MotivoAccion) {
+    this.motivo = { ...m };
+    this.dialog = true;
+  }
+
+  save() {
+    const request = this.motivo.id
+      ? this.motivoService.update(this.motivo.id, this.motivo)
+      : this.motivoService.create(this.motivo);
+
+    request.subscribe(() => {
+      this.load();
+      this.dialog = false;
+      this.messageService.add({severity:'success', summary:'Éxito', detail:'Registro guardado'});
+    });
+  }
+
+  confirmDelete(m: MotivoAccion) {
+    this.confirmationService.confirm({
+      message: '¿Eliminar registro?',
+      accept: () => this.delete(m)
+    });
+  }
+
+  delete(m: MotivoAccion) {
+    this.motivoService.delete(m.id).subscribe(() => {
+      this.load();
+      this.messageService.add({severity:'success', summary:'Eliminado'});
+    });
+  }
+
+  hideDialog() {
+    this.dialog = false;
+  }
+
+  onGlobalFilter(table: Table, event: Event) {
+    table.filterGlobal((event.target as HTMLInputElement).value, 'contains');
+  }
+
+  clear(table: Table) {
+    table.clear();
+    this.filter.nativeElement.value = '';
+  }
+}

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/mantenimientos/programa-accion/programa-accion.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/mantenimientos/programa-accion/programa-accion.ts
@@ -1,0 +1,163 @@
+import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
+import { TemplateModule } from '../../../template.module';
+import { ProgramaAccion } from '../../../interfaces/programa-accion';
+import { ProgramaAccionService } from '../../../services/programa-accion.service';
+import { MessageService, ConfirmationService } from 'primeng/api';
+import { Table } from 'primeng/table';
+
+@Component({
+  selector: 'app-programa-accion',
+  standalone: true,
+  imports: [TemplateModule],
+  providers: [MessageService, ConfirmationService],
+  template: `
+    <p-toolbar styleClass="mb-6">
+      <ng-template #start>
+        <p-button label="Nuevo Programa" icon="pi pi-plus" (onClick)="openNew()" />
+      </ng-template>
+    </p-toolbar>
+    <p-table
+      #dt1
+      [value]="programas"
+      dataKey="id"
+      [rows]="10"
+      [paginator]="true"
+      [rowsPerPageOptions]="[10, 25, 50]"
+      [showCurrentPageReport]="true"
+      currentPageReportTemplate="Mostrando {first} a {last} de {totalRecords} registros"
+      [rowHover]="true"
+      styleClass="p-datatable-gridlines"
+      [globalFilterFields]="['descripcion','estado']"
+      [loading]="loading"
+      responsiveLayout="scroll"
+    >
+      <ng-template pTemplate="caption">
+        <div class="flex items-center justify-between">
+          <p-button [outlined]="true" icon="pi pi-filter-slash" label="Limpiar" (click)="clear(dt1)" />
+          <p-iconfield>
+            <input pInputText #filter type="text" placeholder="Filtrar" (input)="onGlobalFilter(dt1,$event)" />
+          </p-iconfield>
+        </div>
+      </ng-template>
+      <ng-template pTemplate="header">
+        <tr>
+          <th pSortableColumn="descripcion">Descripción<p-sortIcon field="descripcion"></p-sortIcon></th>
+          <th pSortableColumn="estado" style="width:8rem">Activo<p-sortIcon field="estado"></p-sortIcon></th>
+          <th style="width:8rem">Acciones</th>
+        </tr>
+      </ng-template>
+      <ng-template pTemplate="body" let-programa>
+        <tr>
+          <td>{{ programa.descripcion }}</td>
+          <td>
+            <p-tag [value]="programa.estado ? 'Sí' : 'No'" [severity]="programa.estado ? 'success' : 'danger'"></p-tag>
+          </td>
+          <td>
+            <p-button icon="pi pi-pencil" rounded outlined class="mr-2" (onClick)="edit(programa)"></p-button>
+            <p-button icon="pi pi-trash" severity="danger" rounded outlined (onClick)="confirmDelete(programa)"></p-button>
+          </td>
+        </tr>
+      </ng-template>
+      <ng-template pTemplate="emptymessage">
+        <tr>
+          <td colspan="3">No se encontraron registros.</td>
+        </tr>
+      </ng-template>
+      <ng-template pTemplate="loadingbody">
+        <tr>
+          <td colspan="3">Cargando datos. Espere por favor.</td>
+        </tr>
+      </ng-template>
+    </p-table>
+
+    <p-dialog [(visible)]="dialog" header="Programa" [modal]="true" [style]="{width: '400px'}" (onHide)="hideDialog()">
+      <div class="flex flex-col gap-3">
+        <div>
+          <label class="font-bold">Descripción</label>
+          <input pInputText [(ngModel)]="programa.descripcion" placeholder="Descripción del programa" />
+        </div>
+        <div>
+          <p-checkbox [(ngModel)]="programa.estado" binary="true" label="Activo"></p-checkbox>
+        </div>
+      </div>
+      <ng-template #footer>
+        <p-button label="Guardar" (onClick)="save()" />
+      </ng-template>
+    </p-dialog>
+    <p-confirmDialog></p-confirmDialog>
+  `
+})
+export class ProgramaAccionComponent implements OnInit {
+  programas: ProgramaAccion[] = [];
+  dialog = false;
+  programa: ProgramaAccion = new ProgramaAccion();
+  loading = false;
+  @ViewChild('filter') filter!: ElementRef;
+
+  constructor(
+    private programaService: ProgramaAccionService,
+    private messageService: MessageService,
+    private confirmationService: ConfirmationService
+  ) {}
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  load() {
+    this.loading = true;
+    this.programaService.list().subscribe(data => {
+      this.programas = data;
+      this.loading = false;
+    });
+  }
+
+  openNew() {
+    this.programa = new ProgramaAccion();
+    this.dialog = true;
+  }
+
+  edit(p: ProgramaAccion) {
+    this.programa = { ...p };
+    this.dialog = true;
+  }
+
+  save() {
+    const request = this.programa.id
+      ? this.programaService.update(this.programa.id, this.programa)
+      : this.programaService.create(this.programa);
+
+    request.subscribe(() => {
+      this.load();
+      this.dialog = false;
+      this.messageService.add({severity:'success', summary:'Éxito', detail:'Registro guardado'});
+    });
+  }
+
+  confirmDelete(p: ProgramaAccion) {
+    this.confirmationService.confirm({
+      message: '¿Eliminar registro?',
+      accept: () => this.delete(p)
+    });
+  }
+
+  delete(p: ProgramaAccion) {
+    this.programaService.delete(p.id).subscribe(() => {
+      this.load();
+      this.messageService.add({severity:'success', summary:'Eliminado'});
+    });
+  }
+
+  hideDialog() {
+    this.dialog = false;
+  }
+
+  onGlobalFilter(table: Table, event: Event) {
+    table.filterGlobal((event.target as HTMLInputElement).value, 'contains');
+  }
+
+  clear(table: Table) {
+    table.clear();
+    this.filter.nativeElement.value = '';
+  }
+}

--- a/Frontend/sakai-ng-master/src/app/biblioteca/services/motivo-accion.service.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/services/motivo-accion.service.ts
@@ -1,0 +1,75 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { environment } from '../../../environments/environment';
+import { AuthService } from './auth.service';
+import { MotivoAccion } from '../interfaces/motivo-accion';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class MotivoAccionService {
+  private apiUrl = environment.apiUrl;
+  constructor(private http: HttpClient, private auth: AuthService) {}
+
+  private headers(): HttpHeaders {
+    return new HttpHeaders().set('Authorization', `Bearer ${this.auth.getToken()}`);
+  }
+
+  list(): Observable<MotivoAccion[]> {
+    return this.http
+      .get<{ data: any[] }>(`${this.apiUrl}/motivoaccion/lista`, { headers: this.headers() })
+      .pipe(
+        map(res =>
+          res.data.map(m =>
+            new MotivoAccion({
+              id: m.idMotivoAccion,
+              descripcion: m.descripcion,
+              estado: m.estado
+            })
+          )
+        )
+      );
+  }
+
+  private toPayload(motivo: MotivoAccion) {
+    return {
+      idMotivoAccion: motivo.id || undefined,
+      descripcion: motivo.descripcion,
+      estado: motivo.estado
+    };
+  }
+
+  create(motivo: MotivoAccion): Observable<MotivoAccion> {
+    return this.http
+      .post<{ data: any }>(`${this.apiUrl}/motivoaccion`, this.toPayload(motivo), { headers: this.headers() })
+      .pipe(
+        map(res =>
+          new MotivoAccion({
+            id: res.data.idMotivoAccion,
+            descripcion: res.data.descripcion,
+            estado: res.data.estado
+          })
+        )
+      );
+  }
+
+  update(id: number, motivo: MotivoAccion): Observable<MotivoAccion> {
+    return this.http
+      .put<{ data: any }>(`${this.apiUrl}/motivoaccion/${id}`, this.toPayload(motivo), { headers: this.headers() })
+      .pipe(
+        map(res =>
+          new MotivoAccion({
+            id: res.data.idMotivoAccion,
+            descripcion: res.data.descripcion,
+            estado: res.data.estado
+          })
+        )
+      );
+  }
+
+  delete(id: number): Observable<void> {
+    return this.http.delete<void>(`${this.apiUrl}/motivoaccion/${id}`, { headers: this.headers() });
+  }
+}

--- a/Frontend/sakai-ng-master/src/app/biblioteca/services/programa-accion.service.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/services/programa-accion.service.ts
@@ -1,0 +1,75 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { environment } from '../../../environments/environment';
+import { AuthService } from './auth.service';
+import { ProgramaAccion } from '../interfaces/programa-accion';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ProgramaAccionService {
+  private apiUrl = environment.apiUrl;
+  constructor(private http: HttpClient, private auth: AuthService) {}
+
+  private headers(): HttpHeaders {
+    return new HttpHeaders().set('Authorization', `Bearer ${this.auth.getToken()}`);
+  }
+
+  list(): Observable<ProgramaAccion[]> {
+    return this.http
+      .get<{ data: any[] }>(`${this.apiUrl}/programaaccion/lista`, { headers: this.headers() })
+      .pipe(
+        map(res =>
+          res.data.map(p =>
+            new ProgramaAccion({
+              id: p.idProgramaAccion,
+              descripcion: p.descripcion,
+              estado: p.estado
+            })
+          )
+        )
+      );
+  }
+
+  private toPayload(programa: ProgramaAccion) {
+    return {
+      idProgramaAccion: programa.id || undefined,
+      descripcion: programa.descripcion,
+      estado: programa.estado
+    };
+  }
+
+  create(programa: ProgramaAccion): Observable<ProgramaAccion> {
+    return this.http
+      .post<{ data: any }>(`${this.apiUrl}/programaaccion`, this.toPayload(programa), { headers: this.headers() })
+      .pipe(
+        map(res =>
+          new ProgramaAccion({
+            id: res.data.idProgramaAccion,
+            descripcion: res.data.descripcion,
+            estado: res.data.estado
+          })
+        )
+      );
+  }
+
+  update(id: number, programa: ProgramaAccion): Observable<ProgramaAccion> {
+    return this.http
+      .put<{ data: any }>(`${this.apiUrl}/programaaccion/${id}`, this.toPayload(programa), { headers: this.headers() })
+      .pipe(
+        map(res =>
+          new ProgramaAccion({
+            id: res.data.idProgramaAccion,
+            descripcion: res.data.descripcion,
+            estado: res.data.estado
+          })
+        )
+      );
+  }
+
+  delete(id: number): Observable<void> {
+    return this.http.delete<void>(`${this.apiUrl}/programaaccion/${id}`, { headers: this.headers() });
+  }
+}

--- a/Frontend/sakai-ng-master/src/app/layout/component/app.menu.ts
+++ b/Frontend/sakai-ng-master/src/app/layout/component/app.menu.ts
@@ -59,7 +59,7 @@ export class AppMenu {
                         label: 'Aceptaciones Equipos',
                         icon: 'pi pi-fw pi-check',
                         routerLink: ['/main/mantenimiento/aceptaciones-equipos'],role: ['ROLE_ACEPTACIONES_EQUIPOS']
-                    },
+                    }
                 ]
             },
             {
@@ -302,6 +302,16 @@ export class AppMenu {
                         label: 'Especialidades',
                         icon: 'pi pi-fw pi-star',
                         routerLink: ['/main/configuracion/especialidades'],role: ['ROLE_CONF_ESPECIALIDADES']
+                    },
+                    {
+                        label: 'Motivos de acción',
+                        icon: 'pi pi-fw pi-list',
+                        routerLink: ['/main/configuracion/motivos-accion'],role: ['ROLE_MOTIVO_ACCION']
+                    },
+                    {
+                        label: 'Programas de acción',
+                        icon: 'pi pi-fw pi-flag',
+                        routerLink: ['/main/configuracion/programas-accion'],role: ['ROLE_PROGRAMA_ACCION']
                     }
                 ]
             },


### PR DESCRIPTION
## Resumen
- Reubicados los catálogos de motivos y programas de acción dentro de la sección de Configuración
- Ajustadas las rutas y el menú para reflejar el nuevo orden

## Testing
- ⚠️ `npm test -- --watch=false` (Error: No inputs were found in config file 'tsconfig.spec.json')
- ⚠️ `mvn -q -DskipTests package` (Network is unreachable y no se resolvió el parent POM)


------
https://chatgpt.com/codex/tasks/task_e_68c605c293f483298890101fd0f55ef2