### PR TITLE
Corrige consulta de reporte de visitantes al usar Programa

### DIFF
--- a/Backend/login-microsoft365/src/main/java/com/miapp/repository/UsuarioRepository.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/repository/UsuarioRepository.java
@@ -44,7 +44,7 @@ public interface UsuarioRepository extends JpaRepository<Usuario, Long> {
                     "        COALESCE(u.nombreUsuario,''))," +
                     " COALESCE(r.descripcion, 'Sin Rol')," +
                     " COALESCE(e.descripcion, '-')," +
-                    " COALESCE(p.descripcion, '-')," +
+                    " COALESCE(p.descripcionPrograma, '-')," +
                     " COALESCE(u.ciclo, '-')," +
                     " COALESCE(u.email, '-')," +
                     " COALESCE(u.loginCount,0)," +


### PR DESCRIPTION
## Resumen
- actualiza la consulta JPQL del reporte de visitantes para usar el campo `descripcionPrograma` de la entidad `Programa` en lugar de una propiedad inexistente

## Pruebas
- `mvn test` *(falla por falta de acceso a Maven Central en el entorno)*

------
https://chatgpt.com/codex/tasks/task_e_68cba93a7ff083298fd3d802b2dacd82