### PR TITLE
Validar reservas según estado de programa y motivo

### DIFF
--- a/Backend/login-microsoft365/src/main/java/com/miapp/controller/PrestamoController.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/controller/PrestamoController.java
@@ -54,7 +54,9 @@ public class PrestamoController {
                 dto.getTipoPrestamo(),
                 dto.getFechaInicio(),      // ← nuevo
                 dto.getFechaFin(),         // ← nuevo
-                usuario
+                usuario,
+                dto.getEstadoPrograma(),
+                dto.getMotaccion()
         );
         return ResponseEntity.ok(Map.of("status","0","data",creado));
     }

--- a/Backend/login-microsoft365/src/main/java/com/miapp/model/ProgramaMotivoAccion.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/model/ProgramaMotivoAccion.java
@@ -1,0 +1,38 @@
+package com.miapp.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Representa la relación entre un estado de programa y un motivo de acción
+ * que restringe el acceso a las reservas en el portal.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "PROGRAMA_MOTIVO_ACCION")
+public class ProgramaMotivoAccion {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "ID_PROGRAMA_MOTIVO_ACCION")
+    private Long id;
+
+    @Column(name = "PROG_ACTION", length = 20, nullable = false)
+    private String estadoPrograma;
+
+    @Column(name = "PROG_REASON", length = 20, nullable = false)
+    private String motivoAccion;
+
+    @Column(name = "DESCR", length = 200)
+    private String descripcion;
+
+    @Column(name = "AD", length = 200)
+    private String advertencia;
+
+    @Column(name = "ACTIVO", columnDefinition = "NUMBER(1)")
+    private Boolean activo = Boolean.TRUE;
+}

--- a/Backend/login-microsoft365/src/main/java/com/miapp/model/SolicitudDTO.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/model/SolicitudDTO.java
@@ -23,5 +23,8 @@ public class SolicitudDTO {
 
     @JsonFormat(pattern="yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime fechaFin;
+
+    private String estadoPrograma;
+    private String motaccion;
 }
 

--- a/Backend/login-microsoft365/src/main/java/com/miapp/model/dto/CambioEstadoDetalleRequest.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/model/dto/CambioEstadoDetalleRequest.java
@@ -11,4 +11,6 @@ public class CambioEstadoDetalleRequest {
     private String codigoPrograma;
     private String codigoEspecialidad;
     private String codigoCiclo;
+    private String estadoPrograma;
+    private String motaccion;
 }

--- a/Backend/login-microsoft365/src/main/java/com/miapp/repository/ProgramaMotivoAccionRepository.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/repository/ProgramaMotivoAccionRepository.java
@@ -1,0 +1,14 @@
+package com.miapp.repository;
+
+import com.miapp.model.ProgramaMotivoAccion;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ProgramaMotivoAccionRepository extends JpaRepository<ProgramaMotivoAccion, Long> {
+
+    Optional<ProgramaMotivoAccion> findFirstByEstadoProgramaIgnoreCaseAndMotivoAccionIgnoreCaseAndActivoTrue(
+            String estadoPrograma,
+            String motivoAccion
+    );
+}

--- a/Backend/login-microsoft365/src/main/java/com/miapp/service/PrestamoService.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/service/PrestamoService.java
@@ -65,6 +65,7 @@ public class PrestamoService {
     private final BibliotecaMapper bibliotecaMapper;
     private final JdbcTemplate jdbcTemplate;
     private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
+    private final ProgramaMotivoAccionService programaMotivoAccionService;
 
     public DetallePrestamo solicitarPrestamo(Long equipoId,
                                              Integer tipoUsuario,
@@ -78,7 +79,11 @@ public class PrestamoService {
                                              TipoPrestamo tipoPrestamo,
                                              LocalDateTime fechaInicio,
                                              LocalDateTime fechaFin,
-                                             String usuarioLogueado) {
+                                             String usuarioLogueado,
+                                             String estadoPrograma,
+                                             String motaccion) {
+        programaMotivoAccionService.validarReservaPermitida(estadoPrograma, motaccion);
+
         Equipo eq = equipoRepository.findById(equipoId)
                 .orElseThrow(() -> new RuntimeException("Equipo no encontrado"));
         // 1) Estado “RESERVADO”

--- a/Backend/login-microsoft365/src/main/java/com/miapp/service/ProgramaMotivoAccionService.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/service/ProgramaMotivoAccionService.java
@@ -1,0 +1,40 @@
+package com.miapp.service;
+
+import com.miapp.model.ProgramaMotivoAccion;
+import com.miapp.repository.ProgramaMotivoAccionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class ProgramaMotivoAccionService {
+
+    private final ProgramaMotivoAccionRepository repository;
+
+    public void validarReservaPermitida(String estadoPrograma, String motaccion) {
+        if (!StringUtils.hasText(estadoPrograma) || !StringUtils.hasText(motaccion)) {
+            return;
+        }
+
+        String estado = estadoPrograma.trim();
+        String motivo = motaccion.trim();
+
+        Optional<ProgramaMotivoAccion> restriccion = repository
+                .findFirstByEstadoProgramaIgnoreCaseAndMotivoAccionIgnoreCaseAndActivoTrue(estado, motivo);
+
+        restriccion.ifPresent(actual -> {
+            String mensaje = StringUtils.hasText(actual.getAdvertencia())
+                    ? actual.getAdvertencia()
+                    : actual.getDescripcion();
+            if (!StringUtils.hasText(mensaje)) {
+                mensaje = "El usuario no cuenta con acceso para registrar reservas.";
+            }
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, mensaje);
+        });
+    }
+}

--- a/Backend/login-microsoft365/src/main/java/com/miapp/service/impl/BibliotecaServiceImpl.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/service/impl/BibliotecaServiceImpl.java
@@ -8,6 +8,7 @@ import com.miapp.service.BibliotecaService;
 import com.miapp.service.EmailService;
 import com.miapp.service.NotificacionService;
 import com.miapp.service.FileStorageService;
+import com.miapp.service.ProgramaMotivoAccionService;
 import jakarta.persistence.criteria.Join;
 import jakarta.persistence.criteria.JoinType;
 import jakarta.persistence.criteria.Predicate;
@@ -17,7 +18,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
-import java.time.format.DateTimeFormatter;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
@@ -50,6 +50,7 @@ public class BibliotecaServiceImpl implements BibliotecaService {
     private final FileStorageService fileStorageService;
     private final BibliotecaCicloRepository bibliotecaCicloRepository;
     private final PeriodicidadRepository periodicidadRepository;
+    private final ProgramaMotivoAccionService programaMotivoAccionService;
 
     public BibliotecaServiceImpl(BibliotecaRepository bibliotecaRepository,
                                  TipoAdquisicionRepository tipoAdquisicionRepository,
@@ -68,7 +69,8 @@ public class BibliotecaServiceImpl implements BibliotecaService {
                                  EmailService emailService,
                                  FileStorageService fileStorageService,
                                  BibliotecaCicloRepository bibliotecaCicloRepository,
-                                 PeriodicidadRepository periodicidadRepository) {
+                                 PeriodicidadRepository periodicidadRepository,
+                                 ProgramaMotivoAccionService programaMotivoAccionService) {
         this.bibliotecaRepository = bibliotecaRepository;
         this.tipoAdquisicionRepository  = tipoAdquisicionRepository;
         this.especialidadRepository = especialidadRepository;
@@ -87,6 +89,7 @@ public class BibliotecaServiceImpl implements BibliotecaService {
         this.fileStorageService = fileStorageService;
         this.bibliotecaCicloRepository = bibliotecaCicloRepository;
         this.periodicidadRepository = periodicidadRepository;
+        this.programaMotivoAccionService = programaMotivoAccionService;
     }
 
     @Override
@@ -520,6 +523,10 @@ public class BibliotecaServiceImpl implements BibliotecaService {
             detalle.setTipoPrestamo(req.getTipoPrestamo());
         }
         if (req.getIdEstado() != null && req.getIdEstado() == 3L) {
+            programaMotivoAccionService.validarReservaPermitida(
+                    req.getEstadoPrograma(),
+                    req.getMotaccion()
+            );
             // Al reservar registramos la fecha de solicitud/reserva
             detalle.setFechaSolicitud(
                     LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))

--- a/Frontend/sakai-ng-master/src/app/biblioteca/interfaces/material-bibliografico/informacion-academica.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/interfaces/material-bibliografico/informacion-academica.ts
@@ -2,6 +2,8 @@ export interface InformacionAcademicaDetalle {
   gradoAcademico: string;
   carrera: string;
   cicloNivel: string;
+  estadoPrograma?: string;
+  motaccion?: string;
   [key: string]: unknown;
 }
 
@@ -14,4 +16,6 @@ export interface SeleccionAcademica {
   programa: string;
   especialidad: string;
   ciclo: string;
+  estadoPrograma?: string;
+  motaccion?: string;
 }

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/portal/biblioteca-virtual.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/portal/biblioteca-virtual.ts
@@ -762,10 +762,23 @@ export class BibliotecaVirtualComponent {
         }
 
         const valores = this.formAcademico.value as { programa: string; especialidad: string; ciclo: string };
+        const detalleSeleccionado = this.informacionAcademicaDisponible.find(
+            (item) =>
+                item.gradoAcademico === valores.programa &&
+                item.carrera === valores.especialidad &&
+                item.cicloNivel === valores.ciclo
+        );
         const seleccion: SeleccionAcademica = {
             programa: valores.programa,
             especialidad: valores.especialidad,
-            ciclo: valores.ciclo
+            ciclo: valores.ciclo,
+            estadoPrograma: this.obtenerValorCadena(detalleSeleccionado, [
+                'estadoPrograma',
+                'estado_programa',
+                'programaEstado',
+                'estadoProg'
+            ]),
+            motaccion: this.obtenerValorCadena(detalleSeleccionado, ['motaccion', 'motAccion', 'motivoAccion'])
         };
 
         this.seleccionAcademicaConfirmada = seleccion;
@@ -888,6 +901,22 @@ export class BibliotecaVirtualComponent {
         return fallback;
     }
 
+    private obtenerValorCadena(
+        det: InformacionAcademicaDetalle | undefined,
+        claves: string[]
+    ): string | undefined {
+        if (!det) {
+            return undefined;
+        }
+        for (const clave of claves) {
+            const valor = (det as any)?.[clave];
+            if (typeof valor === 'string' && valor.trim()) {
+                return valor.trim();
+            }
+        }
+        return undefined;
+    }
+
     private construirResumenSeleccion(seleccion: SeleccionAcademica): { programa: string; especialidad: string; ciclo: string } {
         const programa =
             this.extraerOpciones('gradoAcademico', ['descripcionGradoAcademico', 'gradoAcademicoDescripcion', 'gradoAcademicoDesc'])
@@ -960,6 +989,12 @@ export class BibliotecaVirtualComponent {
             fechaInicio: this.formatLocalDateTime(dtInicio),
             fechaFin: this.formatLocalDateTime(dtFin)
         };
+        if (seleccion.estadoPrograma) {
+            dto.estadoPrograma = seleccion.estadoPrograma;
+        }
+        if (seleccion.motaccion) {
+            dto.motaccion = seleccion.motaccion;
+        }
         if (sedeId != null) {
             dto.codigoSede = String(sedeId);
         }

--- a/Frontend/sakai-ng-master/src/app/biblioteca/modulos/portal/catalogo-enlinea.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/modulos/portal/catalogo-enlinea.ts
@@ -930,10 +930,23 @@ export class CatalogoEnLineaComponent {
         }
 
         const valores = this.formAcademico.value as { programa: string; especialidad: string; ciclo: string };
+        const detalleSeleccionado = this.informacionAcademicaDisponible.find(
+            (item) =>
+                item.gradoAcademico === valores.programa &&
+                item.carrera === valores.especialidad &&
+                item.cicloNivel === valores.ciclo
+        );
         const seleccion: SeleccionAcademica = {
             programa: valores.programa,
             especialidad: valores.especialidad,
-            ciclo: valores.ciclo
+            ciclo: valores.ciclo,
+            estadoPrograma: this.obtenerValorCadena(detalleSeleccionado, [
+                'estadoPrograma',
+                'estado_programa',
+                'programaEstado',
+                'estadoProg'
+            ]),
+            motaccion: this.obtenerValorCadena(detalleSeleccionado, ['motaccion', 'motAccion', 'motivoAccion'])
         };
 
         this.seleccionAcademicaConfirmada = seleccion;
@@ -1056,6 +1069,22 @@ export class CatalogoEnLineaComponent {
         return fallback;
     }
 
+    private obtenerValorCadena(
+        det: InformacionAcademicaDetalle | undefined,
+        claves: string[]
+    ): string | undefined {
+        if (!det) {
+            return undefined;
+        }
+        for (const clave of claves) {
+            const valor = (det as any)?.[clave];
+            if (typeof valor === 'string' && valor.trim()) {
+                return valor.trim();
+            }
+        }
+        return undefined;
+    }
+
     private construirResumenSeleccion(seleccion: SeleccionAcademica): { programa: string; especialidad: string; ciclo: string } {
         const programa =
             this.extraerOpciones('gradoAcademico', ['descripcionGradoAcademico', 'gradoAcademicoDescripcion', 'gradoAcademicoDesc']).find(
@@ -1090,7 +1119,7 @@ export class CatalogoEnLineaComponent {
 
     private ejecutarReserva(seleccion: SeleccionAcademica): void {
         const requests = this.reservas.map((it) => {
-            const payload = {
+            const payload: any = {
                 idDetalleBiblioteca: it.idDetalleBiblioteca ?? it.id,
                 idEstado: 3,
                 idUsuario: this.user?.sub ?? this.user?.idusuario ?? 0,
@@ -1099,6 +1128,12 @@ export class CatalogoEnLineaComponent {
                 codigoEspecialidad: seleccion.especialidad,
                 codigoCiclo: seleccion.ciclo
             };
+            if (seleccion.estadoPrograma) {
+                payload.estadoPrograma = seleccion.estadoPrograma;
+            }
+            if (seleccion.motaccion) {
+                payload.motaccion = seleccion.motaccion;
+            }
             return this.genericoService.conf_event_put(payload, 'api/biblioteca/detalles/estado');
         });
 

--- a/Frontend/sakai-ng-master/src/app/biblioteca/services/material-bibliografico.service.ts
+++ b/Frontend/sakai-ng-master/src/app/biblioteca/services/material-bibliografico.service.ts
@@ -873,6 +873,12 @@ listarUsuariosOcurrencia(id: number): Observable<OcurrenciaUsuario[]> {
       payload.codigoPrograma = seleccion.programa;
       payload.codigoEspecialidad = seleccion.especialidad;
       payload.codigoCiclo = seleccion.ciclo;
+      if (seleccion.estadoPrograma) {
+        payload.estadoPrograma = seleccion.estadoPrograma;
+      }
+      if (seleccion.motaccion) {
+        payload.motaccion = seleccion.motaccion;
+      }
     }
     return this.http.put<any>(
       `${this.apiUrl}/api/biblioteca/detalles/estado`,


### PR DESCRIPTION
## Summary
- crear la entidad `ProgramaMotivoAccion` junto con su repositorio y servicio para identificar combinaciones de estado de programa y motivo que bloquean reservas
- validar dichas combinaciones al reservar equipos y materiales, ampliando los DTO correspondientes
- enviar los nuevos campos desde el portal académico en Angular al registrar o procesar reservas

## Testing
- `mvn test` *(falla: no se pudo resolver el parent POM por falta de acceso a Maven Central)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68cd084f89808329b1ab7e00ec4a2f33