### PR TITLE
Incluye códigos de estado en la validación de bloqueo por IP

### DIFF
--- a/Backend/login-microsoft365/sql/oracle/biblioteca_procedures.sql
+++ b/Backend/login-microsoft365/sql/oracle/biblioteca_procedures.sql
@@ -1,0 +1,103 @@
+-- Procedimientos almacenados para Oracle Database 21c
+-- Ejecutar este script conectándose con el esquema propietario de las tablas
+-- (por ejemplo BIBLIOTECA, PEDRO, etc.).
+
+-- Procedimiento para inactivar un equipo por su dirección IP
+CREATE OR REPLACE PROCEDURE usp_DetallePrestamoEquipo_InactivarEquipo (
+    p_NumeroIP        IN  EquipoLaboratorio.NumeroIP%TYPE,
+    p_FilasAfectadas  OUT NUMBER
+) AS
+    v_IdDetallePrestamoEquipo DetallePrestamoEquipo.IdDetallePrestamoEquipo%TYPE;
+    v_TotalActualizaciones    NUMBER := 0;
+BEGIN
+    UPDATE ControlPrestamoEquipo cpe
+       SET cpe.FechaFin = SYSDATE,
+           cpe.IdEstado = 0
+     WHERE cpe.IdEstado = 1
+       AND EXISTS (
+               SELECT 1
+                 FROM DetallePrestamoEquipo dpe
+                 JOIN EquipoLaboratorio el
+                   ON dpe.IdEquipoLaboratorio = el.IdEquipoLaboratorio
+                WHERE dpe.IdDetallePrestamoEquipo = cpe.IdDetallePrestamoEquipo
+                  AND el.NumeroIP = p_NumeroIP
+           );
+    v_TotalActualizaciones := v_TotalActualizaciones + SQL%ROWCOUNT;
+
+    UPDATE EquipoLaboratorio el
+       SET el.IdEstado = 2
+     WHERE el.NumeroIP = p_NumeroIP;
+    v_TotalActualizaciones := v_TotalActualizaciones + SQL%ROWCOUNT;
+
+    BEGIN
+        SELECT sub.IdDetallePrestamoEquipo
+          INTO v_IdDetallePrestamoEquipo
+          FROM (
+                SELECT dpe.IdDetallePrestamoEquipo
+                  FROM EquipoLaboratorio el
+                  JOIN DetallePrestamoEquipo dpe
+                    ON el.IdEquipoLaboratorio = dpe.IdEquipoLaboratorio
+                 WHERE el.NumeroIP = p_NumeroIP
+                 ORDER BY dpe.FechaSolicitud DESC
+               ) sub
+         WHERE ROWNUM = 1;
+    EXCEPTION
+        WHEN NO_DATA_FOUND THEN
+            v_IdDetallePrestamoEquipo := NULL;
+    END;
+
+    IF v_IdDetallePrestamoEquipo IS NOT NULL THEN
+        UPDATE DetallePrestamoEquipo dpe
+           SET dpe.IdEstado = 7,
+               dpe.UsuarioRecepcion = 'AUTOMATICO',
+               dpe.FechaRecepcion = SYSDATE,
+               dpe.UsuarioModificacion = 'AUTOMATICO',
+               dpe.FechaModificacion = SYSDATE
+         WHERE dpe.IdDetallePrestamoEquipo = v_IdDetallePrestamoEquipo;
+        v_TotalActualizaciones := v_TotalActualizaciones + SQL%ROWCOUNT;
+    END IF;
+
+    p_FilasAfectadas := v_TotalActualizaciones;
+    COMMIT;
+EXCEPTION
+    WHEN OTHERS THEN
+        ROLLBACK;
+        RAISE;
+END usp_DetallePrestamoEquipo_InactivarEquipo;
+/
+
+-- Procedimiento para validar si un equipo debe bloquearse por su IP
+CREATE OR REPLACE PROCEDURE usp_DetallePrestamoEquipo_Validar (
+    p_NumeroIP  IN  EquipoLaboratorio.NumeroIP%TYPE,
+    p_Resultado OUT NUMBER
+) AS
+    v_IdEstado DetallePrestamoEquipo.IdEstado%TYPE;
+BEGIN
+    BEGIN
+        SELECT sub.IdEstado
+          INTO v_IdEstado
+          FROM (
+                SELECT dpe.IdEstado
+                  FROM EquipoLaboratorio el
+                  JOIN DetallePrestamoEquipo dpe
+                    ON el.IdEquipoLaboratorio = dpe.IdEquipoLaboratorio
+                  LEFT JOIN ControlPrestamoEquipo cpe
+                    ON dpe.IdDetallePrestamoEquipo = cpe.IdDetallePrestamoEquipo
+                 WHERE el.NumeroIP = p_NumeroIP
+                   AND dpe.IdEstado IN (2, 3, 4, 9)
+                   AND (cpe.IdEstado IS NULL OR cpe.IdEstado = 1)
+                 ORDER BY dpe.FechaSolicitud DESC, dpe.IdDetallePrestamoEquipo DESC
+               ) sub
+         WHERE ROWNUM = 1;
+    EXCEPTION
+        WHEN NO_DATA_FOUND THEN
+            v_IdEstado := 2;
+    END;
+
+    IF v_IdEstado IS NULL THEN
+        v_IdEstado := 2;
+    END IF;
+
+    p_Resultado := v_IdEstado;
+END usp_DetallePrestamoEquipo_Validar;
+/

--- a/Backend/login-microsoft365/src/main/java/com/miapp/config/SecurityConfig.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/config/SecurityConfig.java
@@ -60,6 +60,8 @@ public class SecurityConfig {
                             "/auth/api/biblioteca/search",
                             "/auth/api/catalogos/**",
                             "/auth/api/equipos/sedes",
+                            "/auth/api/equipos/validar-bloqueo",
+                            "/auth/api/equipos/inactivar-por-ip",
                             "/auth/sede/lista-activo",
                             "/auth/material-bibliografico/especialidad",
                             "/auth/api/nosotros",

--- a/Backend/login-microsoft365/src/main/java/com/miapp/controller/EquipoController.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/controller/EquipoController.java
@@ -145,5 +145,45 @@ public class EquipoController {
         return ResponseEntity.ok(Map.of("exists", exists));
     }
 
+    @GetMapping("/validar-bloqueo")
+    public ResponseEntity<?> validarBloqueo(@RequestParam String ip) {
+        try {
+            int estadoPrestamo = equipoService.validarBloqueo(ip);
+            boolean requiereBloqueo = estadoPrestamo == 3 || estadoPrestamo == 4 || estadoPrestamo == 9;
+            return ResponseEntity.ok(Map.of(
+                    "status", 0,
+                    "estadoPrestamo", estadoPrestamo,
+                    "requiereBloqueo", requiereBloqueo
+            ));
+        } catch (Exception ex) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(Map.of(
+                            "status", -1,
+                            "message", ex.getMessage()
+                    ));
+        }
+    }
+
+    @PostMapping("/inactivar-por-ip")
+    public ResponseEntity<?> inactivarPorIp(@RequestParam String ip) {
+        try {
+            boolean actualizado = equipoService.inactivarEquipoPorIp(ip);
+            String message = actualizado
+                    ? "Equipo inactivado correctamente"
+                    : "No se encontraron registros activos para el equipo";
+            return ResponseEntity.ok(Map.of(
+                    "status", 0,
+                    "message", message,
+                    "actualizado", actualizado
+            ));
+        } catch (Exception ex) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(Map.of(
+                            "status", -1,
+                            "message", ex.getMessage()
+                    ));
+        }
+    }
+
 
 }

--- a/Backend/login-microsoft365/src/main/java/com/miapp/service/EquipoService.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/service/EquipoService.java
@@ -4,8 +4,15 @@ import com.miapp.model.Equipo;
 import com.miapp.model.Estado;
 import com.miapp.repository.EquipoRepository;
 import com.miapp.repository.EstadoRepository;
-import org.springframework.stereotype.Service;
 import jakarta.transaction.Transactional;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.dao.DataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+
+import java.sql.CallableStatement;
+import java.sql.Connection;
+import java.sql.Types;
 import java.util.List;
 import java.util.Optional;
 
@@ -14,10 +21,32 @@ public class EquipoService {
 
     private final EquipoRepository equipoRepository;
     private final EstadoRepository estadoRepository;
+    private final JdbcTemplate jdbcTemplate;
+    private final String validarBloqueoCall;
+    private final String inactivarEquipoCall;
 
-    public EquipoService(EquipoRepository equipoRepository, EstadoRepository estadoRepository) {
+    public EquipoService(EquipoRepository equipoRepository,
+                         EstadoRepository estadoRepository,
+                         JdbcTemplate jdbcTemplate,
+                         @Value("${app.procedures.schema:}") String procedureSchema) {
         this.equipoRepository = equipoRepository;
         this.estadoRepository = estadoRepository;
+        this.jdbcTemplate = jdbcTemplate;
+        String schema = procedureSchema == null ? "" : procedureSchema.trim();
+        this.validarBloqueoCall = buildCall(schema, "usp_DetallePrestamoEquipo_Validar", 2);
+        this.inactivarEquipoCall = buildCall(schema, "usp_DetallePrestamoEquipo_InactivarEquipo", 2);
+    }
+
+    private String buildCall(String schema, String procedure, int parameterCount) {
+        String qualifiedName = schema.isEmpty() ? procedure : schema + "." + procedure;
+        StringBuilder placeholders = new StringBuilder();
+        for (int i = 0; i < parameterCount; i++) {
+            if (i > 0) {
+                placeholders.append(", ");
+            }
+            placeholders.append("?");
+        }
+        return "{call " + qualifiedName + "(" + placeholders + ")}";
     }
 
     // Registro
@@ -127,5 +156,46 @@ public class EquipoService {
             return equipoRepository.existsByIpAndIdEquipoNot(ip, id);
         }
         return equipoRepository.existsByIp(ip);
+    }
+
+    public int validarBloqueo(String numeroIp) {
+        try {
+            Integer resultado = jdbcTemplate.execute(
+                    (Connection con) -> {
+                        CallableStatement cs = con.prepareCall(validarBloqueoCall);
+                        cs.setString(1, numeroIp);
+                        cs.registerOutParameter(2, Types.NUMERIC);
+                        return cs;
+                    },
+                    (CallableStatement cs) -> {
+                        cs.execute();
+                        Integer valor = cs.getObject(2, Integer.class);
+                        return valor != null ? valor : 2;
+                    }
+            );
+            return resultado != null ? resultado : 2;
+        } catch (DataAccessException ex) {
+            throw new RuntimeException("Error al validar el estado del equipo con IP: " + numeroIp, ex);
+        }
+    }
+
+    public boolean inactivarEquipoPorIp(String numeroIp) {
+        try {
+            Integer actualizados = jdbcTemplate.execute(
+                    (Connection con) -> {
+                        CallableStatement cs = con.prepareCall(inactivarEquipoCall);
+                        cs.setString(1, numeroIp);
+                        cs.registerOutParameter(2, Types.NUMERIC);
+                        return cs;
+                    },
+                    (CallableStatement cs) -> {
+                        cs.execute();
+                        return cs.getInt(2);
+                    }
+            );
+            return actualizados != null && actualizados > 0;
+        } catch (DataAccessException ex) {
+            throw new RuntimeException("Error al inactivar el equipo con IP: " + numeroIp, ex);
+        }
     }
 }

--- a/Backend/login-microsoft365/src/main/resources/application.properties
+++ b/Backend/login-microsoft365/src/main/resources/application.properties
@@ -29,6 +29,8 @@ spring.datasource.password=admin
 spring.datasource.driver-class-name=oracle.jdbc.OracleDriver
 spring.jpa.hibernate.ddl-auto=validate
 spring.jpa.show-sql=true
+# Esquema (opcional) para prefijar los procedimientos PL/SQL cuando no se ejecutan en el esquema del usuario
+#app.procedures.schema=PEDRO
 
 file.upload-dir=uploads/recursos
 app.nosotros-file=config/nosotros.json


### PR DESCRIPTION
## Summary
- ajusta `usp_DetallePrestamoEquipo_InactivarEquipo` para dejar los equipos como disponibles y añade una validación que devuelva el último estado relevante (2, 3, 4 o 9)
- sincroniza `EquipoService` para obtener el valor numérico del procedimiento y exponerlo a los consumidores del endpoint junto con la bandera de bloqueo
- añade en el controlador la evaluación local `requiereBloqueo` basada en los estados que representan reserva o préstamo

## Testing
- `mvn -f Backend/login-microsoft365/pom.xml -DskipTests package` *(falla: red sin acceso a Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68cd8ffc3da483298381d434e2677883