### PR TITLE
chore: ampliar trazas del reporte de visitantes

### DIFF
--- a/Backend/login-microsoft365/src/main/java/com/miapp/controller/PrestamoController.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/controller/PrestamoController.java
@@ -264,6 +264,7 @@ public class PrestamoController {
     private static final DateTimeFormatter FORMATO_DD_MM_YYYY_GUION = DateTimeFormatter.ofPattern("dd-MM-yyyy");
     private static final DateTimeFormatter FORMATO_LOCALE_GMT =
             DateTimeFormatter.ofPattern("EEE MMM dd yyyy HH:mm:ss 'GMT'XXX", Locale.ENGLISH);
+    private static final DateTimeFormatter FORMATO_LOG = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 
     private LocalDateTime parseDate(String dateStr, boolean endExclusive) {
         LocalDate baseDate = resolveLocalDate(dateStr);
@@ -272,6 +273,24 @@ public class PrestamoController {
         }
         LocalDateTime start = baseDate.atStartOfDay();
         return endExclusive ? start.plusDays(1) : start;
+    }
+
+    private String describirRangoConsulta(LocalDateTime inicio, LocalDateTime finExclusiva) {
+        String inicioLegible = formatearFechaLog(inicio);
+        if (finExclusiva == null) {
+            return inicioLegible + " → sin fecha fin";
+        }
+        LocalDateTime finInclusivo = finExclusiva.minusSeconds(1);
+        return inicioLegible
+                + " → "
+                + formatearFechaLog(finInclusivo)
+                + " (límite exclusivo: "
+                + formatearFechaLog(finExclusiva)
+                + ')';
+    }
+
+    private String formatearFechaLog(LocalDateTime valor) {
+        return valor != null ? valor.format(FORMATO_LOG) : "sin fecha";
     }
 
     private LocalDate resolveLocalDate(String dateStr) {
@@ -333,19 +352,45 @@ public class PrestamoController {
         LocalDateTime inicio = parseDate(fechaInicio, false);
         LocalDateTime finExclusiva = parseDate(fechaFin, true);
 
-        List<com.miapp.model.dto.VisitanteBibliotecaVirtualDTO> lista =
-                prestamoService.reporteVisitantesBibliotecaVirtual(
-                        inicio,
-                        finExclusiva,
-                        codigo,
-                        sede,
-                        tipoUsuario,
-                        escuela,
-                        programa,
-                        ciclo,
-                        baseDatos
-                );
-        return ResponseEntity.ok(Map.of("status","0","data", lista));
+        Map<String, Object> filtros = new HashMap<>();
+        filtros.put("fechaInicio", inicio);
+        filtros.put("fechaFin", finExclusiva);
+        filtros.put("codigo", codigo);
+        filtros.put("sede", sede);
+        filtros.put("tipoUsuario", tipoUsuario);
+        filtros.put("escuela", escuela);
+        filtros.put("programa", programa);
+        filtros.put("ciclo", ciclo);
+        filtros.put("baseDatos", baseDatos);
+        System.out.println("[Reporte Visitantes Biblioteca Virtual][Backend] Filtros recibidos: " + filtros);
+        System.out.println("[Reporte Visitantes Biblioteca Virtual][Backend] Rango consultado (inclusive): "
+                + describirRangoConsulta(inicio, finExclusiva));
+
+        try {
+            List<com.miapp.model.dto.VisitanteBibliotecaVirtualDTO> lista =
+                    prestamoService.reporteVisitantesBibliotecaVirtual(
+                            inicio,
+                            finExclusiva,
+                            codigo,
+                            sede,
+                            tipoUsuario,
+                            escuela,
+                            programa,
+                            ciclo,
+                            baseDatos
+                    );
+            System.out.println(
+                    "[Reporte Visitantes Biblioteca Virtual][Backend] Registros devueltos: "
+                            + (lista != null ? lista.size() : 0)
+            );
+            System.out.println("[Reporte Visitantes Biblioteca Virtual][Backend] Respuesta cruda: " + lista);
+            return ResponseEntity.ok(Map.of("status","0","data", lista));
+        } catch (RuntimeException ex) {
+            System.out.println(
+                    "[Reporte Visitantes Biblioteca Virtual][Backend] Error al obtener datos: " + ex.getMessage()
+            );
+            throw ex;
+        }
     }
 
     /** Reporte agregado por día de visitantes de biblioteca virtual */

--- a/Backend/login-microsoft365/src/main/java/com/miapp/service/PrestamoService.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/service/PrestamoService.java
@@ -742,8 +742,12 @@ public class PrestamoService {
                 ORDER BY COUNT(DISTINCT v.IDVISITABIBVIR) DESC
                 """);
 
+        String sqlFinal = sql.toString();
+        System.out.println("[Reporte Visitantes Biblioteca Virtual][Backend] SQL generada:\n" + sqlFinal);
+        System.out.println("[Reporte Visitantes Biblioteca Virtual][Backend] Parámetros SQL: " + params);
+
         return jdbcTemplate.query(
-                sql.toString(),
+                sqlFinal,
                 params.toArray(),
                 (rs, rowNum) -> mapearResumenVisitanteVirtual(new Object[]{
                         rs.getString("SEDE"),

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/visitantes-biblioteca-virtual.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/reportes/visitantes-biblioteca-virtual.ts
@@ -246,8 +246,14 @@ export class ReporteVisitantesBibliotecaVirtual {
             baseDatos: this.normalizarId(this.basededatosFiltro?.id)
         };
         try {
-            this.resultados = (await firstValueFrom(this.svc.reporteVisitantesBibliotecaVirtual(filtros))) ?? [];
+            console.log('[Reporte Visitantes Biblioteca Virtual] Filtros normalizados enviados:', filtros);
+            const respuesta = (await firstValueFrom(this.svc.reporteVisitantesBibliotecaVirtual(filtros))) ?? [];
+            console.log('[Reporte Visitantes Biblioteca Virtual] Respuesta cruda del servicio:', respuesta);
+            const resultados = Array.isArray(respuesta) ? respuesta : [];
+            console.log('[Reporte Visitantes Biblioteca Virtual] Total de registros recibidos:', resultados.length);
+            this.resultados = resultados;
         } catch (error: any) {
+            console.error('[Reporte Visitantes Biblioteca Virtual] Error al obtener datos:', error);
             const msg = error?.status === 403 ? 'No autorizado para ver el reporte.' : 'No fue posible cargar los datos.';
             this.messageService.add({ severity: 'error', detail: msg });
         } finally {

--- a/Frontend/sakai-ng-master/src/app/biblioteca/services/prestamos.service.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/services/prestamos.service.ts
@@ -310,6 +310,11 @@ export class PrestamosService {
             `Bearer ${this.authService.getToken()}`
         );
 
+        console.log(
+            '[Reporte Visitantes Biblioteca Virtual] Parámetros HTTP enviados:',
+            params.toString() || '(sin filtros)'
+        );
+
         return this.http
             .get<{ status: string; data: VisitanteBibliotecaVirtualDTO[] }>(
                 `${this.apiUrl}/api/prestamos/reporte/visitantes-biblioteca-virtual`,


### PR DESCRIPTION
## Resumen
- detallar en el backend el rango inclusivo evaluado y registrar la sentencia SQL y sus parámetros al generar el reporte de visitantes de biblioteca virtual
- emitir en el frontend el querystring calculado antes de invocar al servicio de visitantes

## Pruebas
- no se ejecutaron pruebas automatizadas (cambios orientados a trazas)

------
https://chatgpt.com/codex/tasks/task_e_68cb4ecb1a288329882fc162896c531d