### PR TITLE
feat: actualiza botón de inicio de sesión con icono de Microsoft

### DIFF
--- a/Frontend/sakai-ng-master/src/app/biblioteca/web/portal-landing/components/portal-topbar.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/web/portal-landing/components/portal-topbar.ts
@@ -74,6 +74,8 @@ import { MicrosoftLoginViewModel } from '../../../../pages/auth/microsoft-login.
           type="button"
           class="login"
           label="Iniciar sesión con Microsoft365"
+          icon="pi pi-microsoft"
+          styleClass="ms-login-button"
           (click)="vm.startMicrosoftLogin()"
           [loading]="vm.loading"
         ></button>

--- a/Frontend/sakai-ng-master/src/app/pages/auth/login.ts
+++ b/Frontend/sakai-ng-master/src/app/pages/auth/login.ts
@@ -64,7 +64,8 @@ export interface LoginCredentials {
             <div class="flex flex-col gap-6 items-center">
               <p-button
                 label="Iniciar sesión con Microsoft365"
-                styleClass="w-full sm:w-auto"
+                icon="pi pi-microsoft"
+                styleClass="w-full sm:w-auto ms-login-button"
                 (click)="loginWithMicrosoft()"
                 [loading]="loadingMicrosoft"
               ></p-button>

--- a/Frontend/sakai-ng-master/src/app/pages/landing/components/topbarwidget.component.ts
+++ b/Frontend/sakai-ng-master/src/app/pages/landing/components/topbarwidget.component.ts
@@ -110,6 +110,8 @@ import { MicrosoftLoginViewModel } from '../../auth/microsoft-login.viewmodel';
                         pButton
                         pRipple
                         label="Iniciar sesión con Microsoft365"
+                        icon="pi pi-microsoft"
+                        styleClass="ms-login-button"
                         [rounded]="true"
                         (click)="vm.startMicrosoftLogin()"
                         [loading]="vm.loading"

--- a/Frontend/sakai-ng-master/src/styles.scss
+++ b/Frontend/sakai-ng-master/src/styles.scss
@@ -282,3 +282,25 @@ h6 {
 a {
   color: var(--primary);
 }
+
+.p-button.ms-login-button {
+  background-color: #000000;
+  border-color: #000000;
+  color: #ffffff;
+}
+
+.p-button.ms-login-button:enabled:hover,
+.p-button.ms-login-button:enabled:focus {
+  background-color: #111111;
+  border-color: #111111;
+  color: #ffffff;
+}
+
+.p-button.ms-login-button:enabled:active {
+  background-color: #000000;
+  border-color: #000000;
+}
+
+.p-button.ms-login-button .p-button-icon {
+  color: inherit;
+}


### PR DESCRIPTION
## Summary
- Añadí el icono de Microsoft y el nuevo estilo oscuro al botón de inicio de sesión en la landing y el portal público.
- Apliqué el mismo icono y estilo en la pantalla principal de autenticación para mantener la coherencia visual.
- Incorporé una clase global para definir el aspecto negro del botón y preservar la legibilidad del icono.

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cce80bb61c8329a45fd2fd770eaabc