### PR TITLE
fix: diferir apertura del selector de roles

### DIFF
--- a/Frontend/sakai-ng-master/src/app/biblioteca/web/portal-landing/components/portal-topbar.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/web/portal-landing/components/portal-topbar.ts
@@ -1,11 +1,57 @@
 import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
 import { Router, RouterModule } from '@angular/router';
+import { ButtonModule } from 'primeng/button';
+import { RippleModule } from 'primeng/ripple';
+import { DialogModule } from 'primeng/dialog';
+
+import { AuthService } from '../../../../biblioteca/services/auth.service';
+import { MicrosoftLoginViewModel } from '../../../../pages/auth/microsoft-login.viewmodel';
 
 @Component({
     selector: 'portal-topbar',
     standalone: true,
-    imports: [RouterModule],
-    template: `<header class="site-header full-bleed">
+    imports: [CommonModule, RouterModule, ButtonModule, RippleModule, DialogModule],
+    styles: [`
+      :host ::ng-deep .role-dialog {
+          opacity: 0;
+          transform: scale(0.85);
+          transition: transform 0.3s ease, opacity 0.3s ease;
+      }
+
+      :host ::ng-deep .role-dialog.p-dialog-visible {
+          opacity: 1;
+          transform: scale(1);
+      }
+    `],
+    template: `<p-dialog
+    [(visible)]="vm.roleDialogVisible"
+    [modal]="true"
+    [closable]="false"
+    [appendTo]="'body'"
+    [style]="{ width: '24rem' }"
+    styleClass="role-dialog"
+  >
+    <ng-template pTemplate="header">
+      <div class="w-full text-center">
+        <span class="text-red-600 uppercase font-semibold">Seleccionar usuario</span>
+      </div>
+    </ng-template>
+    <div class="flex flex-col gap-2 w-full">
+      <button
+        *ngFor="let role of vm.userRoles"
+        (click)="vm.selectRole(role.value)"
+        class="w-full border border-gray-300 py-3 text-center uppercase font-medium text-gray-700 hover:text-red-600 hover:border-red-600 transition-colors cursor-pointer"
+      >
+        {{ role.label }}
+      </button>
+    </div>
+    <div class="mt-4 text-sm font-semibold text-center">
+      <span class="text-gray-700">Usuario:</span>
+      <span class="text-red-600">{{ vm.userEmail }}</span>
+    </div>
+  </p-dialog>
+<header class="site-header full-bleed">
   <div class="nav-inner">
     <a class="brand" (click)="go('home')">
       <img class="brand-logo" src="assets/BOTON-LOGO.png" alt="UPSJB" />
@@ -21,14 +67,45 @@ import { Router, RouterModule } from '@angular/router';
     </nav>
 
     <div class="actions">
-      <a class="login" routerLink="/login">Iniciar sesión</a>
-      <a class="btn-registrate" routerLink="/registrate">Regístrate</a>
+      <ng-container *ngIf="!vm.showUserActions; else loggedActions">
+        <button
+          pButton
+          pRipple
+          type="button"
+          class="login"
+          label="Iniciar sesión con Microsoft365"
+          (click)="vm.startMicrosoftLogin()"
+          [loading]="vm.loading"
+        ></button>
+      </ng-container>
+      <ng-template #loggedActions>
+        <button
+          pButton
+          pRipple
+          type="button"
+          class="login"
+          [label]="vm.displayName"
+          (click)="vm.openRoleDialog()"
+        ></button>
+        <button
+          pButton
+          pRipple
+          type="button"
+          class="btn-registrate"
+          label="Cerrar sesión"
+          (click)="vm.logout()"
+        ></button>
+      </ng-template>
     </div>
   </div>
 </header>`
 })
 export class PortalTopbar {
-    constructor(private router: Router) {}
+    vm: MicrosoftLoginViewModel;
+
+    constructor(private router: Router, private authService: AuthService) {
+        this.vm = new MicrosoftLoginViewModel(this.authService, this.router);
+    }
 
     go(fragment: string) {
         this.router.navigate(['/'], { fragment });

--- a/Frontend/sakai-ng-master/src/app/pages/auth/login.ts
+++ b/Frontend/sakai-ng-master/src/app/pages/auth/login.ts
@@ -1,11 +1,7 @@
 import { Component, OnInit } from '@angular/core';
-import { FormsModule } from '@angular/forms';
 import { Router, RouterModule } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { ButtonModule } from 'primeng/button';
-import { CheckboxModule } from 'primeng/checkbox';
-import { InputTextModule } from 'primeng/inputtext';
-import { PasswordModule } from 'primeng/password';
 import { DialogModule } from 'primeng/dialog';
 import { RippleModule } from 'primeng/ripple';
 import { AppFloatingConfigurator } from '../../layout/component/app.floatingconfigurator';
@@ -23,11 +19,7 @@ export interface LoginCredentials {
   imports: [
     CommonModule,
     ButtonModule,
-    CheckboxModule,
-    InputTextModule,
-    PasswordModule,
     DialogModule,
-    FormsModule,
     RouterModule,
     RippleModule,
     AppFloatingConfigurator
@@ -67,35 +59,20 @@ export interface LoginCredentials {
           <div class="w-full bg-surface-0 dark:bg-surface-900 py-12 px-8 sm:px-12" style="border-radius: 53px">
             <div class="text-center mb-8">
               <img src="assets/logo.png" alt="Logo" class="mb-8 w-30 shrink-0 mx-auto" />
-              <span class="text-muted-color font-medium mb-4">Inicia sesión para continuar</span>
-              <div class="flex justify-center w-full mt-4">
-                <p-button label="Iniciar sesión con Microsoft365" styleClass="w-full sm:w-auto" (click)="loginWithMicrosoft()"></p-button>
-              </div>
-              <div class="flex items-center my-4">
-                <div class="flex-grow border-t border-gray-300"></div>
-                <span class="mx-4 text-gray-500">O</span>
-                <div class="flex-grow border-t border-gray-300"></div>
-              </div>
+              <span class="block text-muted-color font-medium">Inicia sesión con tu cuenta institucional</span>
             </div>
-            <div class="flex flex-col gap-4">
-              <div>
-                <label for="email" class="block text-surface-900 dark:text-surface-0 text-xl font-medium mb-2">Correo electrónico</label>
-                <input pInputText id="email" type="text" placeholder="Email address" class="w-full" [(ngModel)]="credentials.email" name="email" />
+            <div class="flex flex-col gap-6 items-center">
+              <p-button
+                label="Iniciar sesión con Microsoft365"
+                styleClass="w-full sm:w-auto"
+                (click)="loginWithMicrosoft()"
+                [loading]="loadingMicrosoft"
+              ></p-button>
+              <div class="text-sm text-center text-gray-500">
+                Usa el botón superior para autenticarte con Microsoft 365. Tras elegir tu perfil,
+                serás redirigido automáticamente al panel principal.
               </div>
-
-              <div>
-                <label for="password" class="block text-surface-900 dark:text-surface-0 font-medium text-xl mb-2">Contraseña</label>
-                <p-password id="password" [(ngModel)]="credentials.password" placeholder="Contraseña" [toggleMask]="true" [fluid]="true" [feedback]="false"></p-password>
-              </div>
-
-              <div class="flex items-center justify-between mt-2 mb-4 gap-4">
-                <div class="flex items-center">
-                  <p-checkbox [(ngModel)]="checked" id="rememberme1" binary class="mr-2"></p-checkbox>
-                  <label for="rememberme1">Recordarme</label>
-                </div>
-                <span class="font-medium no-underline ml-2 text-right cursor-pointer text-primary" (click)="onForgotPassword()">¿Olvidaste tu contraseña?</span>
-              </div>
-              <p-button label="Iniciar sesión" styleClass="w-full" (click)="onLogin()"></p-button>
+              <span class="font-medium text-center text-primary cursor-pointer" (click)="onForgotPassword()">¿Olvidaste tu contraseña?</span>
             </div>
           </div>
         </div>
@@ -121,10 +98,15 @@ export class Login implements OnInit {
   credentials: LoginCredentials = { email: '', password: '', role: '' };
   roleDialogVisible = false;
   msToken: string = '';
+  loadingMicrosoft = false;
 
   constructor(private authService: AuthService, private router: Router) {}
 
   loginWithMicrosoft() {
+    if (this.loadingMicrosoft) {
+      return;
+    }
+    this.loadingMicrosoft = true;
     this.authService.getMicrosoftToken().subscribe({
       next: ({ email, token }) => {
         this.credentials.email = email;
@@ -137,16 +119,19 @@ export class Login implements OnInit {
             } else {
               this.selectRole(this.userRoles[0].value);
             }
+            this.loadingMicrosoft = false;
           },
           error: () => {
             this.userRoles = [{ label: 'ESTUDIANTE', value: 'ESTUDIANTE' }];
             this.selectRole('ESTUDIANTE');
+            this.loadingMicrosoft = false;
           }
         });
       },
       error: (error) => {
         console.error('Error en la autenticación con Microsoft:', error);
         alert(this.authService.obtenerMensajeError(error));
+        this.loadingMicrosoft = false;
       },
     });
   }

--- a/Frontend/sakai-ng-master/src/app/pages/auth/microsoft-login.viewmodel.ts
+++ b/Frontend/sakai-ng-master/src/app/pages/auth/microsoft-login.viewmodel.ts
@@ -1,0 +1,161 @@
+import { Router } from '@angular/router';
+
+import { AuthService } from '../../biblioteca/services/auth.service';
+
+export interface RoleOption {
+  label: string;
+  value: string;
+}
+
+export class MicrosoftLoginViewModel {
+  roleDialogVisible = false;
+  userRoles: RoleOption[] = [];
+  msToken = '';
+  userEmail = '';
+  loading = false;
+  showUserActions = false;
+  private pendingRoleSelection = false;
+
+  constructor(private readonly authService: AuthService, private readonly router: Router) {
+    this.hydrateFromExistingSession();
+  }
+
+  get displayName(): string {
+    const decoded = this.authService.getUser() ?? {};
+    const composedName = decoded?.givenname || decoded?.surname
+      ? `${decoded?.givenname ?? ''} ${decoded?.surname ?? ''}`.trim()
+      : (decoded?.nombres ?? decoded?.name ?? '');
+    if (composedName) {
+      return composedName.toUpperCase();
+    }
+
+    const baseEmail = this.userEmail || decoded?.email || decoded?.sub || decoded?.preferred_username || '';
+    if (!baseEmail) {
+      return 'MI CUENTA';
+    }
+    const alias = baseEmail.split('@')[0];
+    return (alias || baseEmail).toUpperCase();
+  }
+
+  startMicrosoftLogin(): void {
+    if (this.loading) {
+      return;
+    }
+    this.loading = true;
+    this.roleDialogVisible = false;
+    this.pendingRoleSelection = false;
+    this.userRoles = [];
+    this.authService.getMicrosoftToken().subscribe({
+      next: ({ email, token }) => {
+        this.msToken = token;
+        this.userEmail = email;
+        this.loadRoles(email);
+      },
+      error: error => {
+        this.loading = false;
+        console.error('Error en autenticación de Microsoft:', error);
+        alert(this.authService.obtenerMensajeError(error));
+      }
+    });
+  }
+
+  openRoleDialog(): void {
+    if (this.msToken) {
+      if (!this.userRoles.length && this.userEmail) {
+        this.loadRoles(this.userEmail);
+        return;
+      }
+      if (!this.pendingRoleSelection) {
+        this.router.navigate(['/main']);
+        return;
+      }
+      if (this.userRoles.length <= 1) {
+        this.selectRole(this.userRoles[0]?.value ?? 'ESTUDIANTE');
+        return;
+      }
+      this.roleDialogVisible = true;
+      return;
+    }
+
+    if (this.authService.idAuthenticated()) {
+      this.router.navigate(['/main']);
+    }
+  }
+
+  selectRole(role: string): void {
+    const selectedRole = role || 'ESTUDIANTE';
+    this.pendingRoleSelection = false;
+    this.roleDialogVisible = false;
+    if (this.msToken) {
+      const token = this.msToken;
+      this.msToken = '';
+      this.authService.loginMicrosoft(token, selectedRole);
+      return;
+    }
+
+    this.router.navigate(['/main']);
+  }
+
+  logout(): void {
+    this.resetTransientState();
+    this.authService.logout();
+  }
+
+  private hydrateFromExistingSession(): void {
+    if (!this.authService.idAuthenticated()) {
+      return;
+    }
+    const decoded = this.authService.getUser() ?? {};
+    this.userEmail = decoded?.email || decoded?.sub || decoded?.preferred_username || this.authService.getEmail() || '';
+    const storedRoles = this.normalizeRoles(decoded?.role ?? decoded?.roles ?? JSON.parse(localStorage.getItem('role') ?? '[]'));
+    this.userRoles = storedRoles.length ? storedRoles : this.defaultRoles();
+    this.showUserActions = true;
+    this.pendingRoleSelection = false;
+  }
+
+  private loadRoles(email: string): void {
+    this.authService.getRolesByEmail(email).subscribe({
+      next: roles => {
+        this.userRoles = roles.length ? roles : this.defaultRoles();
+        this.showUserActions = true;
+        this.pendingRoleSelection = this.userRoles.length > 1;
+        this.loading = false;
+        if (!this.pendingRoleSelection) {
+          this.selectRole(this.userRoles[0].value);
+        }
+      },
+      error: () => {
+        this.userRoles = this.defaultRoles();
+        this.showUserActions = true;
+        this.pendingRoleSelection = false;
+        this.loading = false;
+        this.selectRole(this.userRoles[0].value);
+      }
+    });
+  }
+
+  private normalizeRoles(input: unknown): RoleOption[] {
+    if (!input) {
+      return [];
+    }
+    const roles = Array.isArray(input) ? input : [input];
+    return roles
+      .map(role => typeof role === 'string' ? role.trim().toUpperCase() : '')
+      .filter(role => !!role)
+      .map(role => ({ label: role, value: role }));
+  }
+
+  private defaultRoles(): RoleOption[] {
+    return [{ label: 'ESTUDIANTE', value: 'ESTUDIANTE' }];
+  }
+
+  private resetTransientState(): void {
+    this.roleDialogVisible = false;
+    this.userRoles = [];
+    this.msToken = '';
+    this.userEmail = '';
+    this.loading = false;
+    this.showUserActions = false;
+    this.pendingRoleSelection = false;
+  }
+}

--- a/Frontend/sakai-ng-master/src/app/pages/landing/components/topbarwidget.component.ts
+++ b/Frontend/sakai-ng-master/src/app/pages/landing/components/topbarwidget.component.ts
@@ -1,13 +1,57 @@
 import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
 import { StyleClassModule } from 'primeng/styleclass';
 import { Router, RouterModule } from '@angular/router';
 import { RippleModule } from 'primeng/ripple';
 import { ButtonModule } from 'primeng/button';
+import { DialogModule } from 'primeng/dialog';
+
+import { AuthService } from '../../../biblioteca/services/auth.service';
+import { MicrosoftLoginViewModel } from '../../auth/microsoft-login.viewmodel';
 
 @Component({
     selector: 'topbar-widget',
-    imports: [RouterModule, StyleClassModule, ButtonModule, RippleModule],
-    template: `<a class="flex items-center" href="#">
+    imports: [CommonModule, RouterModule, StyleClassModule, ButtonModule, RippleModule, DialogModule],
+    styles: [`
+        :host ::ng-deep .role-dialog {
+            opacity: 0;
+            transform: scale(0.85);
+            transition: transform 0.3s ease, opacity 0.3s ease;
+        }
+
+        :host ::ng-deep .role-dialog.p-dialog-visible {
+            opacity: 1;
+            transform: scale(1);
+        }
+    `],
+    template: `<p-dialog
+            [(visible)]="vm.roleDialogVisible"
+            [modal]="true"
+            [closable]="false"
+            [appendTo]="'body'"
+            [style]="{ width: '24rem' }"
+            styleClass="role-dialog"
+        >
+            <ng-template pTemplate="header">
+                <div class="w-full text-center">
+                    <span class="text-red-600 uppercase font-semibold">Seleccionar usuario</span>
+                </div>
+            </ng-template>
+            <div class="flex flex-col gap-2 w-full">
+                <button
+                    *ngFor="let role of vm.userRoles"
+                    (click)="vm.selectRole(role.value)"
+                    class="w-full border border-gray-300 py-3 text-center uppercase font-medium text-gray-700 hover:text-red-600 hover:border-red-600 transition-colors cursor-pointer"
+                >
+                    {{ role.label }}
+                </button>
+            </div>
+            <div class="mt-4 text-sm font-semibold text-center">
+                <span class="text-gray-700">Usuario:</span>
+                <span class="text-red-600">{{ vm.userEmail }}</span>
+            </div>
+        </p-dialog>
+        <a class="flex items-center" href="#">
             <svg viewBox="0 0 54 40" fill="none" xmlns="http://www.w3.org/2000/svg" class="h-12 mr-2">
                 <path
                     fill-rule="evenodd"
@@ -61,11 +105,40 @@ import { ButtonModule } from 'primeng/button';
                 </li>
             </ul>
             <div class="flex border-t lg:border-t-0 border-surface py-4 lg:py-0 mt-4 lg:mt-0 gap-2">
-                <button pButton pRipple label="Iniciar sesión" routerLink="/auth/login" [rounded]="true" [text]="true"></button>
-                <button pButton pRipple label="Registrate" routerLink="/auth/login" [rounded]="true"></button>
+                <ng-container *ngIf="!vm.showUserActions; else loggedActions">
+                    <button
+                        pButton
+                        pRipple
+                        label="Iniciar sesión con Microsoft365"
+                        [rounded]="true"
+                        (click)="vm.startMicrosoftLogin()"
+                        [loading]="vm.loading"
+                    ></button>
+                </ng-container>
+                <ng-template #loggedActions>
+                    <button
+                        pButton
+                        pRipple
+                        [label]="vm.displayName"
+                        [rounded]="true"
+                        [text]="true"
+                        (click)="vm.openRoleDialog()"
+                    ></button>
+                    <button
+                        pButton
+                        pRipple
+                        label="Cerrar sesión"
+                        [rounded]="true"
+                        (click)="vm.logout()"
+                    ></button>
+                </ng-template>
             </div>
         </div> `
 })
 export class TopbarWidget {
-    constructor(public router: Router) {}
+    vm: MicrosoftLoginViewModel;
+
+    constructor(public router: Router, private authService: AuthService) {
+        this.vm = new MicrosoftLoginViewModel(this.authService, this.router);
+    }
 }


### PR DESCRIPTION
## Resumen
- evita que el selector de roles se muestre automáticamente después de recuperar los perfiles de Microsoft 365
- permite finalizar el inicio de sesión al instante cuando solo hay un rol disponible y muestra el diálogo únicamente bajo demanda
- restablece el estado transitorio del viewmodel al comenzar un nuevo flujo o cerrar sesión

## Pruebas
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68cbb51108c08329bea85ac8959feb83