### PR TITLE
Improve Microsoft login claim extraction

### DIFF
--- a/Backend/login-microsoft365/src/main/java/com/miapp/service/UsuarioService.java
+++ b/Backend/login-microsoft365/src/main/java/com/miapp/service/UsuarioService.java
@@ -219,14 +219,20 @@ public class UsuarioService {
         try {
             DecodedJWT decoded = JWT.decode(token);
 
-            String email = decoded.getClaim("preferred_username").asString();
-            if (email == null || email.isBlank()) {
-                email = decoded.getClaim("email").asString();
-            }
+            String email = Stream.of("preferred_username", "email", "upn", "unique_name")
+                    .map(decoded::getClaim)
+                    .filter(Objects::nonNull)
+                    .map(claim -> claim.asString())
+                    .filter(valor -> valor != null && !valor.isBlank())
+                    .findFirst()
+                    .orElse(null);
 
             String id = decoded.getSubject();
+            if (id == null || id.isBlank()) {
+                id = decoded.getClaim("oid").asString();
+            }
 
-            if (email == null || id == null) {
+            if (email == null || id == null || email.isBlank() || id.isBlank()) {
                 return null;
             }
 


### PR DESCRIPTION
## Summary
- extend the Microsoft token parsing to accept additional claim names for the email and identifier
- ensure blank values are ignored so decoding failures fall back to other available claims

## Testing
- mvn -q test *(fails: Non-resolvable parent POM due to offline Maven central)*

------
https://chatgpt.com/codex/tasks/task_e_68d4dc8053dc832984a0993b8405c7dc